### PR TITLE
Query Caching And Invalidation

### DIFF
--- a/angular-client/src/app/app-nav-bar/app-nav-bar.component.ts
+++ b/angular-client/src/app/app-nav-bar/app-nav-bar.component.ts
@@ -49,12 +49,12 @@ export class AppNavBarComponent implements OnInit {
   );
 
   onStartNewRun = () => {
-    const runsQueryResponse = this.serverService.query(() => startNewRun());
+    const runsQueryResponse = this.serverService.query(() => startNewRun(), { invalidates: ['runs'] });
     runsQueryResponse.isLoading.subscribe((isLoading: boolean) => {
       this.newRunIsLoading = isLoading;
     });
-    runsQueryResponse.error.subscribe((error: Error) => {
-      this.messageService.add({ severity: 'error', summary: 'Error', detail: error.message });
+    runsQueryResponse.error.subscribe((error) => {
+      error && this.messageService.add({ severity: 'error', summary: 'Error', detail: error.message });
     });
   };
 

--- a/angular-client/src/components/graph/graph.component.ts
+++ b/angular-client/src/components/graph/graph.component.ts
@@ -86,7 +86,7 @@ export class GraphComponent implements OnInit {
           autoScaleYaxis: true
         },
         animations: {
-          enabled: true,
+          enabled: false,
           easing: 'linear',
           dynamicAnimation: {
             speed: 1000

--- a/angular-client/src/pages/graph-page/graph-caption/run-selector/run-selector.component.ts
+++ b/angular-client/src/pages/graph-page/graph-caption/run-selector/run-selector.component.ts
@@ -21,15 +21,15 @@ export class RunSelectorComponent implements OnInit {
   @Input() selectRun: (run: Run) => void = () => {};
 
   ngOnInit() {
-    const runsQueryResponse = this.serverService.query<Run[]>(() => getAllRuns());
+    const runsQueryResponse = this.serverService.query<Run[]>(() => getAllRuns(), { queryKey: ['runs'] });
     runsQueryResponse.isLoading.subscribe((isLoading: boolean) => {
       this.runsIsLoading = isLoading;
     });
-    runsQueryResponse.error.subscribe((error: Error) => {
-      this.messageService.add({ severity: 'error', summary: 'Error', detail: error.message });
+    runsQueryResponse.error.subscribe((error) => {
+      error && this.messageService.add({ severity: 'error', summary: 'Error', detail: error.message });
     });
-    runsQueryResponse.data.subscribe((data: Run[]) => {
-      this.runs = data;
+    runsQueryResponse.data.subscribe((data) => {
+      if (data) this.runs = data;
     });
 
     this.label = 'Select Run';

--- a/angular-client/src/pages/graph-page/graph-page.component.ts
+++ b/angular-client/src/pages/graph-page/graph-page.component.ts
@@ -43,15 +43,19 @@ export default class GraphPageComponent implements OnInit {
   ngOnInit(): void {
     this.queryDataTypes();
 
-    const runsQueryResponse = this.serverService.query<Run[]>(() => getAllRuns());
+    const runsQueryResponse = this.serverService.query<Run[]>(() => getAllRuns(), { queryKey: ['runs'] });
     runsQueryResponse.isLoading.subscribe((isLoading: boolean) => {
       this.runsIsLoading = isLoading;
     });
-    runsQueryResponse.error.subscribe((error: Error) => {
-      this.toastService.add({ severity: 'error', summary: 'Error', detail: error.message });
+    runsQueryResponse.error.subscribe((error) => {
+      if (error) {
+        this.toastService.add({ severity: 'error', summary: 'Error', detail: error.message });
+      }
     });
-    runsQueryResponse.data.subscribe((data: Run[]) => {
-      this.allRuns = data;
+    runsQueryResponse.data.subscribe((data) => {
+      if (data) {
+        this.allRuns = data;
+      }
     });
 
     this.clearDataType = () => {
@@ -89,13 +93,17 @@ export default class GraphPageComponent implements OnInit {
         dataQueryResponse.isLoading.subscribe((isLoading: boolean) => {
           this.selectedDataTypeValuesIsLoading = isLoading;
         });
-        dataQueryResponse.error.subscribe((error: Error) => {
-          this.selectedDataTypeValuesError = error;
-          this.selectedDataTypeValuesIsError = true;
+        dataQueryResponse.error.subscribe((error) => {
+          if (error) {
+            this.selectedDataTypeValuesError = error;
+            this.selectedDataTypeValuesIsError = true;
+          }
         });
-        dataQueryResponse.data.subscribe((data: DataValue[]) => {
-          this.selectedDataTypeValuesSubject.next(data.map((value) => ({ x: +value.time, y: +value.values[0] })));
-          this.currentValue.next(data.pop());
+        dataQueryResponse.data.subscribe((data) => {
+          if (data) {
+            this.selectedDataTypeValuesSubject.next(data.map((value) => ({ x: +value.time, y: +value.values[0] })));
+            this.currentValue.next(data.pop());
+          }
         });
       } else {
         this.toastService.add({
@@ -136,12 +144,16 @@ export default class GraphPageComponent implements OnInit {
     dataTypesQueryResponse.isLoading.subscribe((isLoading: boolean) => {
       this.dataTypesIsLoading = isLoading;
     });
-    dataTypesQueryResponse.error.subscribe((error: Error) => {
-      this.dataTypesIsError = true;
-      this.dataTypesError = error;
+    dataTypesQueryResponse.error.subscribe((error) => {
+      if (error) {
+        this.dataTypesIsError = true;
+        this.dataTypesError = error;
+      }
     });
-    dataTypesQueryResponse.data.subscribe((data: DataType[]) => {
-      this.dataTypes = data;
+    dataTypesQueryResponse.data.subscribe((data) => {
+      if (data) {
+        this.dataTypes = data;
+      }
     });
   }
 

--- a/angular-client/src/pages/landing-page/components/date-location-display/date-location.component.ts
+++ b/angular-client/src/pages/landing-page/components/date-location-display/date-location.component.ts
@@ -30,13 +30,14 @@ export class DateLocationComponent implements OnInit {
     runsQueryResponse.isLoading.subscribe(() => {
       // TODO: possible loading spinner... but we already have a no location set message
     });
-    runsQueryResponse.error.subscribe((error: Error) => {
-      this.messageService.add({ severity: 'error', summary: 'Error', detail: error.message });
+    runsQueryResponse.error.subscribe((error) => {
+      if (error) {
+        this.messageService.add({ severity: 'error', summary: 'Error', detail: error.message });
+      }
     });
-    runsQueryResponse.data.subscribe((data: Run) => {
-      const run: Run = data;
+    runsQueryResponse.data.subscribe((data) => {
+      const run = data;
       this.location = run?.locationName || 'No Location Set';
-      console.log(run);
     });
   }
 

--- a/angular-client/src/pages/landing-page/landing-page.component.ts
+++ b/angular-client/src/pages/landing-page/landing-page.component.ts
@@ -23,12 +23,14 @@ export default class LandingPageComponent implements OnInit {
 
   ngOnInit() {
     this.onStartNewRun = () => {
-      const runsQueryResponse = this.serverService.query(() => startNewRun());
+      const runsQueryResponse = this.serverService.query(() => startNewRun(), { invalidates: ['runs'] });
       runsQueryResponse.isLoading.subscribe((isLoading: boolean) => {
         this.newRunIsLoading = isLoading;
       });
-      runsQueryResponse.error.subscribe((error: Error) => {
-        this.messageService.add({ severity: 'error', summary: 'Error', detail: error.message });
+      runsQueryResponse.error.subscribe((error) => {
+        if (error) {
+          this.messageService.add({ severity: 'error', summary: 'Error', detail: error.message });
+        }
       });
     };
 

--- a/angular-client/src/pages/map/map.component.ts
+++ b/angular-client/src/pages/map/map.component.ts
@@ -44,21 +44,25 @@ export default class MapComponent implements OnInit {
         });
       }, 100);
     } else {
-      this.isLoading = true;
       const queryResponse = this.apiService.query<DataValue[]>(() =>
         getDataByDataTypeNameAndRunId(DataTypeEnum.POINTS, run.id)
       );
       queryResponse.data.subscribe((points) => {
-        this.isLoading = false;
-        //Allow page to render before building map
-        setTimeout(() => {
-          this.map.buildMap('map');
-          this.map.addPolyline(points.map(this.map.transformDataToCoordinate));
-        }, 100);
+        if (points) {
+          //Allow page to render before building map
+          setTimeout(() => {
+            this.map.buildMap('map');
+            this.map.addPolyline(points.map(this.map.transformDataToCoordinate));
+          }, 100);
+        }
       });
       queryResponse.isLoading.subscribe((isLoading) => (this.isLoading = isLoading));
       queryResponse.isError.subscribe((isError) => (this.isError = isError));
-      queryResponse.error.subscribe((error) => (this.error = error));
+      queryResponse.error.subscribe((error) => {
+        if (error) {
+          this.error = error;
+        }
+      });
     }
   };
 }

--- a/angular-client/src/services/api.service.ts
+++ b/angular-client/src/services/api.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Subject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { QueryResponse } from 'src/utils/api.utils';
 
 /**
@@ -7,18 +7,81 @@ import { QueryResponse } from 'src/utils/api.utils';
  */
 @Injectable({ providedIn: 'root' })
 export default class APIService {
+  private cache = new Map<
+    string,
+    {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      data: BehaviorSubject<any | null>;
+      isLoading: BehaviorSubject<boolean>;
+      isError: BehaviorSubject<boolean>;
+      error: BehaviorSubject<Error | null>;
+      fetchFn: () => Promise<Response>;
+    }
+  >();
   /**
    * Function to query data from the api
    * @param apiCall The api call to make
    * @returns A query response
    */
-  public query<T>(apiCall: () => Promise<Response>): QueryResponse<T> {
-    const data = new Subject<T>();
-    const isLoading = new Subject<boolean>();
-    const isError = new Subject<boolean>();
-    const error = new Subject<Error>();
+  public query<T>(
+    apiCall: () => Promise<Response>,
+    options: { queryKey?: string[]; invalidates?: string[] } = {}
+  ): QueryResponse<T> {
+    const { queryKey, invalidates } = options;
+    let cacheKey;
+    if (queryKey) {
+      cacheKey = this.getQueryKey(queryKey);
+
+      // If cached, return existing observables
+      if (this.cache.has(cacheKey)) {
+        return this.cache.get(cacheKey)!;
+      }
+    }
+
+    // Create new reactive subjects
+    const data = new BehaviorSubject<T | null>(null);
+    const isLoading = new BehaviorSubject<boolean>(true);
+    const isError = new BehaviorSubject<boolean>(false);
+    const error = new BehaviorSubject<Error | null>(null);
+
+    // Fetch and cache data
+    this.fetchData(apiCall, data, isLoading, isError, error, invalidates);
+
+    // Store in cache
+    const queryState = { data, isLoading, isError, error, fetchFn: apiCall };
+    if (cacheKey) {
+      this.cache.set(cacheKey, queryState);
+    }
+
+    return queryState;
+  }
+
+  private invalidateQuery(queryKey: string[]): void {
+    const cacheKey = this.getQueryKey(queryKey);
+
+    if (this.cache.has(cacheKey)) {
+      const cachedQuery = this.cache.get(cacheKey)!;
+
+      cachedQuery.data.next(null);
+      cachedQuery.isLoading.next(true);
+      cachedQuery.isError.next(false);
+      cachedQuery.error.next(null);
+
+      this.fetchData(cachedQuery.fetchFn, cachedQuery.data, cachedQuery.isLoading, cachedQuery.isError, cachedQuery.error);
+    }
+  }
+
+  private fetchData<T>(
+    apiCall: () => Promise<Response>,
+    data: BehaviorSubject<T | null>,
+    isLoading: BehaviorSubject<boolean>,
+    isError: BehaviorSubject<boolean>,
+    error: BehaviorSubject<Error | null>,
+    invalidates?: string[]
+  ) {
     isLoading.next(true);
     isError.next(false);
+
     apiCall()
       .then((response) => this.handleErrors(response, error, isError))
       .then((response) => response.json() as Promise<T>)
@@ -31,13 +94,16 @@ export default class APIService {
           isError.next(true);
           error.next(err);
         }
+      })
+      .finally(() => {
+        if (invalidates) {
+          this.invalidateQuery(invalidates);
+        }
       });
-    return {
-      data,
-      isLoading,
-      isError,
-      error
-    };
+  }
+
+  private getQueryKey(queryKey: string[]): string {
+    return queryKey.join('-'); // Create a unique key
   }
 
   /**
@@ -47,7 +113,7 @@ export default class APIService {
    * @param isError boolean subject to emit whether or not an error has occurred
    * @returns The response
    */
-  private handleErrors(response: Response, error: Subject<Error>, isError: Subject<boolean>): Response {
+  private handleErrors(response: Response, error: BehaviorSubject<Error | null>, isError: Subject<boolean>): Response {
     if (!response.ok) {
       isError.next(true);
       error.next(new Error(response.statusText));

--- a/angular-client/src/utils/api.utils.ts
+++ b/angular-client/src/utils/api.utils.ts
@@ -1,4 +1,4 @@
-import { Subject } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 
 /**
  * The response from a query
@@ -8,8 +8,8 @@ import { Subject } from 'rxjs';
  * @param error The error that has occurred
  */
 export type QueryResponse<T> = {
-  isLoading: Subject<boolean>;
-  data: Subject<T>;
-  isError: Subject<boolean>;
-  error: Subject<Error>;
+  isLoading: BehaviorSubject<boolean>;
+  data: BehaviorSubject<T | null>;
+  isError: BehaviorSubject<boolean>;
+  error: BehaviorSubject<Error | null>;
 };


### PR DESCRIPTION
## Changes

Now that weve added mutation we need the ability to cache and invalidate those caches as we change values. I.e when we start a new run, we need our existing subscriptions to the run query to be updated with the new value.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `package-lock.json` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
