### PR TITLE
#431 Fixed Starting Values for Charging Timers  

### DIFF
--- a/compose/compose.scylla-dev.yml
+++ b/compose/compose.scylla-dev.yml
@@ -1,19 +1,25 @@
- services:    
-    scylla-server: # do not run scylla
-        entrypoint: ["echo", "DISABLED"]
-        restart: "no"
-        
+services:
+  scylla-server: # do not run scylla
+    entrypoint: ["echo", "DISABLED"]
+    restart: "no"
 
-    client:
-      extends:
-        file: ../angular-client/compose.client.yml
-        service: client
-      build:
-        context: ../angular-client
-      environment:
-        BACKEND_URL: http://192.168.100.11:8000
+  client:
+    extends:
+      file: ../angular-client/compose.client.yml
+      service: client
+    build:
+      context: ../angular-client
+    environment:
+      BACKEND_URL: http://127.0.0.1:8000
 
-    siren:
-        extends:
-            file: ../siren-base/compose.siren.yml
-            service: siren
+  siren:
+    extends:
+      file: ../siren-base/compose.siren.yml
+      service: siren
+
+  calypso:
+    extends:
+      file: ./compose.calypso.yml
+      service: calypso
+    depends_on:
+      - siren

--- a/scylla-server/src/socket_handler.rs
+++ b/scylla-server/src/socket_handler.rs
@@ -66,8 +66,8 @@ pub async fn socket_handler_with_metadata(
             item.to_string(),
             TimerData {
                 topic: item,
-                last_change: DateTime::UNIX_EPOCH,
-                last_value: 0.0f32,
+                last_change: chrono::offset::Utc::now(), // ensure that UTC offset is now 
+                last_value: -0.0f32, // create a value that isn't possibly in the range of statuses
                 total_time_per_value_map: FxHashMap::default(),
             },
         );

--- a/scylla-server/src/socket_handler.rs
+++ b/scylla-server/src/socket_handler.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 use regex::Regex;
 use ringbuffer::{AllocRingBuffer, RingBuffer};
 use rustc_hash::FxHashMap;
@@ -66,7 +66,7 @@ pub async fn socket_handler_with_metadata(
             item.to_string(),
             TimerData {
                 topic: item,
-                last_change: chrono::offset::Utc::now(), // ensure that UTC offset is now 
+                last_change: chrono::offset::Utc::now(), // ensure that UTC offset is now
                 last_value: -0.0f32, // create a value that isn't possibly in the range of statuses
                 total_time_per_value_map: FxHashMap::default(),
             },


### PR DESCRIPTION
## Changes

The timer values would error when the car was already charging on start, because the starting values were either not changed (because the starting value was zero, just like the initialized value), or/and the starting time was 0 and was never updated because of that.

TLDR: fixes charging timers when not on constantly changing mock data

## Notes

Also added mock data to scylla-dev and formatted with prettier.

The time starting at "now" may not be needed. Since the first value for the timer will always be different and should always change the time. Will figure out after testing next time the car charges.

NEEDS TOO BE TESTED NEXT TIME THE CAR IS BEING CHARGED. (going to build scylla latest of this branch.)

 

## Test Cases

TBD, needs to work when car is charging and scylla is turned on after 

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] No `package-lock.json` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #431 
