### PR TITLE
Migrate ServerData Protobuf to v2, switch internal struct to chrono + f32, update time sourcing logic

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -57,6 +57,6 @@ jobs:
           provenance: false
           build-args: |
             PROD=true
-            BACKEND_URL=http://192.168.100.1:8000
+            BACKEND_URL=http://192.168.100.11:8000
             MAP_ACCESS_TOKEN=pk.eyJ1IjoibWNrZWVwIiwiYSI6ImNscXBrcmU1ZTBscWIya284cDFyYjR3Nm8ifQ.6TQHlxhAJzptZyV-W28dnw
 

--- a/scylla-server/Cargo.lock
+++ b/scylla-server/Cargo.lock
@@ -3225,6 +3225,7 @@ version = "0.0.1"
 dependencies = [
  "axum 0.7.5",
  "axum-extra",
+ "chrono",
  "clap",
  "console-subscriber",
  "prisma-client-rust",
@@ -3234,6 +3235,7 @@ dependencies = [
  "ringbuffer",
  "rumqttc",
  "serde",
+ "serde_json",
  "socketioxide",
  "tokio",
  "tokio-util",
@@ -3311,12 +3313,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]

--- a/scylla-server/Cargo.toml
+++ b/scylla-server/Cargo.toml
@@ -23,6 +23,8 @@ console-subscriber = { version = "0.3.0", optional = true }
 ringbuffer = "0.15.0"
 clap = { version = "4.5.11", features = ["derive", "env"] }
 axum-extra = { version = "0.9.3", features = ["query"] }
+chrono = { version = "0.4.38", features = ["serde"] }
+serde_json = "1.0.128"
 
 [features]
 top = ["dep:console-subscriber"]

--- a/scylla-server/prisma/seed.rs
+++ b/scylla-server/prisma/seed.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
-use prisma_client_rust::{chrono, QueryError};
+use prisma_client_rust::QueryError;
 use scylla_server::{
     prisma::PrismaClient,
     processors::ClientData,
@@ -35,8 +35,7 @@ async fn main() -> Result<(), QueryError> {
 
     client.system().delete_many(vec![]).exec().await?;
 
-    let created_run =
-        run_service::create_run(&client, chrono::offset::Utc::now().timestamp_millis()).await?;
+    let created_run = run_service::create_run(&client, chrono::offset::Utc::now()).await?;
 
     system_service::upsert_system(&client, "Data And Controls".to_string(), created_run.id).await?;
     driver_service::upsert_driver(&client, "Fergus".to_string(), created_run.id).await?;
@@ -67,72 +66,72 @@ async fn main() -> Result<(), QueryError> {
                 run_id: created_run.id,
                 name: "Pack-Temp".to_string(),
                 unit: "C".to_string(),
-                values: vec!["20".to_string()],
-                timestamp: chrono::offset::Utc::now().timestamp_millis(),
+                values: vec![20f32],
+                timestamp: chrono::offset::Utc::now(),
                 node: "BMS".to_string(),
             },
             ClientData {
                 run_id: created_run.id,
                 name: "Pack-Temp".to_string(),
                 unit: "C".to_string(),
-                values: vec!["21".to_string()],
-                timestamp: chrono::offset::Utc::now().timestamp_millis() + 1000,
+                values: vec![21f32],
+                timestamp: chrono::offset::Utc::now() + Duration::from_millis(1000),
                 node: "BMS".to_string(),
             },
             ClientData {
                 run_id: created_run.id,
                 name: "Pack-Temp".to_string(),
                 unit: "C".to_string(),
-                values: vec!["22".to_string()],
-                timestamp: chrono::offset::Utc::now().timestamp_millis() + 2000,
+                values: vec![22f32],
+                timestamp: chrono::offset::Utc::now() + Duration::from_millis(2000),
                 node: "BMS".to_string(),
             },
             ClientData {
                 run_id: created_run.id,
                 name: "Pack-Temp".to_string(),
                 unit: "C".to_string(),
-                values: vec!["17".to_string()],
-                timestamp: chrono::offset::Utc::now().timestamp_millis() + 3000,
+                values: vec![17f32],
+                timestamp: chrono::offset::Utc::now() + Duration::from_millis(3000),
                 node: "BMS".to_string(),
             },
             ClientData {
                 run_id: created_run.id,
                 name: "Pack-Temp".to_string(),
                 unit: "C".to_string(),
-                values: vec!["25".to_string()],
-                timestamp: chrono::offset::Utc::now().timestamp_millis() + 4000,
+                values: vec![17f32],
+                timestamp: chrono::offset::Utc::now() + Duration::from_millis(4000),
                 node: "BMS".to_string(),
             },
             ClientData {
                 run_id: created_run.id,
                 name: "Pack-Temp".to_string(),
                 unit: "C".to_string(),
-                values: vec!["30".to_string()],
-                timestamp: chrono::offset::Utc::now().timestamp_millis() + 5000,
+                values: vec![17f32],
+                timestamp: chrono::offset::Utc::now() + Duration::from_millis(5000),
                 node: "BMS".to_string(),
             },
             ClientData {
                 run_id: created_run.id,
                 name: "Pack-Temp".to_string(),
                 unit: "C".to_string(),
-                values: vec!["38".to_string()],
-                timestamp: chrono::offset::Utc::now().timestamp_millis() + 6000,
+                values: vec![17f32],
+                timestamp: chrono::offset::Utc::now() + Duration::from_millis(6000),
                 node: "BMS".to_string(),
             },
             ClientData {
                 run_id: created_run.id,
                 name: "Pack-Temp".to_string(),
                 unit: "C".to_string(),
-                values: vec!["32".to_string()],
-                timestamp: chrono::offset::Utc::now().timestamp_millis() + 7000,
+                values: vec![17f32],
+                timestamp: chrono::offset::Utc::now() + Duration::from_millis(7000),
                 node: "BMS".to_string(),
             },
             ClientData {
                 run_id: created_run.id,
                 name: "Pack-Temp".to_string(),
                 unit: "C".to_string(),
-                values: vec!["26".to_string()],
-                timestamp: chrono::offset::Utc::now().timestamp_millis() + 8000,
+                values: vec![17f32],
+                timestamp: chrono::offset::Utc::now() + Duration::from_millis(8000),
                 node: "BMS".to_string(),
             },
         ],
@@ -215,8 +214,8 @@ async fn simulate_route(db: Database, curr_run: i32) -> Result<(), QueryError> {
                 run_id: curr_run,
                 name: "Points".to_string(),
                 unit: "Coord".to_string(),
-                values: vec![inter_lat.to_string(), inter_long.to_string()],
-                timestamp: chrono::offset::Utc::now().timestamp_millis(),
+                values: vec![inter_lat as f32, inter_long as f32],
+                timestamp: chrono::offset::Utc::now(),
                 node: "TPU".to_string(),
             },
         )

--- a/scylla-server/src/controllers/run_controller.rs
+++ b/scylla-server/src/controllers/run_controller.rs
@@ -2,7 +2,6 @@ use axum::{
     extract::{Path, State},
     Extension, Json,
 };
-use prisma_client_rust::chrono;
 use tokio::sync::mpsc;
 use tracing::warn;
 
@@ -43,8 +42,7 @@ pub async fn new_run(
     State(db): State<Database>,
     Extension(channel): Extension<mpsc::Sender<run_service::public_run::Data>>,
 ) -> Result<Json<PublicRun>, ScyllaError> {
-    let run_data =
-        run_service::create_run(&db, chrono::offset::Utc::now().timestamp_millis()).await?;
+    let run_data = run_service::create_run(&db, chrono::offset::Utc::now()).await?;
 
     // notify the mqtt receiver a new run has been created
     if let Err(err) = channel.send(run_data.clone()).await {

--- a/scylla-server/src/main.rs
+++ b/scylla-server/src/main.rs
@@ -6,7 +6,6 @@ use axum::{
     Extension, Router,
 };
 use clap::Parser;
-use prisma_client_rust::chrono;
 use rumqttc::v5::AsyncClient;
 use scylla_server::{
     controllers::{
@@ -196,7 +195,7 @@ async fn main() {
         None
     } else {
         // creates the initial run
-        let curr_run = run_service::create_run(&db, chrono::offset::Utc::now().timestamp_millis())
+        let curr_run = run_service::create_run(&db, chrono::offset::Utc::now())
             .await
             .expect("Could not create initial run!");
         debug!("Configuring current run: {:?}", curr_run);

--- a/scylla-server/src/processors/db_handler.rs
+++ b/scylla-server/src/processors/db_handler.rs
@@ -247,6 +247,7 @@ impl DbHandler {
 
         // if data has some special meanings, push them to the database immediately, notably no matter what also enter batching logic
         match msg.name.as_str() {
+            // TODO remove driver from here, as driver is not car sourced
             "Driver" => {
                 debug!("Upserting driver: {:?}", msg.values);
                 if let Err(err) = driver_service::upsert_driver(
@@ -259,12 +260,14 @@ impl DbHandler {
                     warn!("Driver upsert error: {:?}", err);
                 }
             }
+            // TODO see above
             "location" => {
                 debug!("Upserting location name: {:?}", msg.values);
                 self.location_lock
                     .add_loc_name((*msg.values.first().unwrap_or(&0.0f32)).to_string());
                 self.is_location = true;
             }
+            // TODO see above
             "system" => {
                 debug!("Upserting system: {:?}", msg.values);
                 if let Err(err) = system_service::upsert_system(

--- a/scylla-server/src/processors/mock_data.rs
+++ b/scylla-server/src/processors/mock_data.rs
@@ -1,4 +1,4 @@
-use super::mock_processor::{MockData, MockStringData};
+use super::mock_processor::MockData;
 
 pub const BASE_MOCK_DATA: [MockData; 17] = [
     MockData {
@@ -119,18 +119,5 @@ pub const BASE_MOCK_DATA: [MockData; 17] = [
         num_of_vals: 1,
         min: 0.0,
         max: 600.0,
-    },
-];
-
-pub const BASE_MOCK_STRING_DATA: [MockStringData; 2] = [
-    MockStringData {
-        name: "Driver",
-        unit: "String",
-        vals: "Fergus",
-    },
-    MockStringData {
-        name: "Location",
-        unit: "String",
-        vals: "Max",
     },
 ];

--- a/scylla-server/src/processors/mod.rs
+++ b/scylla-server/src/processors/mod.rs
@@ -1,3 +1,6 @@
+use chrono::serde::ts_milliseconds;
+use chrono::{DateTime, Utc};
+
 pub mod db_handler;
 mod mock_data;
 pub mod mock_processor;
@@ -13,9 +16,12 @@ pub struct ClientData {
     pub run_id: i32,
     pub name: String,
     pub unit: String,
-    pub values: Vec<String>,
-    pub timestamp: i64,
+    pub values: Vec<f32>,
+    /// Client expects time in milliseconds, so serialize as such
+    #[serde(with = "ts_milliseconds")]
+    pub timestamp: DateTime<Utc>,
 
+    /// client doesnt parse node
     #[serde(skip_serializing)]
     pub node: String,
 }
@@ -25,7 +31,7 @@ pub struct ClientData {
 #[derive(Debug)]
 struct LocationData {
     location_name: String,
-    lat: f64,
-    long: f64,
-    radius: f64,
+    lat: f32,
+    long: f32,
+    radius: f32,
 }

--- a/scylla-server/src/processors/mqtt_processor.rs
+++ b/scylla-server/src/processors/mqtt_processor.rs
@@ -260,12 +260,13 @@ impl MqttProcessor {
         // - B: The time packaged in the MQTT header, to millisecond precision (hence the * 1000 on B)
         // - C: The local scylla system time
         // note protobuf defaults to 0 for unfilled time, so consider it as an unset time
-        let unix_time = if data.time > 0 {
+        let unix_time = if data.time_us > 0 {
             // A
-            let Some(unix_time) = chrono::DateTime::from_timestamp_micros(data.time as i64) else {
+            let Some(unix_time) = chrono::DateTime::from_timestamp_micros(data.time_us as i64)
+            else {
                 warn!(
                     "Corrupted time in protobuf: {}, discarding message!",
-                    data.time
+                    data.time_us
                 );
                 return None;
             };

--- a/scylla-server/src/processors/mqtt_processor.rs
+++ b/scylla-server/src/processors/mqtt_processor.rs
@@ -4,7 +4,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use prisma_client_rust::{bigdecimal::ToPrimitive, chrono, serde_json};
+use prisma_client_rust::bigdecimal::ToPrimitive;
 use protobuf::Message;
 use ringbuffer::RingBuffer;
 use rumqttc::v5::{
@@ -25,7 +25,6 @@ use crate::{
 };
 
 use super::ClientData;
-use std::borrow::Cow;
 
 /// The chief processor of incoming mqtt data, this handles
 /// - mqtt state
@@ -154,7 +153,7 @@ impl MqttProcessor {
                             Some(msg) => msg,
                             None => continue
                         };
-                        latency_ringbuffer.push(chrono::offset::Utc::now().timestamp_millis() - msg.timestamp);
+                        latency_ringbuffer.push((chrono::offset::Utc::now() - msg.timestamp).num_milliseconds());
                         self.send_db_msg(msg.clone()).await;
                         self.send_socket_msg(msg, &mut upload_counter);
                     },
@@ -169,8 +168,8 @@ impl MqttProcessor {
                         node: "Internal".to_string(),
                         unit: "".to_string(),
                         run_id: self.curr_run,
-                        timestamp: chrono::offset::Utc::now().timestamp_millis(),
-                        values: vec![sockets.len().to_string()]
+                        timestamp: chrono::offset::Utc::now(),
+                        values: vec![sockets.len() as f32]
                     };
                     self.send_socket_msg(client_data, &mut upload_counter);
                     } else {
@@ -190,10 +189,10 @@ impl MqttProcessor {
                         node: "Internal".to_string(),
                         unit: "ms".to_string(),
                         run_id: self.curr_run,
-                        timestamp: chrono::offset::Utc::now().timestamp_millis(),
-                        values: vec![avg_latency.to_string()]
+                        timestamp: chrono::offset::Utc::now(),
+                        values: vec![avg_latency as f32]
                     };
-                    trace!("Latency update sending: {}", client_data.values.first().unwrap_or(&"n/a".to_string()));
+                    trace!("Latency update sending: {}", client_data.values.first().unwrap_or(&0.0f32));
                     self.send_socket_msg(client_data, &mut upload_counter);
                 }
                 Some(new_run) = self.new_run_channel.recv() => {
@@ -254,48 +253,69 @@ impl MqttProcessor {
 
         let data_type = split.1.replace('/', "-");
 
-        // extract the unix time, returning the current time instead if either the "ts" user property isnt present or it isnt parsable
-        // note the Cow magic involves the return from the map is a borrow, but the unwrap cannot as we dont own it
-        let unix_time = msg
-            .properties
-            .unwrap_or_default()
-            .user_properties
-            .iter()
-            .map(Cow::Borrowed)
-            .find(|f| f.0 == "ts")
-            .unwrap_or_else(|| {
-                debug!("Could not find timestamp in mqtt, using system time");
-                Cow::Owned((
-                    "ts".to_string(),
-                    chrono::offset::Utc::now().timestamp_millis().to_string(),
-                ))
-            })
-            .1
-            .parse::<i64>()
-            .unwrap_or_else(|err| {
-                warn!("Invalid timestamp in mqtt, using system time: {}", err);
-                chrono::offset::Utc::now().timestamp_millis()
-            });
+        // extract the unix time
+        // levels of time priority
+        // - A: The time packaged in the protobuf, to microsecond precision
+        // - B: The time packaged in the MQTT header, to millisecond precision (hence the * 1000 on B)
+        // - C: The local scylla system time
+        // note protobuf defaults to 0 for unfilled time, so consider it as an unset time
+        let unix_time = if data.time > 0 {
+            // A
+            let Some(unix_time) = chrono::DateTime::from_timestamp_micros(data.time as i64) else {
+                warn!(
+                    "Corrupted time in protobuf: {}, discarding message!",
+                    data.time
+                );
+                return None;
+            };
+            unix_time
+        } else {
+            // B
+            match match msg
+                .properties
+                .unwrap_or_default()
+                .user_properties
+                .iter()
+                .find(|f| f.0 == "ts")
+            {
+                Some(val) => {
+                    let Ok(time_parsed) = val.1.parse::<i64>() else {
+                        warn!("Corrupted time in mqtt header, discarding message!");
+                        return None;
+                    };
+                    chrono::DateTime::from_timestamp_millis(time_parsed)
+                }
+                None => None,
+            } {
+                Some(e) => e,
+                None => {
+                    // C
+                    debug!("Could not extract time, using system time!");
+                    chrono::offset::Utc::now()
+                }
+            }
+        };
 
         // ts check for bad sources of time which may return 1970
         // if both system time and packet timestamp are before year 2000, the message cannot be recorded
-        let unix_clean = if unix_time < 963014966000 {
-            debug!("Timestamp before year 2000: {}", unix_time);
-            let sys_time = chrono::offset::Utc::now().timestamp_millis();
-            if sys_time < 963014966000 {
-                warn!("System has no good time, discarding message!");
-                return None;
-            }
-            sys_time
-        } else {
-            unix_time
-        };
+        let unix_clean =
+            if unix_time < chrono::DateTime::from_timestamp_millis(963014966000).unwrap() {
+                debug!("Timestamp before year 2000: {}", unix_time.to_string());
+                let sys_time = chrono::offset::Utc::now();
+                if sys_time < chrono::DateTime::from_timestamp_millis(963014966000).unwrap() {
+                    warn!("System has no good time, discarding message!");
+                    return None;
+                }
+                sys_time
+            } else {
+                unix_time
+            };
 
         Some(ClientData {
             run_id: self.curr_run,
             name: data_type,
             unit: data.unit,
-            values: data.value,
+            values: data.values,
             timestamp: unix_clean,
             node: node.to_string(),
         })

--- a/scylla-server/src/proto/serverdata.proto
+++ b/scylla-server/src/proto/serverdata.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package serverdata.v1;
+package serverdata.v2;
 
 message ServerData {
    // ensure old type is reserved

--- a/scylla-server/src/proto/serverdata.proto
+++ b/scylla-server/src/proto/serverdata.proto
@@ -3,6 +3,12 @@ syntax = "proto3";
 package serverdata.v1;
 
 message ServerData {
-   repeated string value = 1;
+   // ensure old type is reserved
+   reserved 1;
+   reserved "value";
+   
    string unit = 2;
+   // time since unix epoch in MICROSECONDS
+   uint64 time = 3;
+   repeated float values = 4;
 }

--- a/scylla-server/src/proto/serverdata.proto
+++ b/scylla-server/src/proto/serverdata.proto
@@ -9,6 +9,6 @@ message ServerData {
    
    string unit = 2;
    // time since unix epoch in MICROSECONDS
-   uint64 time = 3;
+   uint64 time_us = 3;
    repeated float values = 4;
 }

--- a/scylla-server/src/services/data_service.rs
+++ b/scylla-server/src/services/data_service.rs
@@ -1,4 +1,4 @@
-use prisma_client_rust::{chrono::DateTime, QueryError};
+use prisma_client_rust::QueryError;
 
 use crate::{prisma, processors::ClientData, Database};
 
@@ -43,16 +43,10 @@ pub async fn add_data(
     db.data()
         .create(
             prisma::data_type::name::equals(client_data.name),
-            DateTime::from_timestamp_millis(client_data.timestamp)
-                .expect("Could not parse timestamp")
-                .fixed_offset(),
+            client_data.timestamp.fixed_offset(),
             prisma::run::id::equals(client_data.run_id),
             vec![prisma::data::values::set(
-                client_data
-                    .values
-                    .iter()
-                    .map(|f| f.parse::<f64>().unwrap_or_default())
-                    .collect(),
+                client_data.values.iter().map(|f| *f as f64).collect(),
             )],
         )
         .select(public_data::select())
@@ -72,15 +66,10 @@ pub async fn add_many(db: &Database, client_data: Vec<ClientData>) -> Result<i64
                 .map(|f| {
                     prisma::data::create_unchecked(
                         f.name.to_string(),
-                        DateTime::from_timestamp_millis(f.timestamp)
-                            .expect("Could not parse timestamp")
-                            .fixed_offset(),
+                        f.timestamp.fixed_offset(),
                         f.run_id,
                         vec![prisma::data::values::set(
-                            f.values
-                                .iter()
-                                .map(|f| f.parse::<f64>().unwrap_or_default())
-                                .collect(),
+                            f.values.iter().map(|f| *f as f64).collect(),
                         )],
                     )
                 })

--- a/scylla-server/src/services/run_service.rs
+++ b/scylla-server/src/services/run_service.rs
@@ -1,6 +1,7 @@
 use std::vec;
 
-use prisma_client_rust::{chrono::DateTime, QueryError};
+use chrono::{DateTime, Utc};
+use prisma_client_rust::QueryError;
 
 use crate::{
     prisma::{self},
@@ -43,16 +44,14 @@ pub async fn get_run_by_id(
 
 /// Creates a run
 /// * `db` - The prisma client to make the call to
-/// * `timestamp` - The unix time since epoch in miliseconds when the run starts
+/// * `timestamp` - time when the run starts
 ///   returns: A result containing the data or the QueryError propogated by the db
-pub async fn create_run(db: &Database, timestamp: i64) -> Result<public_run::Data, QueryError> {
+pub async fn create_run(
+    db: &Database,
+    timestamp: DateTime<Utc>,
+) -> Result<public_run::Data, QueryError> {
     db.run()
-        .create(
-            DateTime::from_timestamp_millis(timestamp)
-                .expect("Could not parse timestamp")
-                .fixed_offset(),
-            vec![],
-        )
+        .create(timestamp.fixed_offset(), vec![])
         .select(public_run::select())
         .exec()
         .await
@@ -60,21 +59,16 @@ pub async fn create_run(db: &Database, timestamp: i64) -> Result<public_run::Dat
 
 /// Creates a run with a given id
 /// * `db` - The prisma client to make the call to
-/// * `timestamp` - The unix time since epoch in miliseconds when the run starts
+/// * `timestamp` - time when the run starts
 /// * `run_id` - The id of the run to create, must not already be in use!
 ///   returns: A result containing the data or the QueryError propogated by the db
 pub async fn create_run_with_id(
     db: &Database,
-    timestamp: i64,
+    timestamp: DateTime<Utc>,
     run_id: i32,
 ) -> Result<public_run::Data, QueryError> {
     db.run()
-        .create(
-            DateTime::from_timestamp_millis(timestamp)
-                .expect("Could not parse timestamp")
-                .fixed_offset(),
-            vec![prisma::run::id::set(run_id)],
-        )
+        .create(timestamp.fixed_offset(), vec![prisma::run::id::set(run_id)])
         .select(public_run::select())
         .exec()
         .await

--- a/scylla-server/src/transformers/data_transformer.rs
+++ b/scylla-server/src/transformers/data_transformer.rs
@@ -7,14 +7,14 @@ use crate::{processors::ClientData, services::data_service};
 /// The struct defining the data format sent to the client
 #[derive(Serialize, Debug)]
 pub struct PublicData {
-    /// time in MILLISECONDS
-    pub time: i64,
+    #[serde(rename = "time")]
+    pub time_ms: i64,
     pub values: Vec<f64>,
 }
 // custom impls to avoid comparing values fields
 impl Ord for PublicData {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.time.cmp(&other.time)
+        self.time_ms.cmp(&other.time_ms)
     }
 }
 
@@ -26,7 +26,7 @@ impl PartialOrd for PublicData {
 
 impl PartialEq for PublicData {
     fn eq(&self, other: &Self) -> bool {
-        self.time == other.time
+        self.time_ms == other.time_ms
     }
 }
 
@@ -37,7 +37,7 @@ impl From<&data_service::public_data::Data> for PublicData {
     fn from(value: &data_service::public_data::Data) -> Self {
         PublicData {
             values: value.values.clone(),
-            time: value.time.timestamp_millis(),
+            time_ms: value.time.timestamp_millis(),
         }
     }
 }
@@ -46,7 +46,7 @@ impl From<&data_service::public_data::Data> for PublicData {
 impl From<ClientData> for PublicData {
     fn from(value: ClientData) -> Self {
         PublicData {
-            time: value.timestamp.timestamp_millis(),
+            time_ms: value.timestamp.timestamp_millis(),
             values: value.values.iter().map(|f| *f as f64).collect(),
         }
     }

--- a/scylla-server/src/transformers/data_transformer.rs
+++ b/scylla-server/src/transformers/data_transformer.rs
@@ -1,19 +1,42 @@
+use std::cmp::Ordering;
+
 use serde::Serialize;
 
 use crate::{processors::ClientData, services::data_service};
 
 /// The struct defining the data format sent to the client
-#[derive(Serialize, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Serialize, Debug)]
 pub struct PublicData {
+    /// time in MILLISECONDS
     pub time: i64,
-    pub values: Vec<String>,
+    pub values: Vec<f64>,
 }
+// custom impls to avoid comparing values fields
+impl Ord for PublicData {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.time.cmp(&other.time)
+    }
+}
+
+impl PartialOrd for PublicData {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for PublicData {
+    fn eq(&self, other: &Self) -> bool {
+        self.time == other.time
+    }
+}
+
+impl Eq for PublicData {}
 
 /// convert the prisma type to the client type for JSON encoding
 impl From<&data_service::public_data::Data> for PublicData {
     fn from(value: &data_service::public_data::Data) -> Self {
         PublicData {
-            values: value.values.iter().map(f64::to_string).collect(),
+            values: value.values.clone(),
             time: value.time.timestamp_millis(),
         }
     }
@@ -23,8 +46,8 @@ impl From<&data_service::public_data::Data> for PublicData {
 impl From<ClientData> for PublicData {
     fn from(value: ClientData) -> Self {
         PublicData {
-            time: value.timestamp,
-            values: value.values,
+            time: value.timestamp.timestamp_millis(),
+            values: value.values.iter().map(|f| *f as f64).collect(),
         }
     }
 }

--- a/scylla-server/src/transformers/run_transformer.rs
+++ b/scylla-server/src/transformers/run_transformer.rs
@@ -15,6 +15,7 @@ pub struct PublicRun {
     pub driver_name: String,
     #[serde(rename = "systemName")]
     pub system_name: String,
+    /// time in MILLISECONDS
     pub time: i64,
 }
 

--- a/scylla-server/src/transformers/run_transformer.rs
+++ b/scylla-server/src/transformers/run_transformer.rs
@@ -15,8 +15,8 @@ pub struct PublicRun {
     pub driver_name: String,
     #[serde(rename = "systemName")]
     pub system_name: String,
-    /// time in MILLISECONDS
-    pub time: i64,
+    #[serde(rename = "time")]
+    pub time_ms: i64,
 }
 
 impl From<&public_run::Data> for PublicRun {
@@ -26,7 +26,7 @@ impl From<&public_run::Data> for PublicRun {
             location_name: value.location_name.clone().unwrap_or_default(),
             driver_name: value.driver_name.clone().unwrap_or_default(),
             system_name: value.system_name.clone().unwrap_or_default(),
-            time: value.time.timestamp_millis(),
+            time_ms: value.time.timestamp_millis(),
         }
     }
 }
@@ -40,7 +40,7 @@ impl From<&public_driver::runs::Data> for PublicRun {
             location_name: value.location_name.clone().unwrap_or_default(),
             driver_name: value.driver_name.clone().unwrap_or_default(),
             system_name: value.system_name.clone().unwrap_or_default(),
-            time: value.time.timestamp_millis(),
+            time_ms: value.time.timestamp_millis(),
         }
     }
 }
@@ -52,7 +52,7 @@ impl From<&public_location::runs::Data> for PublicRun {
             location_name: value.location_name.clone().unwrap_or_default(),
             driver_name: value.driver_name.clone().unwrap_or_default(),
             system_name: value.system_name.clone().unwrap_or_default(),
-            time: value.time.timestamp_millis(),
+            time_ms: value.time.timestamp_millis(),
         }
     }
 }
@@ -64,7 +64,7 @@ impl From<&public_system::runs::Data> for PublicRun {
             location_name: value.location_name.clone().unwrap_or_default(),
             driver_name: value.driver_name.clone().unwrap_or_default(),
             system_name: value.system_name.clone().unwrap_or_default(),
-            time: value.time.timestamp_millis(),
+            time_ms: value.time.timestamp_millis(),
         }
     }
 }

--- a/scylla-server/tests/data_service_test.rs
+++ b/scylla-server/tests/data_service_test.rs
@@ -15,7 +15,8 @@ const TEST_KEYWORD: &str = "test";
 async fn test_data_service() -> Result<(), QueryError> {
     let db = cleanup_and_prepare().await?;
 
-    run_service::create_run_with_id(&db, 0, 0).await?;
+    run_service::create_run_with_id(&db, chrono::DateTime::from_timestamp_millis(0).unwrap(), 0)
+        .await?;
     node_service::upsert_node(&db, TEST_KEYWORD.to_owned()).await?;
     data_type_service::upsert_data_type(
         &db,
@@ -41,16 +42,17 @@ async fn test_data_add() -> Result<(), QueryError> {
         TEST_KEYWORD.to_owned(),
     )
     .await?;
-    let run_data = run_service::create_run(&db, 999).await?;
+    let run_data =
+        run_service::create_run(&db, chrono::DateTime::from_timestamp_millis(999).unwrap()).await?;
 
     let data = data_service::add_data(
         &db,
         ClientData {
-            values: vec!["0".to_owned()],
+            values: vec![0f32],
             unit: "A".to_owned(),
             run_id: run_data.id,
             name: TEST_KEYWORD.to_owned(),
-            timestamp: 1000,
+            timestamp: chrono::DateTime::from_timestamp_millis(1000).unwrap(),
             node: "Irrelevant".to_string(),
         },
     )
@@ -60,7 +62,7 @@ async fn test_data_add() -> Result<(), QueryError> {
         PublicData::from(&data),
         PublicData {
             time: 1000,
-            values: vec!["0".to_owned()]
+            values: vec![0f64]
         }
     );
 
@@ -87,11 +89,11 @@ async fn test_data_no_prereqs() -> Result<(), QueryError> {
     data_service::add_data(
         &db,
         ClientData {
-            values: vec!["0".to_owned()],
+            values: vec![0f32],
             unit: "A".to_owned(),
             run_id: 0,
             name: TEST_KEYWORD.to_owned(),
-            timestamp: 1000,
+            timestamp: chrono::DateTime::from_timestamp_millis(1000).unwrap(),
             node: "Irrelevant".to_string(),
         },
     )
@@ -107,17 +109,22 @@ async fn test_data_no_prereqs() -> Result<(), QueryError> {
         TEST_KEYWORD.to_owned(),
     )
     .await?;
-    run_service::create_run_with_id(&db, 1000, 0).await?;
+    run_service::create_run_with_id(
+        &db,
+        chrono::DateTime::from_timestamp_millis(1000).unwrap(),
+        0,
+    )
+    .await?;
 
     // now shouldnt fail as it and node does exist
     data_service::add_data(
         &db,
         ClientData {
-            values: vec!["0".to_owned()],
+            values: vec![0f32],
             unit: "A".to_owned(),
             run_id: 0,
             name: TEST_KEYWORD.to_owned(),
-            timestamp: 1000,
+            timestamp: chrono::DateTime::from_timestamp_millis(1000).unwrap(),
             node: "Irrelevant".to_string(),
         },
     )

--- a/scylla-server/tests/data_service_test.rs
+++ b/scylla-server/tests/data_service_test.rs
@@ -61,7 +61,7 @@ async fn test_data_add() -> Result<(), QueryError> {
     assert_eq!(
         PublicData::from(&data),
         PublicData {
-            time: 1000,
+            time_ms: 1000,
             values: vec![0f64]
         }
     );

--- a/scylla-server/tests/data_type_service_test.rs
+++ b/scylla-server/tests/data_type_service_test.rs
@@ -68,7 +68,7 @@ async fn test_datatype_create() -> Result<(), QueryError> {
         PublicDataType::from(&data),
         PublicDataType {
             name: data_type_name,
-            unit: unit
+            unit
         }
     );
 

--- a/scylla-server/tests/driver_service_test.rs
+++ b/scylla-server/tests/driver_service_test.rs
@@ -24,7 +24,9 @@ async fn test_create_driver() -> Result<(), QueryError> {
     driver_service::upsert_driver(
         &db,
         TEST_KEYWORD.to_owned(),
-        run_service::create_run(&db, 10001).await?.id,
+        run_service::create_run(&db, chrono::DateTime::from_timestamp_millis(1001).unwrap())
+            .await?
+            .id,
     )
     .await?;
 

--- a/scylla-server/tests/location_service_test.rs
+++ b/scylla-server/tests/location_service_test.rs
@@ -20,7 +20,9 @@ async fn test_get_all_locations_and_upsert() -> Result<(), QueryError> {
         100.0,
         200.0,
         300.0,
-        run_service::create_run(&db, 10001).await?.id,
+        run_service::create_run(&db, chrono::DateTime::from_timestamp_millis(1001).unwrap())
+            .await?
+            .id,
     )
     .await?;
 

--- a/scylla-server/tests/run_service_test.rs
+++ b/scylla-server/tests/run_service_test.rs
@@ -20,7 +20,8 @@ async fn test_get_run_by_id() -> Result<(), QueryError> {
     let db = cleanup_and_prepare().await?;
 
     // add a run
-    let run_c = run_service::create_run(&db, 1).await?;
+    let run_c =
+        run_service::create_run(&db, chrono::DateTime::from_timestamp_millis(1).unwrap()).await?;
 
     // get that run
     let run = run_service::get_run_by_id(&db, run_c.id)

--- a/scylla-server/tests/system_service_test.rs
+++ b/scylla-server/tests/system_service_test.rs
@@ -17,7 +17,8 @@ const TEST_KEYWORD: &str = "test";
 async fn test_upsert_system_create() -> Result<(), QueryError> {
     let db = cleanup_and_prepare().await?;
 
-    let run = run_service::create_run(&db, 101).await?;
+    let run =
+        run_service::create_run(&db, chrono::DateTime::from_timestamp_millis(101).unwrap()).await?;
 
     let _ = system_service::upsert_system(&db, TEST_KEYWORD.to_owned(), run.id).await?;
 
@@ -49,7 +50,9 @@ async fn test_get_upsert_system() -> Result<(), QueryError> {
     system_service::upsert_system(
         &db,
         TEST_KEYWORD.to_owned(),
-        run_service::create_run(&db, 101).await?.id,
+        run_service::create_run(&db, chrono::DateTime::from_timestamp_millis(101).unwrap())
+            .await?
+            .id,
     )
     .await?;
 

--- a/scylla-server/tests/system_service_test.rs
+++ b/scylla-server/tests/system_service_test.rs
@@ -59,7 +59,7 @@ async fn test_get_upsert_system() -> Result<(), QueryError> {
     let sys = system_service::get_all_systems(&db).await?;
 
     sys.iter()
-        .find(|&f| f.name == TEST_KEYWORD.to_owned())
+        .find(|&f| f.name == *TEST_KEYWORD)
         .expect("System of the added name should exist in the list of systems");
 
     Ok(())


### PR DESCRIPTION
## Changes

See title.  Was just going to just migrate serverdata and update time sourcing logic, but ran into a ton of bugs with `ClientData` using millisecond timestamps that would require refactoring every instantiation of the struct.  So I said fug it and switched the struct to store a `DateTime` so any caller can pass in precise time.  This `DateTime` is also how the prisma layer understands time.  All times utc!!

Also switched the internal data representation to f32 from string because it was really annoying me all of the mapping and parsing back and forth we do.  This can be reverted no biggie.

## Test Cases

- Works live and query when parsing Calypso accompanying PR: https://github.com/Northeastern-Electric-Racing/Calypso/pull/56
- Works live and query when falling back to system time
- [ ] Need to test falling back to MQTT time

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] All checks passing
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] No `package-lock.json` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)