### PR TITLE
GHCR Auto built with GH Actions

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -34,14 +34,14 @@ jobs:
       # 
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v3.0.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.3.0
       - name: Checkout repository
         uses: actions/checkout@v4
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v3.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -49,31 +49,38 @@ jobs:
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5.3.1
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build and push Docker image for angular client
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v5.4.1
         with:
           context: ./angular-client
           push: true
           target: production
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}-angular-client
+          tags: ${{ steps.meta.outputs.tags }}-angular-client # argos-angular-client
           labels: ${{ steps.meta.outputs.labels }}
+          # for caching
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # https://github.com/docker/build-push-action/issues/820
+          provenance: false
       - name: Build and push Docker image for scylla server
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v5.4.1
         with:
           context: ./scylla-server
           push: true
           target: production
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}-scylla-server
+          tags: ${{ steps.meta.outputs.tags }}-scylla-server # argos-scylla-server
           labels: ${{ steps.meta.outputs.labels }}
+          # for caching
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # https://github.com/docker/build-push-action/issues/820
+          provenance: false
+

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -4,16 +4,7 @@ name: Create and publish a Docker image
 on:
   push:
     branches:
-      - main
-      - Develop
       - ghcr-action
-  pull_request:
-    types:
-    - opened
-    branches:
-    - main
-    - Develop
-    - 'feature/**'
   workflow_dispatch:
 
 
@@ -61,12 +52,12 @@ jobs:
           context: ./angular-client
           push: true
           target: production
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           tags: ${{ steps.meta.outputs.tags }}-angular-client # argos-angular-client
           labels: ${{ steps.meta.outputs.labels }}
           # for caching
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=global
+          cache-to: type=gha,mode=max,scope=global
           # https://github.com/docker/build-push-action/issues/820
           provenance: false
       - name: Build and push Docker image for scylla server
@@ -75,7 +66,7 @@ jobs:
           context: ./scylla-server
           push: true
           target: production
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           tags: ${{ steps.meta.outputs.tags }}-scylla-server # argos-scylla-server
           labels: ${{ steps.meta.outputs.labels }}
           # for caching

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -79,8 +79,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}-scylla-server # argos-scylla-server
           labels: ${{ steps.meta.outputs.labels }}
           # for caching
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=max
           # https://github.com/docker/build-push-action/issues/820
           provenance: false
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -2,7 +2,21 @@
 name: Create and publish a Docker image
 
 on:
-  push
+  push:
+    branches:
+      - main
+      - Develop
+      - ghcr-action
+  pull_request:
+    types:
+    - opened
+    branches:
+    - main
+    - Develop
+    - 'feature/**'
+  workflow_dispatch:
+
+
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
@@ -48,8 +62,10 @@ jobs:
           push: true
           target: production
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}-angular-client
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Build and push Docker image for scylla server
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
@@ -57,5 +73,7 @@ jobs:
           push: true
           target: production
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}-scylla-server
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -49,14 +49,14 @@ jobs:
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5.3.1
+        uses: docker/metadata-action@v5.5.1
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build and push Docker image for angular client
-        uses: docker/build-push-action@v5.4.1
+        uses: docker/build-push-action@v5.4.0
         with:
           context: ./angular-client
           push: true
@@ -70,7 +70,7 @@ jobs:
           # https://github.com/docker/build-push-action/issues/820
           provenance: false
       - name: Build and push Docker image for scylla server
-        uses: docker/build-push-action@v5.4.1
+        uses: docker/build-push-action@v5.4.0
         with:
           context: ./scylla-server
           push: true

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -58,6 +58,10 @@ jobs:
           # cache-to: type=gha,mode=max,scope=global
           # https://github.com/docker/build-push-action/issues/820
           provenance: false
