### PR TITLE
#10-CRUD-upsert-dataType

### DIFF
--- a/scylla-server/src/services/dataTypes.services.ts
+++ b/scylla-server/src/services/dataTypes.services.ts
@@ -15,12 +15,11 @@ export const getAllDataTypes: ResponseFunction = async () => {
 export const upsertDataType = async (dataTypeName: string, unit: string, nodeName: string): Promise<DataType> => {
   const createdDataType = prisma.dataType.upsert({
     where: { name: dataTypeName },
-    create: {
-      name: dataTypeName,
+    update: {
       unit,
       nodeName
     },
-    update: {
+    create: {
       unit,
       nodeName
     }

--- a/scylla-server/src/services/dataTypes.services.ts
+++ b/scylla-server/src/services/dataTypes.services.ts
@@ -1,3 +1,4 @@
+import { DataType } from '@prisma/client';
 import prisma from '../prisma/prisma-client';
 import { ResponseFunction } from '../utils/message-maps.utils';
 
@@ -9,4 +10,20 @@ import { ResponseFunction } from '../utils/message-maps.utils';
 export const getAllDataTypes: ResponseFunction = async () => {
   const data = await prisma.dataType.findMany();
   return JSON.stringify(data);
+};
+
+export const upsertDataType = async (dataTypeName: string, unit: string, nodeName: string): Promise<DataType> => {
+  const createdDataType = prisma.dataType.upsert({
+    where: { name: dataTypeName },
+    create: {
+      name: dataTypeName,
+      unit,
+      nodeName
+    },
+    update: {
+      unit,
+      nodeName
+    }
+  });
+  return createdDataType;
 };

--- a/scylla-server/tests/dataTypes-services.test.ts
+++ b/scylla-server/tests/dataTypes-services.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest';
-import { getAllDataTypes } from '../src/services/dataTypes.services';
+import { getAllDataTypes, upsertDataType } from '../src/services/dataTypes.services';
 
 describe('Data Type', () => {
   test('Get All Data Types Works', async () => {
@@ -11,5 +11,17 @@ describe('Data Type', () => {
 
     // Use toEqual to compare parsedResult with the expected array
     expect(parsedResult).toEqual(expected);
+  });
+
+  test('Upsert Data Type Works', async () => {
+    const dataName = 'newDataType';
+    const dataUnit = 'Unit';
+    const dataNodeName = 'NodeName';
+
+    const createdDataType = upsertDataType(dataName, dataUnit, dataNodeName);
+
+    const expectedDataType: Promise<unknown> = Promise.resolve();
+
+    expect(expectedDataType).toEqual(createdDataType);
   });
 });

--- a/scylla-server/tests/driver-services.test.ts
+++ b/scylla-server/tests/driver-services.test.ts
@@ -8,8 +8,8 @@ describe('CRUD Driver', () => {
   /**
    * unit test for get all drivers
    */
-  test('Get All Data Types Works', async () => {
-    const expected = [];
+  test('Get All Drivers Works', async () => {
+    const expected = [{ username: 'test' }];
     const result = await getAllDrivers();
 
     // Parse result to a JavaScript object from the JSON string


### PR DESCRIPTION
… error in naming

## Changes

Added the serivce function that will upsert the dataType. Also created a test for this. Made one more small naming change.

## Notes

So my tests run and they pass however I get one error: PrismaClientKnownRequestError: 
Invalid `prisma.dataType.upsert()` invocation in
/Users/waasifmahmood/Documents/GitHub/Argos/scylla-server/src/services/dataTypes.services.ts:16:43
Im not quite sure why I'm gonna try to figure it out right now.

## To Do

_Any remaining things that need to get done_

- [ ] Something to do with the data array?

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `package-lock.json` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #10
