### PR TITLE
#502 Get all rules endpoints

### DIFF
--- a/scylla-server/src/controllers/rule_controller.rs
+++ b/scylla-server/src/controllers/rule_controller.rs
@@ -51,3 +51,11 @@ pub async fn delete_rule(
         Err(err) => Err(ScyllaError::RuleError(err)),
     }
 }
+
+#[debug_handler]
+pub async fn get_all_rules(
+    Extension(rules_manager): Extension<Arc<RuleManager>>,
+) -> Json<Vec<Rule>> {
+    debug!("Fetching all rules");
+    Json(rules_manager.get_all_rules().await)
+}

--- a/scylla-server/src/controllers/rule_controller.rs
+++ b/scylla-server/src/controllers/rule_controller.rs
@@ -53,17 +53,19 @@ pub async fn delete_rule(
 }
 
 #[debug_handler]
-pub async fn get_all_rules(
-    Path(requesting_client_id): Path<String>,
+pub async fn get_all_server_rules(
     Extension(rules_manager): Extension<Arc<RuleManager>>,
-) -> Json<RulesResponse> {
-    debug!("Fetching all rules for client: {}", requesting_client_id);
-    
-    let client_id = if requesting_client_id.is_empty() {
-        None
-    } else {
-        Some(ClientId(requesting_client_id))
-    };
-    
-    Json(rules_manager.get_all_rules_with_subscription_status(client_id).await)
+) -> Json<Vec<Rule>> {
+    debug!("Fetching all rules");
+    Json(rules_manager.get_all_rules().await)
+}
+
+
+#[debug_handler]
+pub async fn get_all_rules(
+    Path(client_id): Path<String>,
+    Extension(rules_manager): Extension<Arc<RuleManager>>,
+) -> Result<Json<RulesResponse>, ScyllaError>{
+    debug!("Fetching all rules");
+    Ok(Json(rules_manager.get_all_rules_with_subscription_status(ClientId(client_id)).await))
 }

--- a/scylla-server/src/controllers/rule_controller.rs
+++ b/scylla-server/src/controllers/rule_controller.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 
 use crate::{
     error::ScyllaError,
-    rule_structs::{ClientId, Rule, RuleId, RuleManager},
+    rule_structs::{ClientId, Rule, RuleId, RuleManager, RulesResponse},
 };
 
 #[debug_handler]
@@ -54,8 +54,16 @@ pub async fn delete_rule(
 
 #[debug_handler]
 pub async fn get_all_rules(
+    Path(requesting_client_id): Path<String>,
     Extension(rules_manager): Extension<Arc<RuleManager>>,
-) -> Json<Vec<Rule>> {
-    debug!("Fetching all rules");
-    Json(rules_manager.get_all_rules().await)
+) -> Json<RulesResponse> {
+    debug!("Fetching all rules for client: {}", requesting_client_id);
+    
+    let client_id = if requesting_client_id.is_empty() {
+        None
+    } else {
+        Some(ClientId(requesting_client_id))
+    };
+    
+    Json(rules_manager.get_all_rules_with_subscription_status(client_id).await)
 }

--- a/scylla-server/src/controllers/rule_controller.rs
+++ b/scylla-server/src/controllers/rule_controller.rs
@@ -53,19 +53,22 @@ pub async fn delete_rule(
 }
 
 #[debug_handler]
-pub async fn get_all_server_rules(
+pub async fn get_all_rules(
     Extension(rules_manager): Extension<Arc<RuleManager>>,
 ) -> Json<Vec<Rule>> {
     debug!("Fetching all rules");
     Json(rules_manager.get_all_rules().await)
 }
 
-
 #[debug_handler]
-pub async fn get_all_rules(
+pub async fn get_all_rules_with_client_info(
     Path(client_id): Path<String>,
     Extension(rules_manager): Extension<Arc<RuleManager>>,
-) -> Result<Json<RulesResponse>, ScyllaError>{
+) -> Result<Json<RulesResponse>, ScyllaError> {
     debug!("Fetching all rules");
-    Ok(Json(rules_manager.get_all_rules_with_subscription_status(ClientId(client_id)).await))
+    Ok(Json(
+        rules_manager
+            .get_all_rules_with_subscription_status(ClientId(client_id))
+            .await,
+    ))
 }

--- a/scylla-server/src/main.rs
+++ b/scylla-server/src/main.rs
@@ -25,7 +25,7 @@ use scylla_server::{
         self,
         car_command_controller::{self},
         data_type_controller, file_insertion_controller,
-        rule_controller::{add_rule, delete_rule, get_all_rules, get_all_server_rules},
+        rule_controller::{add_rule, delete_rule, get_all_rules, get_all_rules_with_client_info},
         run_controller, scylla_config_controller,
         video_streamer_controller::{self},
         OutputDirectory, VideoSuffix,
@@ -406,8 +406,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Router::new()
                 .route("/rules/add", put(add_rule))
                 .route("/rules/delete/{rule_id}", post(delete_rule))
-                .route("/rules", get(get_all_server_rules))
-                .route("/rules/{client_id}", get(get_all_rules))
+                .route("/rules", get(get_all_rules))
+                .route("/rules/{client_id}", get(get_all_rules_with_client_info))
                 //.route("/rules/delete/{rule_id}", post()).route("/rules/poll")
                 .layer(Extension(rules_manager)),
         )

--- a/scylla-server/src/main.rs
+++ b/scylla-server/src/main.rs
@@ -406,7 +406,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Router::new()
                 .route("/rules/add", put(add_rule))
                 .route("/rules/delete/{rule_id}", post(delete_rule))
-                .route("/rules", get(get_all_rules))
+                .route("/rules/{requesting_client_id}", get(get_all_rules))
                 //.route("/rules/delete/{rule_id}", post()).route("/rules/poll")
                 .layer(Extension(rules_manager)),
         )

--- a/scylla-server/src/main.rs
+++ b/scylla-server/src/main.rs
@@ -25,7 +25,7 @@ use scylla_server::{
         self,
         car_command_controller::{self},
         data_type_controller, file_insertion_controller,
-        rule_controller::{add_rule, delete_rule, get_all_rules},
+        rule_controller::{add_rule, delete_rule, get_all_rules, get_all_server_rules},
         run_controller, scylla_config_controller,
         video_streamer_controller::{self},
         OutputDirectory, VideoSuffix,
@@ -406,7 +406,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Router::new()
                 .route("/rules/add", put(add_rule))
                 .route("/rules/delete/{rule_id}", post(delete_rule))
-                .route("/rules/{requesting_client_id}", get(get_all_rules))
+                .route("/rules", get(get_all_server_rules))
+                .route("/rules/{client_id}", get(get_all_rules))
                 //.route("/rules/delete/{rule_id}", post()).route("/rules/poll")
                 .layer(Extension(rules_manager)),
         )

--- a/scylla-server/src/main.rs
+++ b/scylla-server/src/main.rs
@@ -25,7 +25,7 @@ use scylla_server::{
         self,
         car_command_controller::{self},
         data_type_controller, file_insertion_controller,
-        rule_controller::{add_rule, delete_rule},
+        rule_controller::{add_rule, delete_rule, get_all_rules},
         run_controller, scylla_config_controller,
         video_streamer_controller::{self},
         OutputDirectory, VideoSuffix,
@@ -406,6 +406,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Router::new()
                 .route("/rules/add", put(add_rule))
                 .route("/rules/delete/{rule_id}", post(delete_rule))
+                .route("/rules", get(get_all_rules))
                 //.route("/rules/delete/{rule_id}", post()).route("/rules/poll")
                 .layer(Extension(rules_manager)),
         )

--- a/scylla-server/src/rule_structs.rs
+++ b/scylla-server/src/rule_structs.rs
@@ -324,8 +324,8 @@ pub struct ClientRule {
 #[derive(Serialize, Clone)]
 /// Response containing all rules with subscription status
 pub struct RulesResponse {
-    pub requesting_client_id: String,
-    pub rules: Vec<ClientRule>,
+    pub requesting_client_id: ClientId,
+    pub client_rules: Vec<ClientRule>,
 }
 
 /// errors seen in the rule manager
@@ -499,15 +499,10 @@ impl RuleManager {
 
     pub async fn get_all_rules_with_subscription_status(
         &self,
-        requesting_client_id: Option<ClientId>,
+        requesting_client_id: ClientId,
     ) -> RulesResponse {
         let rules_guard = self.rules.read().await;
         let subscriptions_guard = self.subscriptions.read().await;
-
-        let client_id_str = requesting_client_id
-            .as_ref()
-            .map(|id| id.0.clone())
-            .unwrap_or_default();
 
         let rules = rules_guard
             .iter()
@@ -517,11 +512,7 @@ impl RuleManager {
                     .cloned()
                     .unwrap_or_default();
 
-                let is_subscribed = if let Some(ref client_id) = requesting_client_id {
-                    subscribers.contains(client_id)
-                } else {
-                    false
-                };
+                let is_subscribed = subscribers.contains(&requesting_client_id);
 
                 ClientRule {
                     rule: rule.clone(),
@@ -532,8 +523,8 @@ impl RuleManager {
             .collect();
 
         RulesResponse {
-            requesting_client_id: client_id_str,
-            rules,
+            requesting_client_id: requesting_client_id,
+            client_rules: rules,
         }
     }
 

--- a/scylla-server/src/rule_structs.rs
+++ b/scylla-server/src/rule_structs.rs
@@ -185,7 +185,7 @@ pub const RULE_SOCKET_KEY: &str = "rule_notify";
 // since client IDs, rule IDs, and topics are scattered about, wrap them here
 
 /// a client_id, add to derives to get more string features
-#[derive(PartialEq, Eq, Hash, Display, Clone, AsRef)]
+#[derive(PartialEq, Eq, Hash, Display, Clone, AsRef, Serialize)]
 pub struct ClientId(pub String);
 
 /// a Rule ID, add to derives to get more string features
@@ -310,6 +310,22 @@ impl Rule {
         }
         Some(false)
     }
+}
+
+#[derive(Serialize, Clone)]
+/// Rule with subscription information
+pub struct ClientRule {
+    #[serde(flatten)]
+    pub rule: Rule,
+    pub subscribers: Vec<ClientId>,
+    pub is_subscribed: bool,
+}
+
+#[derive(Serialize, Clone)]
+/// Response containing all rules with subscription status
+pub struct RulesResponse {
+    pub requesting_client_id: String,
+    pub rules: Vec<ClientRule>,
 }
 
 /// errors seen in the rule manager
@@ -479,6 +495,46 @@ impl RuleManager {
             .into_iter()
             .map(|rule| rule.clone())
             .collect()
+    }
+
+    pub async fn get_all_rules_with_subscription_status(
+        &self,
+        requesting_client_id: Option<ClientId>,
+    ) -> RulesResponse {
+        let rules_guard = self.rules.read().await;
+        let subscriptions_guard = self.subscriptions.read().await;
+
+        let client_id_str = requesting_client_id
+            .as_ref()
+            .map(|id| id.0.clone())
+            .unwrap_or_default();
+
+        let rules = rules_guard
+            .iter()
+            .map(|(rule_id, rule)| {
+                let subscribers = subscriptions_guard
+                    .get_left(rule_id)
+                    .cloned()
+                    .unwrap_or_default();
+
+                let is_subscribed = if let Some(ref client_id) = requesting_client_id {
+                    subscribers.contains(client_id)
+                } else {
+                    false
+                };
+
+                ClientRule {
+                    rule: rule.clone(),
+                    subscribers: subscribers.into_iter().collect(),
+                    is_subscribed,
+                }
+            })
+            .collect();
+
+        RulesResponse {
+            requesting_client_id: client_id_str,
+            rules,
+        }
     }
 
     pub async fn get_all_clients(&self) -> Vec<ClientId> {

--- a/scylla-server/src/rule_structs.rs
+++ b/scylla-server/src/rule_structs.rs
@@ -217,7 +217,7 @@ pub struct RuleNotification {
 }
 
 #[serde_as]
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 /// A single modular rule, can be serial/deserialized
 pub struct Rule {
     id: RuleId,


### PR DESCRIPTION
## Changes

I created two endpoints to get all of the rules available. One of them has more info and is focused on being conducive with our new UI for rules (the rules dashboard) (endpoint:  "rules/{client_id}"), it includes all clients subscribed to each rule, and whether or not the client is subscribed to the rule (which I decided to include as this functionality is somewhat trivial to compute, and would most likely be done by clients calling the endpoint).

## Notes

Decided to start getting rid of putting client_id in the auth header from now on, as for the foreseeable future we won't be putting auth on rules. If we add auth later, we can just wrap all of the rules in an auth route, and just always assume that client_id is not secure.

## Test Cases

- tested adding a rule, and using both endpoints to get it.
- tested client that had no subbed rules (endpoint correctly ID's not subbed)
- tested client that had subbed rules (endpoint correctly ID's subbed)


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #502 
