### PR TITLE
#325 - bms header and connection dot abstraction

### DIFF
--- a/angular-client/src/app/app-nav-bar/app-nav-bar.component.html
+++ b/angular-client/src/app/app-nav-bar/app-nav-bar.component.html
@@ -30,7 +30,14 @@
     </div>
 
     <div style="display: flex; align-items: center">
-      <toast-button [onClick]="this.onStartNewRun" label="Start New Run" additionalStyles="height: 35px" />
+      <toast-button
+        [onClick]="this.onStartNewRun"
+        buttonLabel="Start New Run"
+        popUpSeverity="success"
+        popUpTitle="New Run Started"
+        popUpDetails="Your new run has started successfully."
+        additionalStyles="height: 35px"
+      />
       <typography variant="large-header" content="{{ time$ | async | date: 'HH:mm:ss' }}" style="margin-left: 20px" />
     </div>
   </nav>

--- a/angular-client/src/app/app.module.ts
+++ b/angular-client/src/app/app.module.ts
@@ -125,6 +125,8 @@ import { providePrimeNG } from 'primeng/config';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import Lara from '@primeng/themes/aura';
 import { TreeModule } from 'primeng/tree';
+import { BmsHeaderComponent } from 'src/pages/bms-debug-page/components/bms-header/bms-header.component';
+import { ConnectionDotWithMessageComponent } from 'src/components/connection-dot-with-message/connection-dot-with-message.component';
 @NgModule({
   declarations: [
     AppContextComponent,
@@ -224,7 +226,9 @@ import { TreeModule } from 'primeng/tree';
     AccHighVoltageComponent,
     BmsOverflowComponent,
     InfoValueDisplayComponent,
-    SelectDropdownComponent
+    SelectDropdownComponent,
+    BmsHeaderComponent,
+    ConnectionDotWithMessageComponent
   ],
   bootstrap: [AppContextComponent],
   imports: [

--- a/angular-client/src/components/connection-dot-with-message/connection-dot-with-message.component.html
+++ b/angular-client/src/components/connection-dot-with-message/connection-dot-with-message.component.html
@@ -1,0 +1,14 @@
+<hstack spacing="10px" style="margin-top: 10px">
+  <div
+    class="connection-dot"
+    [style.background-color]="this.getStatusColor()()"
+    [style.border-color]="this.getStatusColor()()"
+    style="margin-top: -10px; width: 30px; height: 30px"
+  ></div>
+  <typography
+    variant="info-title"
+    [content]="this.getStatusMessage()()"
+    additionalStyles="fontSize:20px"
+    style="margin-top: -10px"
+  ></typography>
+</hstack>

--- a/angular-client/src/components/connection-dot-with-message/connection-dot-with-message.component.spec.ts
+++ b/angular-client/src/components/connection-dot-with-message/connection-dot-with-message.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ConnectionDotWithMessageComponent } from './connection-dot-with-message.component';
+
+describe('ConnectionDotWithMessageComponent', () => {
+  let component: ConnectionDotWithMessageComponent;
+  let fixture: ComponentFixture<ConnectionDotWithMessageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ConnectionDotWithMessageComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ConnectionDotWithMessageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular-client/src/components/connection-dot-with-message/connection-dot-with-message.component.ts
+++ b/angular-client/src/components/connection-dot-with-message/connection-dot-with-message.component.ts
@@ -1,0 +1,11 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'connection-dot-with-message',
+  templateUrl: './connection-dot-with-message.component.html',
+  styleUrl: './connection-dot-with-message.component.css'
+})
+export class ConnectionDotWithMessageComponent {
+  getStatusColor = input.required<() => string>();
+  getStatusMessage = input.required<() => string>();
+}

--- a/angular-client/src/components/toast-button/toast-button.component.html
+++ b/angular-client/src/components/toast-button/toast-button.component.html
@@ -1,3 +1,3 @@
 <div id="button">
-  <button type="button" class="btn" (click)="handleClick()" [style]="style">{{ label }}</button>
+  <button type="button" class="btn" (click)="handleClick()" [style]="style">{{ this.buttonLabel() }}</button>
 </div>

--- a/angular-client/src/components/toast-button/toast-button.component.ts
+++ b/angular-client/src/components/toast-button/toast-button.component.ts
@@ -1,5 +1,7 @@
-import { Component, Input, OnInit, inject } from '@angular/core';
+import { Component, OnInit, inject, input } from '@angular/core';
 import { MessageService } from 'primeng/api';
+
+export type toastSeverity = 'success' | 'info' | 'warn' | 'error';
 
 @Component({
   selector: 'toast-button',
@@ -8,26 +10,31 @@ import { MessageService } from 'primeng/api';
 })
 export class ToastButtonComponent implements OnInit {
   private messageService = inject(MessageService);
-  @Input() label!: string;
-  @Input() onClick!: () => void;
-  @Input() additionalStyles?: string;
-  style!: string;
+  buttonLabel = input.required<string>();
+  popUpSeverity = input<toastSeverity>('success');
+  popUpTitle = input<string>('Success!');
+  popUpDetails = input<string>('No Details Set');
+  disableToast = input<boolean>(false);
+
+  onClick = input.required<() => void>();
+  additionalStyles = input<string>('');
+  style = 'width: 140px; height: 45px;';
 
   ngOnInit(): void {
-    this.style = 'width: 140px; height: 45px; ';
-
-    if (this.additionalStyles) {
-      this.style += this.additionalStyles;
-    }
+    this.style += this.additionalStyles();
   }
 
   handleClick() {
-    this.onClick();
+    // the first () is to access the signal value,
+    // which is the function which we call with the second ()
+    this.onClick()();
+    // if the toast is disabled, we don't want to show it
+    if (this.disableToast()) return;
     setTimeout(() => {
       this.messageService.add({
-        severity: 'success',
-        summary: 'Success!',
-        detail: 'Your new run has started successfully.'
+        severity: this.popUpSeverity(),
+        summary: this.popUpTitle(),
+        detail: this.popUpDetails()
       });
     });
   }

--- a/angular-client/src/data-type.enum.ts
+++ b/angular-client/src/data-type.enum.ts
@@ -77,6 +77,14 @@ export enum DataTypeEnum {
   Segment_Temp_3 = 'BMS/Segment_Temp/3',
   Segment_Temp_4 = 'BMS/Segment_Temp/4',
   Segment_Temp_5 = 'BMS/Segment_Temp/5',
+
+  // Segment Voltage
+  Segment_Voltage_1 = 'BMS/Segment_Voltage/1',
+  Segment_Voltage_2 = 'BMS/Segment_Voltage/2',
+  Segment_Voltage_3 = 'BMS/Segment_Voltage/3',
+  Segment_Voltage_4 = 'BMS/Segment_Voltage/4',
+  Segment_Voltage_5 = 'BMS/Segment_Voltage/5',
+
   // BMS Per Cell
   // Alpha
   PER_CELL_ALPHA_DIE_TEMP_0 = 'BMS/PerCell/Alpha/0/DieTemp',

--- a/angular-client/src/data-type.enum.ts
+++ b/angular-client/src/data-type.enum.ts
@@ -71,6 +71,7 @@ export enum DataTypeEnum {
   INTERNAL_THERMAL_ERROR = 'BMS/Status/F/Thermal_Err',
   INTERNAL_SOFTWARE_FAULT = 'BMS/Status/F/Software',
   PACK_OVERHEAT = 'BMS/Status/F/Pack_Overheat',
+
   // BMS Debug
   Segment_Temp_1 = 'BMS/Segment_Temp/1',
   Segment_Temp_2 = 'BMS/Segment_Temp/2',
@@ -98,5 +99,9 @@ export enum DataTypeEnum {
   PER_CELL_BETA_DIE_TEMP_1 = 'BMS/PerCell/Beta/1/DieTemp',
   PER_CELL_BETA_DIE_TEMP_2 = 'BMS/PerCell/Beta/2/DieTemp',
   PER_CELL_BETA_DIE_TEMP_3 = 'BMS/PerCell/Beta/3/DieTemp',
-  PER_CELL_BETA_DIE_TEMP_4 = 'BMS/PerCell/Beta/4/DieTemp'
+  PER_CELL_BETA_DIE_TEMP_4 = 'BMS/PerCell/Beta/4/DieTemp',
+
+  // Overflow and CRC
+  PER_CELL_OVERFLOWID = 'BMS/PerCell/OverflowID',
+  PER_CELL_CRC = 'BMS/PerCell/PECErrorChip'
 }

--- a/angular-client/src/pages/bms-debug-page/bms-debug-page.component.html
+++ b/angular-client/src/pages/bms-debug-page/bms-debug-page.component.html
@@ -4,23 +4,8 @@
   } @else {
     <!-- TODO: Add components for the segment summary-->
     <mat-grid-list cols="6" gutterSize="15px" rowHeight="1.5rem" style="margin-top: -20px">
-      <mat-grid-tile [colspan]="3" rowspan="3" style="padding-left: 16px">
-        <typography
-          class="title-style"
-          variant="x-large-title"
-          [content]="windowSize > 1300 ? 'Accumulator' : 'Accumulator'"
-          additionalStyles="font-size: 6vw; letter-spacing: 0.2rem; word-spacing: 0.2rem; line-height: 0px; text-align: left; margin-top: 10px"
-        />
-      </mat-grid-tile>
-
-      <mat-grid-tile [colspan]="1" rowspan="3">
-        <segment-selector style="height: 80%; width: 100%; margin-top: 10px" />
-      </mat-grid-tile>
-      <mat-grid-tile [colspan]="1" rowspan="3">
-        <crc style="height: 80%; width: 100%; margin-top: 10px" />
-      </mat-grid-tile>
-      <mat-grid-tile [colspan]="1" rowspan="3">
-        <bms-overflow style="height: 80%; width: 100%; margin-top: 10px" />
+      <mat-grid-tile [colspan]="6" rowspan="3">
+        <bms-header style="width: 100%" />
       </mat-grid-tile>
       <mat-grid-tile [colspan]="6" rowspan="5">
         <bms-at-a-glance style="height: 100%; width: 100%" />

--- a/angular-client/src/pages/bms-debug-page/components/bms-header/bms-header.component.css
+++ b/angular-client/src/pages/bms-debug-page/components/bms-header/bms-header.component.css
@@ -1,0 +1,13 @@
+.title-style {
+  display: grid;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  grid-template-columns: [start] 1fr [end];
+  padding-left: 20px;
+}
+
+/* Add these styles to your component */
+mat-grid-tile {
+  overflow: visible !important; /* Allow dropdown to overflow */
+}

--- a/angular-client/src/pages/bms-debug-page/components/bms-header/bms-header.component.html
+++ b/angular-client/src/pages/bms-debug-page/components/bms-header/bms-header.component.html
@@ -1,0 +1,20 @@
+<mat-grid-list cols="6" gutterSize="15px" rowHeight="1.5rem">
+  <mat-grid-tile [colspan]="3" rowspan="3" style="padding-left: 16px">
+    <typography
+      class="title-style"
+      variant="x-large-title"
+      [content]="windowSize > 1300 ? 'Accumulator' : 'Accumulator'"
+      additionalStyles="font-size: 6vw; letter-spacing: 0.2rem; word-spacing: 0.2rem; line-height: 0px; text-align: left; margin-top: 10px"
+    />
+  </mat-grid-tile>
+
+  <mat-grid-tile [colspan]="1" rowspan="3">
+    <segment-selector style="height: 80%; width: 100%; margin-top: 10px" />
+  </mat-grid-tile>
+  <mat-grid-tile [colspan]="1" rowspan="3">
+    <crc style="height: 80%; width: 100%; margin-top: 10px" />
+  </mat-grid-tile>
+  <mat-grid-tile [colspan]="1" rowspan="3">
+    <bms-overflow style="height: 80%; width: 100%; margin-top: 10px" />
+  </mat-grid-tile>
+</mat-grid-list>

--- a/angular-client/src/pages/bms-debug-page/components/bms-header/bms-header.component.spec.ts
+++ b/angular-client/src/pages/bms-debug-page/components/bms-header/bms-header.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BmsHeaderComponent } from './bms-header.component';
+
+describe('BmsHeaderComponent', () => {
+  let component: BmsHeaderComponent;
+  let fixture: ComponentFixture<BmsHeaderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BmsHeaderComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(BmsHeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular-client/src/pages/bms-debug-page/components/bms-header/bms-header.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/bms-header/bms-header.component.ts
@@ -1,0 +1,34 @@
+import { Component, HostListener, OnInit } from '@angular/core';
+import { SegmentSummarys } from '../segment-summary/segment-summary.component';
+
+@Component({
+  selector: 'bms-header',
+  templateUrl: './bms-header.component.html',
+  styleUrl: './bms-header.component.css'
+})
+export class BmsHeaderComponent implements OnInit {
+  time = new Date();
+  newRunIsLoading = false;
+  mobileThreshold = 768;
+  windowSize: number = window.innerWidth;
+  isMobile = window.innerWidth < this.mobileThreshold;
+  segments = [
+    SegmentSummarys.Segment1,
+    SegmentSummarys.Segment2,
+    SegmentSummarys.Segment3,
+    SegmentSummarys.Segment4,
+    SegmentSummarys.Segment5
+  ];
+
+  constructor() {}
+
+  ngOnInit() {
+    console.log('BMS Debug Page');
+  }
+
+  @HostListener('window:resize', ['$event'])
+  onResize() {
+    this.isMobile = window.innerWidth <= this.mobileThreshold;
+    this.windowSize = window.innerWidth;
+  }
+}

--- a/angular-client/src/pages/bms-debug-page/components/bms-overflow/bms-overflow.component.html
+++ b/angular-client/src/pages/bms-debug-page/components/bms-overflow/bms-overflow.component.html
@@ -1,5 +1,9 @@
 <info-background>
-  <hstack>
+  <vstack spacing="0">
     <typography variant="header" content="Overflow" additionalStyles="fontSize:20px" style="margin-top: -20px"></typography>
-  </hstack>
+    <connection-dot-with-message
+      [getStatusColor]="getStatusColor"
+      [getStatusMessage]="getStatusMessage"
+    ></connection-dot-with-message>
+  </vstack>
 </info-background>

--- a/angular-client/src/pages/bms-debug-page/components/bms-overflow/bms-overflow.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/bms-overflow/bms-overflow.component.ts
@@ -1,8 +1,32 @@
-import { Component } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
+import { DataTypeEnum } from 'src/data-type.enum';
+import Storage from 'src/services/storage.service';
 
 @Component({
   selector: 'bms-overflow',
   templateUrl: './bms-overflow.component.html',
   styleUrl: './bms-overflow.component.css'
 })
-export class BmsOverflowComponent {}
+export class BmsOverflowComponent implements OnInit {
+  storage = inject(Storage);
+  overflowID: number | undefined = undefined;
+
+  ngOnInit(): void {
+    this.storage.get(DataTypeEnum.PER_CELL_OVERFLOWID).subscribe((value) => {
+      if (parseFloat(value.time) > Date.now() - 4000) {
+        this.overflowID = parseInt(value.values[0]);
+      } else {
+        this.overflowID = undefined;
+      }
+    });
+  }
+
+  getStatusColor = (): string => {
+    const dotColor = this.overflowID === undefined ? '#19ff30' : 'red';
+    return dotColor;
+  };
+
+  getStatusMessage = (): string => {
+    return this.overflowID === undefined ? 'Clear' : 'Warning!';
+  };
+}

--- a/angular-client/src/pages/bms-debug-page/components/crc/crc.component.html
+++ b/angular-client/src/pages/bms-debug-page/components/crc/crc.component.html
@@ -1,5 +1,9 @@
 <info-background>
   <vstack spacing="0">
     <typography variant="header" content="All CRC's" additionalStyles="fontSize:20px" style="margin-top: -20px"></typography>
+    <connection-dot-with-message
+      [getStatusColor]="this.getStatusColor"
+      [getStatusMessage]="this.getStatusMessage"
+    ></connection-dot-with-message>
   </vstack>
 </info-background>

--- a/angular-client/src/pages/bms-debug-page/components/crc/crc.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/crc/crc.component.ts
@@ -1,8 +1,32 @@
-import { Component } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
+import { DataTypeEnum } from 'src/data-type.enum';
+import Storage from 'src/services/storage.service';
 
 @Component({
   selector: 'crc',
   templateUrl: './crc.component.html',
   styleUrl: './crc.component.css'
 })
-export class CRCComponent {}
+export class CRCComponent implements OnInit {
+  storage = inject(Storage);
+  pecErrorChip: number | undefined = undefined;
+
+  ngOnInit(): void {
+    this.storage.get(DataTypeEnum.PER_CELL_CRC).subscribe((value) => {
+      if (parseFloat(value.time) > Date.now() - 4000) {
+        this.pecErrorChip = parseInt(value.values[0]);
+      } else {
+        this.pecErrorChip = undefined;
+      }
+    });
+  }
+
+  getStatusColor = (): string => {
+    const dotColor = this.pecErrorChip === undefined ? '#19ff30' : 'red';
+    return dotColor;
+  };
+
+  getStatusMessage = (): string => {
+    return this.pecErrorChip === undefined ? 'Clear' : 'Warning!';
+  };
+}

--- a/angular-client/src/pages/bms-debug-page/components/segment-summary/segment-summary.component.html
+++ b/angular-client/src/pages/bms-debug-page/components/segment-summary/segment-summary.component.html
@@ -3,13 +3,15 @@
     <info-value-display style="margin-top: 10px" containerStyle="" [value]="temperature" unit="C" subtitle="Temperature" />
 
     <divider style="width: 100px; margin-top: 15px" />
-    <info-value-display style="margin-top: -5px" [value]="31" unit="V" subtitle="Voltages" />
+    <info-value-display style="margin-top: -5px" [value]="voltage" unit="V" subtitle="Voltages" />
     <divider style="width: 100px; margin-top: 25px" />
     <info-value-display style="margin-top: -5px" containerStyle="" [value]="alphaChipTemp" unit="C" subtitle="Chip Temp" />
     <toast-button
-      label="See More ➜"
+      buttonLabel="See More ➜"
       additionalStyles="background-color: #2aaeee; color: black; border-radius: 20px"
       style="margin-top: 20px"
+      [disableToast]="true"
+      [onClick]="this.openSegmentPage"
     />
   </vstack>
 </info-background>

--- a/angular-client/src/pages/bms-debug-page/components/segment-summary/segment-summary.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/segment-summary/segment-summary.component.ts
@@ -21,13 +21,14 @@ export class SegmentSummaryComponent implements OnInit {
   temperature!: number;
   alphaChipTemp!: number;
   betaChipTemp!: number;
+  voltage!: number;
 
   ngOnInit(): void {
     this.subscribeAndUpdateTemperature();
   }
 
   subscribeAndUpdateTemperature = () => {
-    const [segmentTempKey, alphaChipTempKey, betaChipTempKey] = this.getRelevantKeys();
+    const [segmentTempKey, alphaChipTempKey, betaChipTempKey, voltageKey] = this.getRelevantKeys();
 
     this.storage.get(segmentTempKey).subscribe((value) => {
       this.temperature = parseFloat(value.values[0]);
@@ -38,40 +39,54 @@ export class SegmentSummaryComponent implements OnInit {
     this.storage.get(betaChipTempKey).subscribe((value) => {
       this.betaChipTemp = parseFloat(value.values[0]);
     });
+    this.storage.get(voltageKey).subscribe((value) => {
+      this.voltage = parseFloat(value.values[0]);
+    });
   };
 
-  getRelevantKeys = (): [DataTypeEnum, DataTypeEnum, DataTypeEnum] => {
+  openSegmentPage = () => {
+    // Open the segment page with the segment number
+    console.log('TODO: Opening segment page for segment: ', this.segmentNumber());
+  };
+
+  getRelevantKeys = (): [DataTypeEnum, DataTypeEnum, DataTypeEnum, DataTypeEnum] => {
     let segmentTempKey!: DataTypeEnum;
     let alphaChipTempKey!: DataTypeEnum;
     let betaChipTempKey!: DataTypeEnum;
+    let voltageKey!: DataTypeEnum;
 
     switch (this.segmentNumber()) {
       case SegmentSummarys.Segment1:
         segmentTempKey = DataTypeEnum.Segment_Temp_1;
         alphaChipTempKey = DataTypeEnum.PER_CELL_ALPHA_DIE_TEMP_0;
         betaChipTempKey = DataTypeEnum.PER_CELL_BETA_DIE_TEMP_0;
+        voltageKey = DataTypeEnum.Segment_Voltage_1;
         break;
       case SegmentSummarys.Segment2:
         segmentTempKey = DataTypeEnum.Segment_Temp_2;
         alphaChipTempKey = DataTypeEnum.PER_CELL_ALPHA_DIE_TEMP_1;
         betaChipTempKey = DataTypeEnum.PER_CELL_BETA_DIE_TEMP_1;
+        voltageKey = DataTypeEnum.Segment_Voltage_2;
         break;
       case SegmentSummarys.Segment3:
         segmentTempKey = DataTypeEnum.Segment_Temp_3;
         alphaChipTempKey = DataTypeEnum.PER_CELL_ALPHA_DIE_TEMP_2;
         betaChipTempKey = DataTypeEnum.PER_CELL_BETA_DIE_TEMP_2;
+        voltageKey = DataTypeEnum.Segment_Voltage_3;
         break;
       case SegmentSummarys.Segment4:
         segmentTempKey = DataTypeEnum.Segment_Temp_4;
         alphaChipTempKey = DataTypeEnum.PER_CELL_ALPHA_DIE_TEMP_3;
         betaChipTempKey = DataTypeEnum.PER_CELL_BETA_DIE_TEMP_3;
+        voltageKey = DataTypeEnum.Segment_Voltage_4;
         break;
       case SegmentSummarys.Segment5:
         segmentTempKey = DataTypeEnum.Segment_Temp_5;
         alphaChipTempKey = DataTypeEnum.PER_CELL_ALPHA_DIE_TEMP_4;
         betaChipTempKey = DataTypeEnum.PER_CELL_BETA_DIE_TEMP_4;
+        voltageKey = DataTypeEnum.Segment_Voltage_5;
         break;
     }
-    return [segmentTempKey, alphaChipTempKey, betaChipTempKey];
+    return [segmentTempKey, alphaChipTempKey, betaChipTempKey, voltageKey];
   };
 }

--- a/angular-client/src/pages/charging-page/components/active-status/active-status.component.css
+++ b/angular-client/src/pages/charging-page/components/active-status/active-status.component.css
@@ -1,7 +1,0 @@
-.connection-dot {
-  background-color: #2c2c2c;
-  border: 3px solid;
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-}

--- a/angular-client/src/pages/charging-page/components/balancing-status/balancing-status.component.css
+++ b/angular-client/src/pages/charging-page/components/balancing-status/balancing-status.component.css
@@ -1,7 +1,1 @@
-.connection-dot {
-  background-color: #2c2c2c;
-  border: 3px solid;
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-}
+

--- a/angular-client/src/pages/charging-page/components/cell-temp/cell-temp-display/cell-temp-display.component.css
+++ b/angular-client/src/pages/charging-page/components/cell-temp/cell-temp-display/cell-temp-display.component.css
@@ -1,6 +1,0 @@
-.connection-dot {
-  width: 50px;
-  height: 50px;
-  border-radius: 50%;
-  margin-top: 20px;
-}

--- a/angular-client/src/pages/charging-page/components/cell-temp/cell-temp-display/cell-temp-mobile/cell-temp-mobile.component.css
+++ b/angular-client/src/pages/charging-page/components/cell-temp/cell-temp-display/cell-temp-mobile/cell-temp-mobile.component.css
@@ -1,6 +1,0 @@
-.connection-dot {
-  width: 50px;
-  height: 50px;
-  border-radius: 50%;
-  margin-top: 20px;
-}

--- a/angular-client/src/pages/charging-page/components/charging-state/charging-status.component.css
+++ b/angular-client/src/pages/charging-page/components/charging-state/charging-status.component.css
@@ -1,11 +1,3 @@
-.connection-dot {
-  background-color: #2c2c2c;
-  border: 3px solid;
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-}
-
 .typography-centered {
   display: flex;
   align-items: center;

--- a/angular-client/src/pages/charging-page/components/combined-status-display/combined-status-display.component.css
+++ b/angular-client/src/pages/charging-page/components/combined-status-display/combined-status-display.component.css
@@ -1,7 +1,0 @@
-.connection-dot {
-  background-color: #2c2c2c;
-  border: 3px solid;
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-}

--- a/angular-client/src/pages/charging-page/components/combined-status-display/mobile-view/combined-status-mobile.component.css
+++ b/angular-client/src/pages/charging-page/components/combined-status-display/mobile-view/combined-status-mobile.component.css
@@ -1,7 +1,0 @@
-.connection-dot {
-  background-color: #2c2c2c;
-  border: 3px solid;
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-}

--- a/angular-client/src/pages/charging-page/components/faulted-status/faulted-status.component.css
+++ b/angular-client/src/pages/charging-page/components/faulted-status/faulted-status.component.css
@@ -1,7 +1,0 @@
-.connection-dot {
-  background-color: #2c2c2c;
-  border: 3px solid;
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-}

--- a/angular-client/src/pages/charging-page/components/high-low-cell/high-low-cell-display/high-low-cell-display.component.css
+++ b/angular-client/src/pages/charging-page/components/high-low-cell/high-low-cell-display/high-low-cell-display.component.css
@@ -1,6 +1,0 @@
-.connection-dot {
-  width: 50px;
-  height: 50px;
-  border-radius: 50%;
-  margin-top: 20px;
-}

--- a/angular-client/src/pages/charging-page/components/high-low-cell/high-low-cell-display/high-low-cell-mobile/high-low-cell-mobile.component.css
+++ b/angular-client/src/pages/charging-page/components/high-low-cell/high-low-cell-display/high-low-cell-mobile/high-low-cell-mobile.component.css
@@ -1,6 +1,0 @@
-.connection-dot {
-  width: 50px;
-  height: 50px;
-  border-radius: 50%;
-  margin-top: 20px;
-}

--- a/angular-client/src/pages/landing-page/components/connection-display/connection-display.component.css
+++ b/angular-client/src/pages/landing-page/components/connection-display/connection-display.component.css
@@ -10,12 +10,3 @@
   display: flex;
   justify-content: center;
 }
-
-.connection-dot {
-  display: flex;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  margin-right: 5px;
-}

--- a/angular-client/src/styles.css
+++ b/angular-client/src/styles.css
@@ -25,6 +25,14 @@ body {
   --mdc-dialog-container-color: transparent !important;
 }
 
+.connection-dot {
+  background-color: transparent;
+  border: 3px solid;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+}
+
 .p-dialog-title {
   --p-dialog-title-font-weight: bold;
 }

--- a/compose/compose.calypso.yml
+++ b/compose/compose.calypso.yml
@@ -1,7 +1,7 @@
 services:
     calypso:
         container_name: calypso
-        image: calypso
+        image: ghcr.io/northeastern-electric-racing/calypso:develop
         restart: unless-stopped
         environment:
           # in prod mode

--- a/compose/compose.calypso.yml
+++ b/compose/compose.calypso.yml
@@ -1,7 +1,7 @@
 services:
     calypso:
         container_name: calypso
-        image: ghcr.io/northeastern-electric-racing/calypso:develop
+        image: calypso
         restart: unless-stopped
         environment:
           # in prod mode


### PR DESCRIPTION
## Changes

Abstracted the header component, adding support for overflow and crc correction. Abstracted css for connection dot.

## Notes

#338 is compared against for now so you can see actual diff. That should also be merged first.

Currently we will display the crc and overflow if we get the values for either relevant topics then we will display a warning!.  
Also currently the abstraction is sub-optimal because it relies on repeating styles for mat-grid-list (matching the parent component).

## Test Cases

N/A

## Screenshots

Just the header:
<img width="1439" alt="Screenshot 2025-03-16 at 11 25 16 PM" src="https://github.com/user-attachments/assets/c8e9d0cc-8911-4f81-b3a8-abdfd2bd16ec" />

Whole Page:
<img width="1437" alt="Screenshot 2025-03-16 at 11 26 48 PM" src="https://github.com/user-attachments/assets/6ed801dc-c0c0-42d3-9435-1ffd234b415c" />



## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #325 
