### PR TITLE
Remove parsing of MQTT header time

### DIFF
--- a/scylla-server/src/mqtt_processor.rs
+++ b/scylla-server/src/mqtt_processor.rs
@@ -210,18 +210,16 @@ impl MqttProcessor {
         // levels of time priority
         // - A: The time packaged in the protobuf, to microsecond precision
         // - B: The local scylla system time
-        // note protobuf defaults to 0 for unfilled time, so consider it as an unset time
-        let unix_time = if data.time_us > 0 {
-            // A
-            let Some(unix_time) = chrono::DateTime::from_timestamp_micros(data.time_us as i64)
-            else {
-                warn!(
-                    "Corrupted time in protobuf: {}, discarding message!",
-                    data.time_us
-                );
-                return (false, None);
-            };
-            unix_time
+
+        // note protobuf defaults to 0 for unfilled time
+
+        // A
+        let Some(unix_time) = chrono::DateTime::from_timestamp_micros(data.time_us as i64) else {
+            warn!(
+                "Corrupted time in protobuf: {}, discarding message!",
+                data.time_us
+            );
+            return (false, None);
         };
 
         // ts check for bad sources of time which may return 1970
@@ -229,7 +227,7 @@ impl MqttProcessor {
         let unix_clean =
             if unix_time < chrono::DateTime::from_timestamp_millis(963014966000).unwrap() {
                 debug!("Timestamp before year 2000: {}", unix_time.to_string());
-                // C
+                // B
                 let sys_time = chrono::offset::Utc::now();
                 if sys_time < chrono::DateTime::from_timestamp_millis(963014966000).unwrap() {
                     warn!("System has no good time, discarding message!");

--- a/scylla-server/src/mqtt_processor.rs
+++ b/scylla-server/src/mqtt_processor.rs
@@ -209,8 +209,7 @@ impl MqttProcessor {
         // extract the unix time
         // levels of time priority
         // - A: The time packaged in the protobuf, to microsecond precision
-        // - B: The time packaged in the MQTT header, to millisecond precision (hence the * 1000 on B)
-        // - C: The local scylla system time
+        // - B: The local scylla system time
         // note protobuf defaults to 0 for unfilled time, so consider it as an unset time
         let unix_time = if data.time_us > 0 {
             // A
@@ -223,31 +222,6 @@ impl MqttProcessor {
                 return (false, None);
             };
             unix_time
-        } else {
-            // B
-            match match msg
-                .properties
-                .unwrap_or_default()
-                .user_properties
-                .iter()
-                .find(|f| f.0 == "ts")
-            {
-                Some(val) => {
-                    let Ok(time_parsed) = val.1.parse::<i64>() else {
-                        warn!("Corrupted time in mqtt header, discarding message!");
-                        return (false, None);
-                    };
-                    chrono::DateTime::from_timestamp_millis(time_parsed)
-                }
-                None => None,
-            } {
-                Some(e) => e,
-                None => {
-                    // C
-                    debug!("Could not extract time, using system time!");
-                    chrono::offset::Utc::now()
-                }
-            }
         };
 
         // ts check for bad sources of time which may return 1970
@@ -255,6 +229,7 @@ impl MqttProcessor {
         let unix_clean =
             if unix_time < chrono::DateTime::from_timestamp_millis(963014966000).unwrap() {
                 debug!("Timestamp before year 2000: {}", unix_time.to_string());
+                // C
                 let sys_time = chrono::offset::Utc::now();
                 if sys_time < chrono::DateTime::from_timestamp_millis(963014966000).unwrap() {
                     warn!("System has no good time, discarding message!");


### PR DESCRIPTION
## Changes

_Explanation of changes goes here_

When I was a wee lad I created the MQTT header injection of system time via a C plugin in Mosquitto and nanoMQ.  That sucked in a few ways:
- C gettimeofday is horribly inefficient
- It was being stored in ASCII, taking up a shitload of space
- It required hundreds of lines of build support code on Odysseus

With the addition of the new protobuf spec for serverdata and the time_us field, that other method was deprecated.  this PR removes it completely as Odysseus is removing the support from Mosquitto rn.  This should be tested just in case some sources of data were falling back to this time.  If a failure occurs the code should warn about no good source of time.

## Notes

_Any other notes go here_

## Test Cases

- Case A
- Edge case
- ...

## Screenshots

_If you made UI changes you must post a screenshot of the whole page for each change in 1) a normal sized window and 2) the smallest possible window_

_If you did any manual testing (e.g., with Postman), put screenshots of the http request and before and after of the db_

_If none of this applies, you can delete this section_

## To Do

_Any remaining things that need to get done_

- [ ] item 1
- [ ] ...

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `package-lock.json` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