+          build-args: |
+            PROD=true
+            BACKEND_URL=http://192.168.100.1:8000
+            MAP_ACCESS_TOKEN=pk.eyJ1IjoibWNrZWVwIiwiYSI6ImNscXBrcmU1ZTBscWIya284cDFyYjR3Nm8ifQ.6TQHlxhAJzptZyV-W28dnw
       - name: Build and push Docker image for scylla server
         uses: docker/build-push-action@v5.4.0
         with:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,61 @@
+#
+name: Create and publish a Docker image
+
+on:
+  push
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      # 
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image for angular client
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: ./angular-client
+          push: true
+          target: production
+          platforms: linux/amd64;linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Build and push Docker image for scylla server
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: ./scylla-server
+          push: true
+          target: production
+          platforms: linux/amd64;linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -50,12 +50,12 @@ jobs:
           context: ./angular-client
           push: true
           target: production
-          platforms: linux/arm64
+          platforms: linux/arm64,linux/amd64
           tags: ${{ steps.meta.outputs.tags }}-angular-client # argos-angular-client
           labels: ${{ steps.meta.outputs.labels }}
           # for caching
-          cache-from: type=gha,scope=global
-          cache-to: type=gha,mode=max,scope=global
+          # cache-from: type=gha,scope=global
+          # cache-to: type=gha,mode=max,scope=global
           # https://github.com/docker/build-push-action/issues/820
           provenance: false
       - name: Build and push Docker image for scylla server
@@ -64,7 +64,7 @@ jobs:
           context: ./scylla-server
           push: true
           target: production
-          platforms: linux/arm64
+          platforms: linux/arm64,linux/amd64
           tags: ${{ steps.meta.outputs.tags }}-scylla-server # argos-scylla-server
           labels: ${{ steps.meta.outputs.labels }}
           # for caching

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -47,7 +47,7 @@ jobs:
           context: ./angular-client
           push: true
           target: production
-          platforms: linux/amd64;linux/arm64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Build and push Docker image for scylla server
@@ -56,6 +56,6 @@ jobs:
           context: ./scylla-server
           push: true
           target: production
-          platforms: linux/amd64;linux/arm64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -24,8 +24,6 @@ jobs:
       packages: write
       # 
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.0.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.3.0
       - name: Checkout repository

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 **/.env
 scylla-server/src/prisma/mydatabase.db
 scylla-server/src/prisma/mydatabase.db-journal
+**/environment.ts
 
 # Xcode
 #

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 **/.env
 scylla-server/src/prisma/mydatabase.db
 scylla-server/src/prisma/mydatabase.db-journal
-**/environment.ts
 
 # Xcode
 #

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@
 .vscode
 
 docker-compose.yml
+docker-compose-dev.yml
 .eslintrc.js
 tsconfig.json
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,6 @@ I've setup a docker-compose file, so that you can easily run both these containe
 
 This will build the docker images that will be run:
 
-In order to build the angular-client, you will have to enter the angular-client directory and run `npm run build` in order to generate the dist file that the nginx server that hosts the application on the router uses. 
-
-Then: 
-
 `docker-compose build`
 
 If changes are made to either the client or scylla you will need to rebuild and push to hub in order to pull on the router. You may not have permissions to push to the hub, contact head of application software to gain permission.

--- a/README.md
+++ b/README.md
@@ -45,11 +45,17 @@ Then to actually run the server run:
 
 ### Running the Project in Prod Mode
 
-I've setup a docker-compose file, so that you can easily run both these containers with a few commands:
+There is a `docker-compose-dev.yml` file for a dev which varies from the router deployment:
+- It matches the number of CPUs as the router to roughly simulate router CPU (your CPU is still faster)
+- You must build it locally first!
+- It does not persist the database between `down` commands
+
+Note that both compose files limit memory to the same amount.  However, the disk I/O of the router is **much** slower than yours.
+
 
 This will build the docker images that will be run:
 
-`docker-compose build`
+`docker-compose -f ./docker-compose-dev.yml build`
 
 This will run the two docker images and output all the outputs from both of them to the terminal:
 
@@ -59,7 +65,11 @@ This will start the containers, if the container is not already an image through
 
 ### Running on the Openwrt router
 
