### PR TITLE
#463 - added topic url's to graph page

### DIFF
--- a/angular-client/src/pages/graph-page/graph-page.component.ts
+++ b/angular-client/src/pages/graph-page/graph-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit, inject } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { MessageService } from 'primeng/api';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { getDataByDatatTypeNameAndTiming, getDataByDataTypeNameAndRunId } from 'src/api/data.api';
@@ -51,6 +51,7 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
   private faultService = inject(FaultService);
   private topicSelectionService = inject(TopicSelectionService);
   private router = inject(Router); // for fault page navigation
+  private route = inject(ActivatedRoute);
 
   // keep track of the subscriptions, that way we cancel all subs anywhere anytime
   subscriptions: Subscription[] = [];
@@ -182,6 +183,14 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
         if (dataTypes.length > 0 || this.selectedDataTypes.length > 0) {
           this.processDataTypeSelection(dataTypes);
         }
+        this.updateUrl(dataTypes);
+      })
+    );
+
+    // Subscribe to URL changes to sync back to service
+    this.persistentSubscriptions.push(
+      this.route.queryParamMap.subscribe((params) => {
+        this.syncUrlToService(params);
       })
     );
 
@@ -332,9 +341,34 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
       dataTypesQueryResponse.data.subscribe((data) => {
         if (data) {
           this.dataTypes = data;
+          // Once the datatypes are actually loaded, sync to url
+          this.syncUrlToService(this.route.snapshot.queryParamMap);
+          this.updateUrl(this.topicSelectionService.getSelectedDataTypes().value);
         }
       })
     );
+  }
+
+  private syncUrlToService(params: ParamMap) {
+    if (this.dataTypes.length === 0) return;
+
+    const topicNames = new Set(params.get('topics')?.split(',') ?? []);
+    const topics = this.dataTypes.filter((dt) => topicNames.has(dt.name));
+
+    this.topicSelectionService.setSelectedDataTypes(topics);
+  }
+
+  private updateUrl(selectedDataTypes: DataType[]) {
+    if (this.dataTypes.length === 0) return;
+
+    const topics = selectedDataTypes.map((dt) => dt.name).join(',') || null;
+
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { topics },
+      queryParamsHandling: 'merge',
+      replaceUrl: true
+    });
   }
 
   private processRealTimeDataTypeSelection = (dataTypes: DataType[]) => {

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar.component.ts
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar.component.ts
@@ -25,7 +25,7 @@ export default class GraphSidebarComponent implements OnInit {
     this.isMobile = window.innerWidth <= this.mobileThreshold;
   }
 
-  @HostListener('window:resize', ['$event'])
+  @HostListener('window:resize')
   onResize() {
     this.isMobile = window.innerWidth <= this.mobileThreshold;
   }

--- a/compose/compose.calypso.yml
+++ b/compose/compose.calypso.yml
@@ -1,11 +1,11 @@
 services:
-    calypso:
-        container_name: calypso
-        image: ghcr.io/northeastern-electric-racing/calypso:m1calypso
-        restart: unless-stopped
-        environment:
-          # in prod mode
-          #- CALYPSO_CAN_ENCODE=false
-          #- CALYPSO_SOCKETCAN_IFACE=vcan0
-          # in sim or prod mode
-          - CALYPSO_SIREN_HOST_URL=siren:1883
+  calypso:
+    container_name: calypso
+    image: ghcr.io/northeastern-electric-racing/calypso:Develop
+    restart: unless-stopped
+    environment:
+      # in prod mode
+      #- CALYPSO_CAN_ENCODE=false
+      #- CALYPSO_SOCKETCAN_IFACE=vcan0
+      # in sim or prod mode
+      - CALYPSO_SIREN_HOST_URL=siren:1883


### PR DESCRIPTION
## Changes

Added syncing topic selection to url param on graph screen, to allow for sharing of current viewed topic via url to others.

## Notes

Had to add a little bit weird of a line to make sure that syncing still happened on initial load as we have to wait for available topics to load first.

## Test Cases

- Topic selection still works
- Topic de-selection still works
- On page reload topics are loaded correctly.
- URL is synced with topic selection

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #463 
