### PR TITLE
Reversing heat-map, 3 digit precision for voltages on cell view

### DIFF
--- a/angular-client/src/components/info-value-dispaly/info-value-display.component.html
+++ b/angular-client/src/components/info-value-dispaly/info-value-display.component.html
@@ -1,10 +1,15 @@
 <vstack spacing="0px" [style]="containerStyle()">
   <hstack spacing="5px" [style]="valueUnitContainerStyle()">
     @if (this.boolValue() !== undefined) {
-      <typography variant="info-value" [content]="this.boolValue() ? 'YES' : 'NO'" />
+      <typography variant="info-value" [content]="this.boolValue() ? 'YES' : 'NO'" [additionalStyles]="this.valueStyle()" />
       <typography variant="info-unit" [content]="this.unit()" />
     } @else {
-      <typography variant="info-value" [content]="this.formattedValue" style="margin-bottom: -10px" />
+      <typography
+        variant="info-value"
+        [content]="this.formattedValue"
+        style="margin-bottom: -10px"
+        [additionalStyles]="this.valueStyle()"
+      />
       <typography variant="info-unit" [content]="this.unit()" />
     }
 

--- a/angular-client/src/components/info-value-dispaly/info-value-display.component.ts
+++ b/angular-client/src/components/info-value-dispaly/info-value-display.component.ts
@@ -34,6 +34,7 @@ export class InfoValueDisplayComponent implements OnInit, OnChanges {
   containerStyle = input<string>('');
   valueUnitContainerStyle = input<string>('');
   value = input<number>();
+  valueStyle = input<string>('');
   boolValue = input<boolean>();
   precision = input<number>(1);
   subtitle = input<string>('');

--- a/angular-client/src/pages/bms-debug-page/components/cell-by-cell-heat-map/cell-by-cell-heat-map.component.html
+++ b/angular-client/src/pages/bms-debug-page/components/cell-by-cell-heat-map/cell-by-cell-heat-map.component.html
@@ -19,7 +19,7 @@
     </hstack>
     <div style="padding-top: 20px"></div>
     <hstack alignItems="end" justifyContent="end" spacing="1vw">
-      @for (cell of alphaCells.slice().reverse(); track cell) {
+      @for (cell of alphaCells; track cell) {
         <cell-tile
           [value]="cell.temp"
           [color]="this.getTempColor(cell.temp)"
@@ -43,7 +43,7 @@
     </hstack>
     <div style="padding-top: 20px"></div>
     <hstack alignItems="end" justifyContent="end" spacing="1vw">
-      @for (cell of alphaCells.slice().reverse(); track cell) {
+      @for (cell of alphaCells; track cell) {
         <cell-tile
           [value]="this.averageVoltCellPair(cell)"
           [color]="this.getVoltColor(this.averageVoltCellPair(cell))"

--- a/angular-client/src/pages/bms-debug-page/components/cell-by-cell-heat-map/cell-by-cell-heat-map.component.html
+++ b/angular-client/src/pages/bms-debug-page/components/cell-by-cell-heat-map/cell-by-cell-heat-map.component.html
@@ -7,7 +7,7 @@
   <div style="padding-top: 20px"></div>
   @if (this.view.toString() === 'Temperature') {
     <hstack alignItems="end" justifyContent="end" spacing="1vw">
-      @for (cell of betaCells; track cell) {
+      @for (cell of betaCells.slice().reverse(); track cell) {
         <cell-tile
           [value]="cell.temp"
           [color]="this.getTempColor(cell.temp)"
@@ -19,7 +19,7 @@
     </hstack>
     <div style="padding-top: 20px"></div>
     <hstack alignItems="end" justifyContent="end" spacing="1vw">
-      @for (cell of alphaCells; track cell) {
+      @for (cell of alphaCells.slice().reverse(); track cell) {
         <cell-tile
           [value]="cell.temp"
           [color]="this.getTempColor(cell.temp)"
@@ -31,7 +31,7 @@
     </hstack>
   } @else if (this.view.toString() === 'Voltage') {
     <hstack alignItems="end" justifyContent="end" spacing="1vw">
-      @for (cell of betaCells; track cell) {
+      @for (cell of betaCells.slice().reverse(); track cell) {
         <cell-tile
           [value]="this.averageVoltCellPair(cell)"
           [color]="this.getVoltColor(this.averageVoltCellPair(cell))"
@@ -43,7 +43,7 @@
     </hstack>
     <div style="padding-top: 20px"></div>
     <hstack alignItems="end" justifyContent="end" spacing="1vw">
-      @for (cell of alphaCells; track cell) {
+      @for (cell of alphaCells.slice().reverse(); track cell) {
         <cell-tile
           [value]="this.averageVoltCellPair(cell)"
           [color]="this.getVoltColor(this.averageVoltCellPair(cell))"

--- a/angular-client/src/pages/bms-debug-page/components/cell-by-cell-heat-map/cell-by-cell-heat-map.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/cell-by-cell-heat-map/cell-by-cell-heat-map.component.ts
@@ -1,4 +1,4 @@
-import { Component, effect, inject, input } from '@angular/core';
+import { Component, effect, inject, input, OnInit } from '@angular/core';
 import { Segment } from 'src/utils/bms.utils';
 import { Subscription } from 'rxjs';
 import { HeatMapService, HeatMapView } from 'src/services/heat-map.service';
@@ -10,7 +10,7 @@ import { DropdownOption, SelectorConfig } from 'src/components/select-dropdown/s
   templateUrl: './cell-by-cell-heat-map.component.html',
   styleUrl: './cell-by-cell-heat-map.component.css'
 })
-export class CellByCellHeatMapComponent {
+export class CellByCellHeatMapComponent implements OnInit {
   private cellService = inject(CellService);
   private heatMapService = inject(HeatMapService);
   currentSegment = input.required<Segment>();
@@ -48,6 +48,10 @@ export class CellByCellHeatMapComponent {
     });
   }
 
+  ngOnInit(): void {
+    this.alphaCells = this.cellService.getAlphaCellsBySegment(this.currentSegment());
+    this.betaCells = this.cellService.getBetaCellsBySegment(this.currentSegment());
+  }
   getTempColor = (value: number | undefined) => {
     if (value === undefined) {
       return 'grey';

--- a/angular-client/src/pages/bms-debug-page/components/cell-view/cell-view.component.html
+++ b/angular-client/src/pages/bms-debug-page/components/cell-view/cell-view.component.html
@@ -3,12 +3,15 @@
     <hstack style="margin-top: -2vh" spacing="5vw">
       <info-value-display
         [value]="this.cellViewData?.cellNumbers?.[0]"
+        valueStyle="fontSize: 30px;"
         [subtitle]="this.getCellNumTitle()"
         [precision]="0"
         style="padding-top: 25px"
       ></info-value-display>
       <info-value-display
         [value]="this.cellViewData?.volt1"
+        [precision]="3"
+        valueStyle="fontSize: 30px;"
         unit="V"
         [subtitle]="this.getCellVoltageTitle()"
         style="margin-top: 0.8vh"
@@ -16,6 +19,7 @@
       <info-value-display
         [boolValue]="this.cellViewData?.balancing1"
         [subtitle]="this.getBalancingTitle()"
+        valueStyle="fontSize: 30px;"
         style="padding-top: 25px"
       ></info-value-display>
     </hstack>
@@ -23,18 +27,22 @@
     <hstack spacing="20px" spacing="5vw" style="margin-top: -1vh">
       <info-value-display
         [value]="this.cellViewData?.cellNumbers?.[1]"
+        valueStyle="fontSize: 30px;"
         [subtitle]="this.getCellNumTitle()"
         style="padding-top: 25px"
         [precision]="0"
       ></info-value-display>
       <info-value-display
         [value]="this.cellViewData?.volt2"
+        valueStyle="fontSize: 30px;"
         unit="V"
         [subtitle]="this.getCellVoltageTitle()"
         style="margin-top: 0.5vh"
+        [precision]="3"
       ></info-value-display>
       <info-value-display
         [boolValue]="this.cellViewData?.balancing2"
+        valueStyle="fontSize: 30px;"
         [subtitle]="this.getBalancingTitle()"
         style="padding-top: 25px"
       ></info-value-display>


### PR DESCRIPTION
## Changes

reversed cells in heat map.... pipes, and other methods of reversing other then in the template was a little messy, performance isn't seemingly affected. Also added 3-digit precision for voltages on cell-view, decreasing size of values in that cell-view.


## Notes

The way effect is used may not be optimal (but that already exists and we can look at another time)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `package-lock.json` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