-Just do `docker compose down` and `docker-compose pull` and `docker-compose up -d`.
+The `docker-compose.yml` file is made for the router.  When you push a commit it automatically gets built for the router in 20-30 minutes.
+To use a non-standard branch edit the docker-compose.yml file to the name of the tag specified by the name [here](https://github.com/Northeastern-Electric-Racing/Argos/pkgs/container/argos).
+Then do `docker compose down` and `docker compose pull` and `docker compose up -d`.
+
+**The database is stored in a volume called `argos_db-data`, delete the volume to start the database fresh!**
 
 ### Codegen Protobuf Types
 

--- a/README.md
+++ b/README.md
@@ -70,3 +70,7 @@ Just do `docker compose down` and `docker-compose pull` and `docker-compose up -
 
 #### Codegen
 `npm run build:proto`
+
+### Siren
+The configuration for the Mosquitto MQTT server on the router is in the siren-base folder.
+Note that the configuration is used in the docker compose file, but the configuration on the TPU is stored in [Odysseus.](https://github.com/Northeastern-Electric-Racing/Odysseus/tree/cb12fb3240d5fd58adfeae26262e158ad6dd889b/odysseus_tree/overlays/rootfs_overlay_tpu/etc/mosquitto)

--- a/README.md
+++ b/README.md
@@ -51,30 +51,15 @@ This will build the docker images that will be run:
 
 `docker-compose build`
 
-If changes are made to either the client or scylla you will need to rebuild and push to hub in order to pull on the router. You may not have permissions to push to the hub, contact head of application software to gain permission.
-
 This will run the two docker images and output all the outputs from both of them to the terminal:
-
-If you are on x86_64 you will have to change platform: linux/arm64 to linux/amd64 in order to properly pull the timescaledb
 
 `docker-compose up`
 
 This will start the containers, if the container is not already an image through docker-compose build, it will attempt to pull the images from docker hub. 
 
-Scylla will not be able to communicate with timescale with this configuration. If deploying to router you will have to change the docker-compose file to not use a shared network, instead add `network_mode: host`
-instead of 
-```
-networks: 
-   - shared-network
-```
+### Running on the Openwrt router
 
-This will allow the docker containers to communicate on the openwrt router using the host network. However on mac and windows since docker runs in a vm you will be unable to connect to these containers, you will have to use a shared-network for the timescaledb and then run scylla and the client manually from your machine. 
-
-### If running on the router
-
-If updating code you will need to go to the openwrt and remove the docker container and image for the image you are updating
-
-you will only need to copy the docker-compose file from this repository to the router (make sure to change the network mode to be host and not use shared network (see above)) then run `docker-compose up`. Make sure you've pushed the most up to date image to docker hub, if you havn't it will pull the old images. 
+Just do `docker compose down` and `docker-compose pull` and `docker-compose up -d`.
 
 ### Codegen Protobuf Types
 

--- a/angular-client/.dockerignore
+++ b/angular-client/.dockerignore
@@ -1,0 +1,9 @@
+# Ignore existing environment.ts file
+src/environments/environment.ts
+
+# Ignore other files/directories you don't want in the Docker image
+.git
+.gitignore
+Dockerfile
+.dockerignore
+README.md

--- a/angular-client/.gitignore
+++ b/angular-client/.gitignore
@@ -38,7 +38,7 @@ testem.log
 /typings
 
 # Environment variables
-/src/environment/environment.ts
+./src/environment/environment.ts
 
 # System files
 .DS_Store

--- a/angular-client/.gitignore
+++ b/angular-client/.gitignore
@@ -38,7 +38,7 @@ testem.log
 /typings
 
 # Environment variables
-./src/environment/environment.ts
+/src/environment/environment.ts
 
 # System files
 .DS_Store

--- a/angular-client/.gitignore
+++ b/angular-client/.gitignore
@@ -38,7 +38,7 @@ testem.log
 /typings
 
 # Environment variables
-/environment/environment.ts
+/src/environment/environment.ts
 
 # System files
 .DS_Store

--- a/angular-client/.gitignore
+++ b/angular-client/.gitignore
@@ -38,7 +38,6 @@ testem.log
 /typings
 
 # Environment variables
-./src/environment/environment.ts
 
 # System files
 .DS_Store

--- a/angular-client/.gitignore
+++ b/angular-client/.gitignore
@@ -38,7 +38,7 @@ testem.log
 /typings
 
 # Environment variables
-**/environment.prod.ts
+/environment/environment.ts
 
 # System files
 .DS_Store

--- a/angular-client/Dockerfile
+++ b/angular-client/Dockerfile
@@ -4,6 +4,20 @@ WORKDIR /usr/src/app
 COPY package.json package-lock.json ./
 RUN npm install
 COPY . .
+
+ARG PROD
+ARG BACKEND_URL
+ARG MAP_ACCESS_TOKEN
+
+# Create the environment.ts file with the required content
+RUN echo "export const environment = {" > src/environments/environment.ts \
+    && echo "  production: ${PROD}," >> src/environments/environment.ts \
+    && echo "  url: '${BACKEND_URL}'," >> src/environments/environment.ts \
+    && echo "  mapbox: {" >> src/environments/environment.ts \
+    && echo "    accessToken: '${MAP_ACCESS_TOKEN}'" >> src/environments/environment.ts \
+    && echo "  }" >> src/environments/environment.ts \
+    && echo "};" >> src/environments/environment.ts
+
 RUN npm run build
 
 # Use official nginx image as the base image

--- a/angular-client/Dockerfile
+++ b/angular-client/Dockerfile
@@ -1,14 +1,21 @@
+# build the node application, required for serving step
+FROM node:alpine AS Build
+WORKDIR /usr/src/app
+COPY package.json package-lock.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
 # Use official nginx image as the base image
 FROM nginx:latest as Production
 
 # Set the working directory
 WORKDIR /usr/local/app
 
-# Add the build file
-COPY ./dist /usr/local/app
+# copy dist
+COPY --from=Build /usr/src/app/dist /usr/local/app/
 
 # Copy the build output to replace the default nginx contents.
-
 RUN mv /usr/local/app/angular-client/* /usr/share/nginx/html
 
 EXPOSE 80

--- a/angular-client/Dockerfile
+++ b/angular-client/Dockerfile
@@ -10,13 +10,13 @@ ARG BACKEND_URL
 ARG MAP_ACCESS_TOKEN
 
 # Create the environment.ts file with the required content
-RUN echo "export const environment = {" > src/environments/environment.ts \
-    && echo "  production: ${PROD}," >> src/environments/environment.ts \
-    && echo "  url: '${BACKEND_URL}'," >> src/environments/environment.ts \
-    && echo "  mapbox: {" >> src/environments/environment.ts \
-    && echo "    accessToken: '${MAP_ACCESS_TOKEN}'" >> src/environments/environment.ts \
-    && echo "  }" >> src/environments/environment.ts \
-    && echo "};" >> src/environments/environment.ts
+RUN echo "export const environment = {" > src/environment/environment.ts \
+    && echo "  production: ${PROD}," >> src/environment/environment.ts \
+    && echo "  url: '${BACKEND_URL}'," >> src/environment/environment.ts \
+    && echo "  mapbox: {" >> src/environment/environment.ts \
+    && echo "    accessToken: '${MAP_ACCESS_TOKEN}'" >> src/environment/environment.ts \
+    && echo "  }" >> src/environment/environment.ts \
+    && echo "};" >> src/environment/environment.ts
 
 RUN npm run build
 

--- a/angular-client/Dockerfile
+++ b/angular-client/Dockerfile
@@ -1,4 +1,7 @@
 # build the node application, required for serving step
+ARG PROD
+ARG BACKEND_URL
+ARG MAP_ACCESS_TOKEN
 FROM node:alpine AS Build
 WORKDIR /usr/src/app
 COPY package.json package-lock.json ./

--- a/angular-client/src/api/urls.ts
+++ b/angular-client/src/api/urls.ts
@@ -1,6 +1,6 @@
 import { environment } from 'src/environment/environment';
 
-const baseURL = environment.url;
+const baseURL = (environment as any).url || 'http://localhost:8000';
 
 /* Nodes */
 const getAllNodes = () => `${baseURL}/nodes`;

--- a/angular-client/src/app/context/app-context.component.ts
+++ b/angular-client/src/app/context/app-context.component.ts
@@ -12,7 +12,7 @@ import Storage from 'src/services/storage.service';
   templateUrl: './app-context.component.html'
 })
 export default class AppContext implements OnInit {
-  socket = io(environment.url);
+  socket = io((environment as any).url || 'http://localhost:8000');
   socketService = new SocketService(this.socket);
 
   constructor(private storage: Storage) {}

--- a/angular-client/src/environment/environment.ts
+++ b/angular-client/src/environment/environment.ts
@@ -1,0 +1,6 @@
+export const environment = {
+  production: false,
+  mapbox: {
+    accessToken: 'pk.eyJ1IjoibWNrZWVwIiwiYSI6ImNscXBrcmU1ZTBscWIya284cDFyYjR3Nm8ifQ.6TQHlxhAJzptZyV-W28dnw'
+  }
+};

--- a/angular-client/src/environment/environment.ts
+++ b/angular-client/src/environment/environment.ts
@@ -1,6 +1,5 @@
 export const environment = {
-  production: true,
-  url: 'http://192.168.100.1:8000',
+  production: false,
   mapbox: {
     accessToken: 'pk.eyJ1IjoibWNrZWVwIiwiYSI6ImNscXBrcmU1ZTBscWIya284cDFyYjR3Nm8ifQ.6TQHlxhAJzptZyV-W28dnw'
   }

--- a/angular-client/src/environment/environment.ts
+++ b/angular-client/src/environment/environment.ts
@@ -1,6 +1,0 @@
-export const environment = {
-  production: false,
-  mapbox: {
-    accessToken: 'pk.eyJ1IjoibWNrZWVwIiwiYSI6ImNscXBrcmU1ZTBscWIya284cDFyYjR3Nm8ifQ.6TQHlxhAJzptZyV-W28dnw'
-  }
-};

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,79 @@
+services:
+  odyssey-timescale:
+    container_name: odyssey-timescale
+    image: timescale/timescaledb:2.13.1-pg15
+    restart: unless-stopped
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+    ports: # needs to be published for charybdis, which runs outside of docker
+      - 5432:5432
+    expose:
+      - 5432
+    cpu_shares: 1024
+    mem_limit: 3gb
+    cpuset: 0-3
+    stop_grace_period: 1m
+
+  scylla-server:
+    container_name: scylla-server
+    restart: unless-stopped
+    # image: ghcr.io/northeastern-electric-racing/argos:ghcr-action-scylla-server
+    build:
+      context: ./scylla-server
+      target: production
+      dockerfile: Dockerfile
+    ports:
+      - 8000:8000
+    depends_on:
+      - odyssey-timescale
+      - siren
+    environment:
+      - SOURCE_DATABASE_URL=postgresql://postgres:password@odyssey-timescale:5432/timescaledb
+      - PROD_SIREN_HOST_URL=siren
+      - PROD=true
+    # extra_hosts:
+    #   - "host.docker.internal:host-gateway" # for external siren
+    cpu_shares: 1024
+    cpuset: 0-3
+    mem_limit: 2gb
+    stop_grace_period: 10s
+
+
+  client:
+    container_name: client
+    restart: unless-stopped
+    # image: ghcr.io/northeastern-electric-racing/argos:ghcr-action-angular-client
+    build:
+      context: ./angular-client
+      args:
+        PROD: "true"
+        BACKEND_URL: http://localhost:8000
+        MAP_ACCESS_TOKEN: pk.eyJ1IjoibWNrZWVwIiwiYSI6ImNscXBrcmU1ZTBscWIya284cDFyYjR3Nm8ifQ.6TQHlxhAJzptZyV-W28dnw
+      target: production
+      dockerfile: Dockerfile
+    ports:
+      - 80:80
+    depends_on:
+      - scylla-server
+    cpu_shares: 512
+    cpuset: 0-3
+    mem_limit: 1gb
+
+  siren:
+    container_name: siren
+    restart: unless-stopped
+    image: eclipse-mosquitto:latest
+    ports:
+      - 1883:1883
+      - 9001:9001 # why?
+    expose:
+      - 1883
+    volumes:
+      - ./siren-base/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf
+    cpu_shares: 2048
+    cpuset: 0-3
+    mem_limit: 2gb
+    oom_kill_disable: true
+  
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     restart: unless-stopped
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
+    ports: # needs to be published for charybdis, which runs outside of docker
+      - 5432:5432
     expose:
       - 5432
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   odyssey-timescale:
     container_name: odyssey-timescale
     image: timescale/timescaledb:2.13.1-pg15
-    platform: linux/arm64
     restart: unless-stopped
     network_mode: host
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@ services:
       - 5432:5432
     expose:
       - 5432
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    cpu_shares: 1024
+    mem_limit: 3gb
+    stop_grace_period: 1m
 
   scylla-server:
     container_name: scylla-server
@@ -24,12 +29,17 @@ services:
       - 8000:8000
     depends_on:
       - odyssey-timescale
+      - siren
     environment:
       - SOURCE_DATABASE_URL=postgresql://postgres:password@odyssey-timescale:5432/timescaledb
-      - PROD_SIREN_HOST_URL=host.docker.internal
+      - PROD_SIREN_HOST_URL=siren
       - PROD=true
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+    # extra_hosts:
+    #   - "host.docker.internal:host-gateway" # for external siren
+    cpu_shares: 1024
+    mem_limit: 2gb
+    stop_grace_period: 10s
+
 
   client:
     container_name: client
@@ -47,6 +57,32 @@ services:
       - 80:80
     depends_on:
       - scylla-server
+    cpu_shares: 512
+    mem_limit: 1gb
+
+  siren:
+    container_name: siren
+    restart: unless-stopped
+    image: eclipse-mosquitto:latest
+    ports:
+      - 1883:1883
+      - 9001:9001 # why?
+    expose:
+      - 1883
+    volumes:
+      - ./siren-base/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf
+    cpu_shares: 2048
+    mem_limit: 2gb
+    oom_kill_disable: true
+
+    
+
+
+  
+
+
+volumes:
+  db-data:
   
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,11 +75,6 @@ services:
     mem_limit: 2gb
     oom_kill_disable: true
 
-    
-
-
-  
-
 
 volumes:
   db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,10 @@ services:
     image: ghcr.io/northeastern-electric-racing/argos:ghcr-action-angular-client
     build:
       context: ./angular-client
+      args:
+        PROD: true
+        BACKEND_URL: http://192.168.100.1:8000
+        MAP_ACCESS_TOKEN: pk.eyJ1IjoibWNrZWVwIiwiYSI6ImNscXBrcmU1ZTBscWIya284cDFyYjR3Nm8ifQ.6TQHlxhAJzptZyV-W28dnw
       target: production
       dockerfile: Dockerfile
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,20 +5,15 @@ services:
     container_name: odyssey-timescale
     image: timescale/timescaledb:2.13.1-pg15
     restart: unless-stopped
-    network_mode: host
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
-    ports:
-      - 5432:5432
     expose:
       - 5432
-    tty: true
 
   scylla-server:
     container_name: scylla-server
     restart: unless-stopped
     image: ghcr.io/northeastern-electric-racing/argos:ghcr-action-scylla-server
-    network_mode: host
     build:
       context: ./scylla-server
       target: production
@@ -27,18 +22,25 @@ services:
       - 8000:8000
     depends_on:
       - odyssey-timescale
+    environment:
+      - SOURCE_DATABASE_URL=postgresql://postgres:password@odyssey-timescale:5432/timescaledb
+      - PROD_SIREN_HOST_URL=host.docker.internal
+      - PROD=true
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   client:
     container_name: client
     restart: unless-stopped
     image: ghcr.io/northeastern-electric-racing/argos:ghcr-action-angular-client
-    network_mode: host
     build:
       context: ./angular-client
       target: production
       dockerfile: Dockerfile
     ports:
-      - 4200:80
+      - 80:80
     depends_on:
       - scylla-server
+  
+
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   scylla-server:
     container_name: scylla-server
     restart: unless-stopped
-    image: mckeep/scylla-server-prod:1.0.0
+    image: ghcr.io/northeastern-electric-racing/argos:ghcr-action-scylla-server
     network_mode: host
     build:
       context: ./scylla-server
@@ -31,7 +31,7 @@ services:
   client:
     container_name: client
     restart: unless-stopped
-    image: mckeep/client-prod:1.0.0
+    image: ghcr.io/northeastern-electric-racing/argos:ghcr-action-angular-client
     network_mode: host
     build:
       context: ./angular-client

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     build:
       context: ./angular-client
       args:
-        PROD: true
+        PROD: "true"
         BACKEND_URL: http://192.168.100.1:8000
         MAP_ACCESS_TOKEN: pk.eyJ1IjoibWNrZWVwIiwiYSI6ImNscXBrcmU1ZTBscWIya284cDFyYjR3Nm8ifQ.6TQHlxhAJzptZyV-W28dnw
       target: production

--- a/siren-base/mosquitto/mosquitto.conf
+++ b/siren-base/mosquitto/mosquitto.conf
@@ -3,6 +3,8 @@
 # Note that comments cannot be on the same line as uncommented keys (ie # only respected at line position 0)
 # # *** ^^^
 
+max_topic_alias 65534
+
 #per_listener_settings false
 
 allow_zero_length_clientid false
@@ -31,7 +33,7 @@ persistent_client_expiration 14d
 
 #pid_file
 
-queue_qos0_messages true
+queue_qos0_messages false
 
 #retain_available true
 
@@ -187,7 +189,7 @@ bridge_protocol_version mqttv50
 
 #local_clientid
 
-#notifications true
+notifications true
 
 #notification_topic
 
@@ -242,5 +244,4 @@ restart_timeout 5
 
 #include_dir
 
-# *** diff from tpu
 max_qos 2 # *** moved to bottom see bug https://github.com/eclipse/mosquitto/issues/2991

--- a/siren-base/mosquitto/mosquitto.conf
+++ b/siren-base/mosquitto/mosquitto.conf
@@ -1,0 +1,246 @@
+# See mosquitto.conf for comments and info. https://mosquitto.org/man/mosquitto-conf-5.html
+# All options here uncommented were changed, commented are the defaults being noted.
+# Note that comments cannot be on the same line as uncommented keys (ie # only respected at line position 0)
+# # *** ^^^
+
+#per_listener_settings false
+
+allow_zero_length_clientid false
+
+#auto_id_prefix auto-
+
+check_retain_source false
+
+#max_inflight_bytes 0
+
+#max_inflight_messages 20
+
+#max_keepalive 65535
+
+#max_packet_size 0
+
+#max_queued_bytes 0
+
+#max_queued_messages 1000
+
+#memory_limit 0
+
+#message_size_limit 0
+
+persistent_client_expiration 14d
+
+#pid_file
+
+queue_qos0_messages true
+
+#retain_available true
+
+#set_tcp_nodelay false
+
+#sys_interval 10
+
+#upgrade_outgoing_qos false
+
+#user mosquitto
+
+# =================================================================
+# Listeners
+# =================================================================
+
+listener 1883
+
+socket_domain ipv4
+
+#bind_interface
+
+#http_dir
+
+#max_connections -1
+
+#mount_point
+
+#protocol mqtt
+
+#use_username_as_clientid
+
+#websockets_headers_size
+
+# -----------------------------------------------------------------
+# Certificate based SSL/TLS support
+# -----------------------------------------------------------------
+
+#certfile
+
+#keyfile
+
+#ciphers
+
+#ciphers_tls1.3
+
+#crlfile
+
+#dhparamfile
+
+#require_certificate false
+
+#cafile
+#capath
+
+#use_identity_as_username false
+
+# -----------------------------------------------------------------
+# Pre-shared-key based SSL/TLS support
+# -----------------------------------------------------------------
+
+#psk_hint
+
+#ciphers
+
+#use_identity_as_username false
+
+
+# =================================================================
+# Persistence
+# =================================================================
+
+autosave_interval 30
+
+#autosave_on_changes false
+
+#persistence false
+
+#persistence_file mosquitto.db
+
+#persistence_location
+
+
+# =================================================================
+# Logging
+# =================================================================
+# *** diff from tpu (for docker)
+log_dest file /mosquitto/log/mosquitto.log
+
+
+log_type notice
+#log_type information
+
+connection_messages true
+
+log_timestamp true
+
+#log_timestamp_format
+
+#websockets_log_level 0
+
+
+# =================================================================
+# Security
+# =================================================================
+
+#clientid_prefixes
+
+allow_anonymous true
+
+# -----------------------------------------------------------------
+# Default authentication and topic access control
+# -----------------------------------------------------------------
+
+#password_file
+
+#psk_file
+
+#acl_file
+
+# *** diff from tpu
+#plugin /usr/lib/mosquitto/mosquitto_message_timestamp.so
+
+# plugin_opt_db_host
+# plugin_opt_db_port
+# plugin_opt_db_username
+# plugin_opt_db_password
+
+
+# =================================================================
+# Bridges
+# =================================================================
+
+# *** diff from tpu
+connection tpu
+# *** tpu ip
+# *** diff from tpu
+address 192.168.100.12
+# *** diff from tpu (needed as topic key required)
+topic reserved out 2 dummy dummyremote
+
+
+#bridge_bind_address
+
+#bridge_attempt_unsubscribe true
+
+bridge_protocol_version mqttv50
+
+#cleansession false
+
+#idle_timeout 60
+
+#keepalive_interval 60
+
+#local_clientid
+
+#notifications true
+
+#notification_topic
+
+# *** diff from tpu
+remote_clientid base_station
+
+#remote_password
+
+#remote_username
+
+restart_timeout 5
+
+#round_robin false
+
+#start_type automatic
+
+#threshold 10
+
+#try_private true
+
+#bridge_outgoing_retain true
+
+#bridge_max_packet_size 0
+
+
+# -----------------------------------------------------------------
+# Certificate based SSL/TLS support
+# -----------------------------------------------------------------
+
+#bridge_cafile
+#bridge_capath
+
+#bridge_alpn
+
+#bridge_insecure false
+
+#bridge_certfile
+
+#bridge_keyfile
+
+# -----------------------------------------------------------------
+# PSK based SSL/TLS support
+# -----------------------------------------------------------------
+
+#bridge_identity
+#bridge_psk
+
+
+# =================================================================
+# External config files
+# =================================================================
+
+#include_dir
+
+# *** diff from tpu
+max_qos 2 # *** moved to bottom see bug https://github.com/eclipse/mosquitto/issues/2991


### PR DESCRIPTION
Changes:
 - Add a workflow which builds scylla and angular for arm64 and amd64, and publishes them to ghcr.io as public, builds upon **manually calling it in the actions tab and PR merged.**.  Rationale: it takes 30+ min to run so only do it when a user manually calls it, and when PR is created and merged.
 - Allows angular-client to be built from the docker image (idk why this wasnt done before?)
 - Edits the compose to be platform agnostic
 - Edits the compose to point to this repository GHCR link

Tested:
- Can run on x86_64, can run on router
- **Did not test with edits done to env**