### PR TITLE
#200 switch new run to static atomic

### DIFF
--- a/scylla-server/src/controllers/run_controller.rs
+++ b/scylla-server/src/controllers/run_controller.rs
@@ -5,9 +5,6 @@ use axum::{
     Json,
 };
 
-use tokio::sync::mpsc;
-use tracing::warn;
-
 use crate::{
     error::ScyllaError, services::run_service, transformers::run_transformer::PublicRun, Database,
 };

--- a/scylla-server/src/controllers/run_controller.rs
+++ b/scylla-server/src/controllers/run_controller.rs
@@ -42,6 +42,10 @@ pub async fn new_run(State(db): State<Database>) -> Result<Json<PublicRun>, Scyl
     let run_data = run_service::create_run(&db, chrono::offset::Utc::now()).await?;
 
     crate::RUN_ID.store(run_data.id, Ordering::Relaxed);
+    tracing::info!(
+        "Starting new run with ID: {}",
+        crate::RUN_ID.load(Ordering::Relaxed)
+    );
 
     Ok(Json::from(PublicRun::from(&run_data)))
 }

--- a/scylla-server/src/lib.rs
+++ b/scylla-server/src/lib.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::AtomicI32;
+
 pub mod controllers;
 pub mod error;
 pub mod processors;
@@ -23,3 +25,6 @@ pub enum RateLimitMode {
     #[default]
     None,
 }
+
+// Atomic to keep track the current run id across EVERYTHING (very scary)
+pub static RUN_ID: AtomicI32 = AtomicI32::new(-1);

--- a/scylla-server/src/main.rs
+++ b/scylla-server/src/main.rs
@@ -1,8 +1,5 @@
 use std::{
-    sync::{
-        atomic::{AtomicI32, Ordering},
-        Arc,
-    },
+    sync::{atomic::Ordering, Arc},
     time::Duration,
 };
 
@@ -14,6 +11,7 @@ use axum::{
 use clap::Parser;
 use prisma_client_rust::chrono;
 use rumqttc::v5::AsyncClient;
+use scylla_server::RUN_ID;
 use scylla_server::{
     controllers::{
         self,
@@ -28,7 +26,7 @@ use scylla_server::{
         mqtt_processor::{MqttProcessor, MqttProcessorOptions},
         ClientData,
     },
-    services::run_service::{self, public_run},
+    services::run_service::{self},
     Database, RateLimitMode,
 };
 use socketioxide::{extract::SocketRef, SocketIo};
@@ -107,8 +105,6 @@ struct ScyllaArgs {
     )]
     socketio_discard_percent: u8,
 }
-
-static RUN_ID: AtomicI32 = AtomicI32::new(-1);
 
 #[tokio::main]
 async fn main() {

--- a/scylla-server/src/processors/mqtt_processor.rs
+++ b/scylla-server/src/processors/mqtt_processor.rs
@@ -181,7 +181,6 @@ impl MqttProcessor {
                         node: "Internal".to_string(),
                         unit: "ms".to_string(),
                         run_id: crate::RUN_ID.load(Ordering::Relaxed),
-                        run_id: self.curr_run,
                         timestamp: chrono::offset::Utc::now(),
                         values: vec![avg_latency as f32]
                     };

--- a/scylla-server/src/processors/mqtt_processor.rs
+++ b/scylla-server/src/processors/mqtt_processor.rs
@@ -62,7 +62,6 @@ pub struct MqttProcessorOptions {
 impl MqttProcessor {
     /// Creates a new mqtt receiver and socketio and db sender
     /// * `channel` - The mpsc channel to send the database data to
-    /// * `new_run_id` - The changed atomic run id.
     /// * `io` - The socketio layer to send the data to
     /// * `cancel_token` - The token which indicates cancellation of the task
     /// * `opts` - The mqtt processor options to use


### PR DESCRIPTION
## Changes

Implemented a global AtomicI32 to keep track of current run number.

## Notes

Had to do a global Atomic because Atomics couldn't be passed through a post (doesn't have clone trait).

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `package-lock.json` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #200 
