### PR TITLE
Time based range added + misc

### DIFF
--- a/angular-client/src/pages/graph-page/graph-page.component.html
+++ b/angular-client/src/pages/graph-page/graph-page.component.html
@@ -38,33 +38,17 @@
                 additionalStyles="background-color: #0c2026; border: 1.4px solid #8fcadd; width: 90px; font-size: 11px;"
               />
 
-              @if (rangeMode === 'time') {
-                <label style="color: #fff; font-size: 12px">X (sec):</label>
-                <p-inputNumber
-                  [(ngModel)]="this.timeRangeSeconds"
-                  mode="decimal"
-                  [min]="1"
-                  [step]="1"
-                  styleClass="time-range-input"
-                  inputStyleClass="text-xs p-4"
-                  placeholder="30"
-                  (onInput)="onGraphConfigChange()"
-                ></p-inputNumber>
-              } @else {
-                <label style="color: #fff; font-size: 12px">X (points):</label>
-                <p-inputNumber
-                  [(ngModel)]="this.dataPoints"
-                  mode="decimal"
-                  [minFractionDigits]="1"
-                  [maxFractionDigits]="3"
-                  [step]="0.1"
-                  styleClass="time-range-input"
-                  inputStyleClass="text-xs p-4"
-                  inputId="minmaxfraction"
-                  placeholder="Auto"
-                  (onInput)="onGraphConfigChange()"
-                ></p-inputNumber>
-              }
+              <label style="color: #fff; font-size: 12px">{{ rangeMode === 'time' ? 'X (sec):' : 'X (points):' }}</label>
+              <p-inputNumber
+                [(ngModel)]="rangeValue"
+                mode="decimal"
+                [min]="1"
+                [step]="1"
+                styleClass="time-range-input"
+                inputStyleClass="text-xs p-4"
+                [placeholder]="rangeMode === 'time' ? '30' : 'Auto'"
+                (onInput)="onGraphConfigChange()"
+              ></p-inputNumber>
             }
 
             <label style="color: #fff; font-size: 12px">Y Min:</label>

--- a/angular-client/src/pages/graph-page/graph-page.component.html
+++ b/angular-client/src/pages/graph-page/graph-page.component.html
@@ -32,19 +32,39 @@
           <!-- Graph Configuration Inputs -->
           <div style="display: flex; align-items: center; gap: 5px; margin-left: 15px">
             @if (this.realTime === true) {
-              <label style="color: #fff; font-size: 12px">X (points):</label>
-              <p-inputNumber
-                [(ngModel)]="this.dataPoints"
-                mode="decimal"
-                [minFractionDigits]="1"
-                [maxFractionDigits]="3"
-                [step]="0.1"
-                styleClass="time-range-input"
-                inputStyleClass="text-xs p-4"
-                inputId="minmaxfraction"
-                placeholder="Auto"
-                (onInput)="onGraphConfigChange()"
-              ></p-inputNumber>
+              <argos-button
+                [onClick]="this.toggleRangeMode"
+                [label]="rangeMode === 'time' ? 'Time Range' : 'Point Range'"
+                additionalStyles="background-color: #0c2026; border: 1.4px solid #8fcadd; width: 90px; font-size: 11px;"
+              />
+              
+              @if (rangeMode === 'time') {
+                <label style="color: #fff; font-size: 12px">X (sec):</label>
+                <p-inputNumber
+                  [(ngModel)]="this.timeRangeSeconds"
+                  mode="decimal"
+                  [min]="1"
+                  [step]="1"
+                  styleClass="time-range-input"
+                  inputStyleClass="text-xs p-4"
+                  placeholder="60"
+                  (onInput)="onGraphConfigChange()"
+                ></p-inputNumber>
+              } @else {
+                <label style="color: #fff; font-size: 12px">X (points):</label>
+                <p-inputNumber
+                  [(ngModel)]="this.dataPoints"
+                  mode="decimal"
+                  [minFractionDigits]="1"
+                  [maxFractionDigits]="3"
+                  [step]="0.1"
+                  styleClass="time-range-input"
+                  inputStyleClass="text-xs p-4"
+                  inputId="minmaxfraction"
+                  placeholder="Auto"
+                  (onInput)="onGraphConfigChange()"
+                ></p-inputNumber>
+              }
             }
 
             <label style="color: #fff; font-size: 12px">Y Min:</label>

--- a/angular-client/src/pages/graph-page/graph-page.component.html
+++ b/angular-client/src/pages/graph-page/graph-page.component.html
@@ -37,7 +37,7 @@
                 [label]="rangeMode === 'time' ? 'Time Range' : 'Point Range'"
                 additionalStyles="background-color: #0c2026; border: 1.4px solid #8fcadd; width: 90px; font-size: 11px;"
               />
-              
+
               @if (rangeMode === 'time') {
                 <label style="color: #fff; font-size: 12px">X (sec):</label>
                 <p-inputNumber

--- a/angular-client/src/pages/graph-page/graph-page.component.html
+++ b/angular-client/src/pages/graph-page/graph-page.component.html
@@ -47,7 +47,7 @@
                   [step]="1"
                   styleClass="time-range-input"
                   inputStyleClass="text-xs p-4"
-                  placeholder="60"
+                  placeholder="30"
                   (onInput)="onGraphConfigChange()"
                 ></p-inputNumber>
               } @else {

--- a/angular-client/src/pages/graph-page/graph-page.component.ts
+++ b/angular-client/src/pages/graph-page/graph-page.component.ts
@@ -157,7 +157,7 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
   yAxisMax: number | null = null;
   // Range mode: 'time' for time-based range, 'points' for data point-based range
   rangeMode: 'time' | 'points' = 'time'; // Default to time-based
-  timeRangeSeconds: number = 60; // Default to 60 seconds (1 minute)
+  timeRangeSeconds: number = 30; // Default to 30 seconds
   graphConfig = {
     maxPoints: this.dataPoints,
     yMin: this.yAxisMin,
@@ -528,7 +528,7 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
     }
   };
 
-  clearGraph = false;
+  clearGraph = 0;
 
   clearDataType: () => void = () => {
     // Unsubscribe from all previous subscriptions
@@ -547,6 +547,6 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
     this.selectedDataTypeValuesIsLoading = false;
     this.selectedDataTypeValuesIsError = false;
     this.selectedDataTypeValuesError = undefined;
-    this.clearGraph = true;
+    this.clearGraph++;
   };
 }

--- a/angular-client/src/pages/graph-page/graph-page.component.ts
+++ b/angular-client/src/pages/graph-page/graph-page.component.ts
@@ -12,7 +12,7 @@ import { FaultService } from 'src/services/fault.service';
 import Storage from 'src/services/storage.service';
 import { TopicSelectionService } from 'src/services/topic-selection.service';
 import { DataValue } from 'src/utils/socket.utils';
-import { DataType, FaultData, GraphData, GraphInfo, Run } from 'src/utils/types.utils';
+import { DataType, FaultData, GraphData, ObservableGraphInfo, Run } from 'src/utils/types.utils';
 import { ButtonComponent } from '../../components/argos-button/argos-button.component';
 import { FaultButtonsComponent } from './graph-caption/fault-buttons/fault-buttons.component';
 import { GeneralButtonsComponent } from './graph-caption/general-buttons/general-buttons.component';
@@ -147,7 +147,7 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
   // When we are in live mode the data  is constantly udpated.
   // The Behvaorial subject is update just a single time when querying for data.
   // these should always be reset when switching between modes.
-  selectedDataTypeValuesSubject = [new BehaviorSubject<GraphInfo>({ label: '', data: [] })];
+  selectedDataTypeValuesSubject: ObservableGraphInfo[] = [];
   selectedDataTypeValuesIsLoading = false; // specifically used for querying updates.
   selectedDataTypeValuesIsError = false;
   selectedDataTypeValuesError?: Error;
@@ -223,8 +223,8 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
       sub.unsubscribe();
     });
 
-    this.selectedDataTypeValuesSubject.forEach((subject) => {
-      subject.complete();
+    this.selectedDataTypeValuesSubject.forEach((item) => {
+      item.updates.complete();
     });
     this.selectedDataTypeValuesSubject = [];
     this.selectedDataTypeValuesSubject.length = 0;
@@ -386,10 +386,10 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
   private processRealTimeDataTypeSelection = (dataTypes: DataType[]) => {
     dataTypes.forEach((dataType) => {
       const key = dataType.name;
-      const targetSubject = this.selectedDataTypeValuesSubject.find((s) => s.getValue().label === key);
+      const target = this.selectedDataTypeValuesSubject.find((s) => s.label === key);
       const valuesSubject = this.storage.get(key);
 
-      if (targetSubject !== undefined) {
+      if (target !== undefined) {
         this.subscriptions.push(
           valuesSubject.subscribe((value: DataValue) => {
             // Skip processing if paused
@@ -401,10 +401,7 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
               return [{ x: +value.time, y: +val }];
             });
 
-            targetSubject.next({
-              label: dataType.name,
-              data: newPoints
-            });
+            target.updates.next(newPoints);
           })
         );
       }
@@ -469,15 +466,15 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
               });
             });
 
-            let target = this.selectedDataTypeValuesSubject.find((subj) => subj.getValue().label === dataType.name);
+            let target = this.selectedDataTypeValuesSubject.find((s) => s.label === dataType.name);
 
             if (!target) {
               // (shouldn't normally happen, but keep it safe)
-              target = new BehaviorSubject<GraphInfo>({ label: dataType.name, data: [] });
+              target = { label: dataType.name, updates: new BehaviorSubject<GraphData[][]>([]) };
               this.selectedDataTypeValuesSubject.push(target);
             }
 
-            target.next({ label: dataType.name, data: graphData });
+            target.updates.next(graphData);
           }
         })
       );
@@ -493,7 +490,10 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
     this.clearDataType();
     this.selectedDataTypes = dataTypes;
 
-    this.selectedDataTypeValuesSubject = dataTypes.map((dt) => new BehaviorSubject<GraphInfo>({ label: dt.name, data: [] }));
+    this.selectedDataTypeValuesSubject = dataTypes.map((dt) => ({
+      label: dt.name,
+      updates: new BehaviorSubject<GraphData[][]>([])
+    }));
 
     if (this.realTime) {
       this.processRealTimeDataTypeSelection(dataTypes);
@@ -518,8 +518,8 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
     this.subscriptions = [];
 
     // Clear and complete existing subjects to prevent memory leaks
-    this.selectedDataTypeValuesSubject.forEach((subject) => {
-      subject.complete();
+    this.selectedDataTypeValuesSubject.forEach((item) => {
+      item.updates.complete();
     });
     this.selectedDataTypeValuesSubject = []; // More explicit reset
 

--- a/angular-client/src/pages/graph-page/graph-page.component.ts
+++ b/angular-client/src/pages/graph-page/graph-page.component.ts
@@ -384,14 +384,12 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
   }
 
   private processRealTimeDataTypeSelection = (dataTypes: DataType[]) => {
-    const dataTypeValues = this.selectedDataTypeValuesSubject.map((subject) => subject.getValue());
-
     dataTypes.forEach((dataType) => {
       const key = dataType.name;
-      const graphInfo = dataTypeValues.find((dtV) => dtV.label === key);
+      const targetSubject = this.selectedDataTypeValuesSubject.find((s) => s.getValue().label === key);
       const valuesSubject = this.storage.get(key);
 
-      if (graphInfo !== undefined) {
+      if (targetSubject !== undefined) {
         this.subscriptions.push(
           valuesSubject.subscribe((value: DataValue) => {
             // Skip processing if paused
@@ -399,32 +397,14 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
               return;
             }
 
-            const storedValues = graphInfo.data;
-
-            // Process new values and filter in one pass for better performance
-            value.values.forEach((val, i) => {
-              const graphData = { x: +value.time, y: +val, label: dataType.name };
-
-              if (storedValues[i]) {
-                storedValues[i].push(graphData);
-
-                // Limit to prevent memory buildup
-                if (storedValues[i].length > this.dataPoints) {
-                  storedValues[i].shift();
-                }
-              } else {
-                storedValues[i] = [graphData];
-              }
+            const newPoints: GraphData[][] = value.values.map((val) => {
+              return [{ x: +value.time, y: +val }];
             });
 
-            // Update the subject with the already filtered data
-            const targetSubject = this.selectedDataTypeValuesSubject.find((s) => s.getValue().label === dataType.name);
-            if (targetSubject) {
-              targetSubject.next({
-                label: dataType.name,
-                data: storedValues
-              });
-            }
+            targetSubject.next({
+              label: dataType.name,
+              data: newPoints
+            });
           })
         );
       }

--- a/angular-client/src/pages/graph-page/graph-page.component.ts
+++ b/angular-client/src/pages/graph-page/graph-page.component.ts
@@ -155,10 +155,15 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
   dataPointsChanged = false;
   yAxisMin: number | null = null;
   yAxisMax: number | null = null;
+  // Range mode: 'time' for time-based range, 'points' for data point-based range
+  rangeMode: 'time' | 'points' = 'time'; // Default to time-based
+  timeRangeSeconds: number = 60; // Default to 60 seconds (1 minute)
   graphConfig = {
     maxPoints: this.dataPoints,
     yMin: this.yAxisMin,
-    yMax: this.yAxisMax
+    yMax: this.yAxisMax,
+    rangeMode: this.rangeMode,
+    timeRangeMs: this.timeRangeSeconds * 1000
   };
   onGraphConfigChange = () => {
     if (this.realTime) {
@@ -167,8 +172,15 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
     this.graphConfig = {
       maxPoints: this.dataPoints,
       yMin: this.yAxisMin,
-      yMax: this.yAxisMax
+      yMax: this.yAxisMax,
+      rangeMode: this.rangeMode,
+      timeRangeMs: this.timeRangeSeconds * 1000
     };
+  };
+
+  toggleRangeMode = () => {
+    this.rangeMode = this.rangeMode === 'time' ? 'points' : 'time';
+    this.onGraphConfigChange();
   };
 
   // Run when page starts up

--- a/angular-client/src/pages/graph-page/graph-page.component.ts
+++ b/angular-client/src/pages/graph-page/graph-page.component.ts
@@ -151,7 +151,7 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
   selectedDataTypeValuesIsLoading = false; // specifically used for querying updates.
   selectedDataTypeValuesIsError = false;
   selectedDataTypeValuesError?: Error;
-  dataPoints: number = 300;
+  dataPoints: number = 100;
   dataPointsChanged = false;
   yAxisMin: number | null = null;
   yAxisMax: number | null = null;
@@ -177,6 +177,17 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
       timeRangeMs: this.timeRangeSeconds * 1000
     };
   };
+  // Getter/setter to allow same function input for ngModel in template.
+  get rangeValue(): number {
+    return this.rangeMode === 'time' ? this.timeRangeSeconds : this.dataPoints;
+  }
+  set rangeValue(val: number) {
+    if (this.rangeMode === 'time') {
+      this.timeRangeSeconds = val;
+    } else {
+      this.dataPoints = val;
+    }
+  }
 
   toggleRangeMode = () => {
     this.rangeMode = this.rangeMode === 'time' ? 'points' : 'time';

--- a/angular-client/src/pages/graph-page/graph/graph.component.ts
+++ b/angular-client/src/pages/graph-page/graph/graph.component.ts
@@ -49,7 +49,13 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
   isSliding: boolean = false;
   timeRangeMs: number | undefined = undefined;
   private timeOuts: NodeJS.Timeout[] = [];
-  graphConfig = input.required<{ maxPoints: number; yMin: number | null; yMax: number | null }>();
+  graphConfig = input.required<{ 
+    maxPoints: number; 
+    yMin: number | null; 
+    yMax: number | null;
+    rangeMode: 'time' | 'points';
+    timeRangeMs: number;
+  }>();
   range = input<number | undefined>(undefined);
   subscriptions: Subscription[] = [];
 
@@ -178,11 +184,16 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
 
     this.chart.updateSeries(series);
 
+    // Use time-based range if in time mode, otherwise use calculated timeRangeMs from point-based logic
+    const effectiveRange = this.graphConfig().rangeMode === 'time' 
+      ? this.graphConfig().timeRangeMs 
+      : this.timeRangeMs;
+
     this.chart.updateOptions({
       ...this.options,
       xaxis: {
         ...this.options.xaxis,
-        range: this.timeRangeMs
+        range: effectiveRange
       }
     });
   };
@@ -209,13 +220,24 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
           line.push({ x: val.x, y: +val.y.toFixed(3) });
         }
 
-        if (this.realTime() && line.length > this.graphConfig().maxPoints) {
-          const shiftedPoint = line.shift()?.x; // Remove the oldest point
-          // THE BELOW IS A SOMEWHAT TEMP FIX, ULTIMATELY THIS SHOULD BE MORE DYNAMIC AND BE OFFERED AS A CONFIG OPTION
-          // Calculate the actual time range: difference between newest and oldest remaining points
-          const timeDiff = line.length > 0 && shiftedPoint !== undefined ? val.x - shiftedPoint : 0;
-          // Update time range if this is larger than current range
-          this.timeRangeMs = timeDiff < (this.timeRangeMs ?? Number.MAX_SAFE_INTEGER) ? timeDiff : this.timeRangeMs;
+        if (this.realTime()) {
+          const config = this.graphConfig();
+          
+          if (config.rangeMode === 'time') {
+            // Time-based trimming: remove points older than timeRangeMs
+            const cutoffTime = val.x - config.timeRangeMs;
+            while (line.length > 0 && line[0].x < cutoffTime) {
+              line.shift();
+            }
+          } else {
+            // Point-based trimming: keep only maxPoints
+            if (line.length > config.maxPoints) {
+              const shiftedPoint = line.shift()?.x;
+              // Calculate the actual time range for point-based mode
+              const timeDiff = line.length > 0 && shiftedPoint !== undefined ? val.x - shiftedPoint : 0;
+              this.timeRangeMs = timeDiff < (this.timeRangeMs ?? Number.MAX_SAFE_INTEGER) ? timeDiff : this.timeRangeMs;
+            }
+          }
         }
       });
     });

--- a/angular-client/src/pages/graph-page/graph/graph.component.ts
+++ b/angular-client/src/pages/graph-page/graph/graph.component.ts
@@ -175,7 +175,7 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
 
     const series = Array.from(this.data).map(([key, points], index) => ({
       name: key,
-      data: points, // pass by reference — no copy needed, Apex clones internally
+      data: points,
       yaxis: index
     }));
 

--- a/angular-client/src/pages/graph-page/graph/graph.component.ts
+++ b/angular-client/src/pages/graph-page/graph/graph.component.ts
@@ -14,26 +14,6 @@ import {
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { GraphInfo } from 'src/utils/types.utils';
 
-/**
- * Binary search for the insertion index to keep `arr` sorted by `x`.
- * Returns the index at which `x` should be inserted.
- */
-function binarySearchInsertIndex(arr: { x: number }[], x: number): number {
-  let lo = 0;
-  let hi = arr.length;
-  while (lo < hi) {
-    // shift right, same as mid = Math.floor((lo + hi) / 2) but avoids potential overflow
-    // interesting article: https://research.google/blog/extra-extra-read-all-about-it-nearly-all-binary-searches-and-mergesorts-are-broken/
-    const mid = (lo + hi) >>> 1;
-    if (arr[mid].x < x) {
-      lo = mid + 1;
-    } else {
-      hi = mid;
-    }
-  }
-  return lo;
-}
-
 type ChartOptions = {
   chart: ApexChart;
   xaxis: ApexXAxis;
@@ -237,15 +217,7 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
 
       value.forEach((val) => {
         const point = { x: val.x, y: Math.round(val.y * 10000) / 10000 };
-
-        // Fast path: in-order append (the common case)
-        if (line.length === 0 || val.x >= line[line.length - 1].x) {
-          line.push(point);
-        } else {
-          // Out of order: binary search for correct sorted position
-          const idx = binarySearchInsertIndex(line, val.x);
-          line.splice(idx, 0, point);
-        }
+        line.push(point);
       });
 
       // Trim after processing all points in this series batch
@@ -254,18 +226,15 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
         const latestX = line[line.length - 1].x;
 
         if (config.rangeMode === 'time') {
-          // Time-based trimming: bulk-remove points outside the time range + 10% buffer
+          // Time-based trimming: remove point if outside the time range + 10% buffer
           const buffer = config.timeRangeMs * 0.1;
           const cutoff = latestX - config.timeRangeMs - buffer;
-          // Binary search for first point >= cutoff for O(log n) bulk trim
-          const trimIdx = binarySearchInsertIndex(line, cutoff);
-          if (trimIdx > 0) {
-            line.splice(0, trimIdx);
+          if (line[0].x < cutoff) {
+            line.shift();
           }
         } else if (line.length > config.maxPoints * 1.1) {
           // Point-based trimming: keep maxPoints
-          const excess = line.length - config.maxPoints;
-          const [shiftedPoint] = line.splice(0, excess);
+          const shiftedPoint = line.shift();
           const timeDiff = shiftedPoint !== undefined ? latestX - shiftedPoint.x : 0;
           this.timeRangeMs = timeDiff < (this.timeRangeMs ?? Number.MAX_SAFE_INTEGER) ? timeDiff : this.timeRangeMs;
         }

--- a/angular-client/src/pages/graph-page/graph/graph.component.ts
+++ b/angular-client/src/pages/graph-page/graph/graph.component.ts
@@ -12,6 +12,7 @@ import {
   ApexYAxis
 } from 'ng-apexcharts';
 import { Subscription } from 'rxjs';
+import { binarySearchInsertIndex } from 'src/utils/array.utils';
 import { GraphInfo, ObservableGraphInfo } from 'src/utils/types.utils';
 
 type ChartOptions = {
@@ -211,7 +212,16 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
 
       value.forEach((val) => {
         const point = { x: val.x, y: Math.round(val.y * 10000) / 10000 };
-        line.push(point);
+
+        // if the point is in order according to it's timestamp, just push it to the end of the line
+        if (line.length === 0 || val.x >= line.at(-1)!.x) {
+          line.push(point);
+        } else {
+          // Out of order: binary search for correct sorted position
+          // (very rare but it's nice to be able to assume sorted data for efficient trimming later)
+          const idx = binarySearchInsertIndex(line, val.x);
+          line.splice(idx, 0, point);
+        }
       });
 
       // Trim after processing all points in this series batch
@@ -220,15 +230,16 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
         const latestX = line[line.length - 1].x;
 
         if (config.rangeMode === 'time') {
-          // Time-based trimming: remove point if outside the time range + 10% buffer
+          // remove point if outside the time range + 10% buffer (for better UX)
           const buffer = config.timeRangeMs * 0.1;
           const cutoff = latestX - config.timeRangeMs - buffer;
           if (line[0].x < cutoff) {
             line.shift();
           }
         } else if (line.length > config.maxPoints * 1.1) {
-          // Point-based trimming: keep maxPoints
           const shiftedPoint = line.shift();
+          // point based trim requires is to calculate the max time range we can show that
+          // doesn't show points being deleted. So we default to smallest range.
           const timeDiff = shiftedPoint !== undefined ? latestX - shiftedPoint.x : 0;
           this.timeRangeMs = timeDiff < (this.timeRangeMs ?? Number.MAX_SAFE_INTEGER) ? timeDiff : this.timeRangeMs;
         }

--- a/angular-client/src/pages/graph-page/graph/graph.component.ts
+++ b/angular-client/src/pages/graph-page/graph/graph.component.ts
@@ -61,11 +61,8 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
   clearGraph = input<number>(0);
   options!: ChartOptions;
   chart!: ApexCharts;
-  previousDataLength: number = 0;
   // label -> x,y (topic, data point)
   data!: Map<string, Array<{ x: number; y: number }>>;
-  // label -> set of seen x-values for O(1) duplicate detection
-  dataKeys!: Map<string, Set<number>>;
   isSliding: boolean = false;
   timeRangeMs: number | undefined = undefined;
   private timeOuts: NodeJS.Timeout[] = [];
@@ -113,9 +110,7 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
       if (this.chart) {
         this.chart.updateSeries([]);
       }
-      this.previousDataLength = 0;
       this.data = new Map();
-      this.dataKeys = new Map();
       this.timeRangeMs = undefined;
     });
 
@@ -190,7 +185,6 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
       this.chart.destroy();
     }
     this.data.clear();
-    this.dataKeys.clear();
   }
 
   updateChart = () => {
@@ -199,24 +193,29 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const series = Array.from(this.data).map(([key, map], index) => ({
+    const series = Array.from(this.data).map(([key, points], index) => ({
       name: key,
-      data: Array.from(map),
-      yaxis: index // Assign each series to a y-axis index
+      data: points, // pass by reference — no copy needed, Apex clones internally
+      yaxis: index
     }));
-
-    this.chart.updateSeries(series);
 
     // Use time-based range if in time mode, otherwise use calculated timeRangeMs from point-based logic
     const effectiveRange = this.graphConfig().rangeMode === 'time' ? this.graphConfig().timeRangeMs : this.timeRangeMs;
 
-    this.chart.updateOptions({
-      ...this.options,
-      xaxis: {
-        ...this.options.xaxis,
-        range: effectiveRange
-      }
-    });
+    // Single updateOptions call with series included — avoids two separate re-renders
+    // Pass false, false to skip animation bookkeeping (getPreviousPaths) and animate flag
+    this.chart.updateOptions(
+      {
+        ...this.options,
+        series,
+        xaxis: {
+          ...this.options.xaxis,
+          range: effectiveRange
+        }
+      },
+      false, // redraw (default is false)
+      false // animate (default is true)
+    );
   };
 
   graphInfoCallback = (info: GraphInfo | undefined) => {
@@ -231,47 +230,44 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
       const label = (info?.label ?? '') + ' ' + i;
       if (!this.data.has(label)) {
         this.data.set(label, []);
-        this.dataKeys.set(label, new Set());
       }
       const line = this.data.get(label)!;
-      const keys = this.dataKeys.get(label)!;
 
       value.forEach((val) => {
-        // O(1) duplicate check via Set
-        if (!keys.has(val.x)) {
-          const point = { x: val.x, y: +val.y.toFixed(3) };
-          keys.add(val.x);
+        const point = { x: val.x, y: Math.round(val.y * 10000) / 10000 };
 
-          // Fast path: in-order append (the common case)
-          if (line.length === 0 || val.x >= line[line.length - 1].x) {
-            line.push(point);
-          } else {
-            // Out of order: binary search for correct sorted position
-            const idx = binarySearchInsertIndex(line, val.x);
-            line.splice(idx, 0, point);
-          }
-        }
-
-        if (this.realTime()) {
-          const config = this.graphConfig();
-
-          if (config.rangeMode === 'time') {
-            // Time-based trimming: bulk-remove points outside the time range + 10% buffer
-            const buffer = config.timeRangeMs * 0.1;
-            const cutoff = val.x - config.timeRangeMs - buffer;
-            while (line.length > 0 && line[0].x < cutoff) {
-              keys.delete(line.shift()!.x);
-            }
-          } else if (line.length > config.maxPoints * 1.1) {
-            // Point-based trimming: keep maxPoints + 10% buffer
-            const shiftedPoint = line.shift();
-            if (shiftedPoint) keys.delete(shiftedPoint.x);
-            // Calculate the actual time range for point-based mode
-            const timeDiff = line.length > 0 && shiftedPoint !== undefined ? val.x - shiftedPoint.x : 0;
-            this.timeRangeMs = timeDiff < (this.timeRangeMs ?? Number.MAX_SAFE_INTEGER) ? timeDiff : this.timeRangeMs;
-          }
+        // Fast path: in-order append (the common case)
+        if (line.length === 0 || val.x >= line[line.length - 1].x) {
+          line.push(point);
+        } else {
+          // Out of order: binary search for correct sorted position
+          const idx = binarySearchInsertIndex(line, val.x);
+          line.splice(idx, 0, point);
         }
       });
+
+      // Trim after processing all points in this series batch
+      if (this.realTime() && line.length > 0) {
+        const config = this.graphConfig();
+        const latestX = line[line.length - 1].x;
+
+        if (config.rangeMode === 'time') {
+          // Time-based trimming: bulk-remove points outside the time range + 10% buffer
+          const buffer = config.timeRangeMs * 0.1;
+          const cutoff = latestX - config.timeRangeMs - buffer;
+          // Binary search for first point >= cutoff for O(log n) bulk trim
+          const trimIdx = binarySearchInsertIndex(line, cutoff);
+          if (trimIdx > 0) {
+            line.splice(0, trimIdx);
+          }
+        } else if (line.length > config.maxPoints * 1.1) {
+          // Point-based trimming: keep maxPoints
+          const excess = line.length - config.maxPoints;
+          const [shiftedPoint] = line.splice(0, excess);
+          const timeDiff = shiftedPoint !== undefined ? latestX - shiftedPoint.x : 0;
+          this.timeRangeMs = timeDiff < (this.timeRangeMs ?? Number.MAX_SAFE_INTEGER) ? timeDiff : this.timeRangeMs;
+        }
+      }
     });
 
     this.updateChart();
@@ -279,7 +275,6 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.data = new Map();
-    this.dataKeys = new Map();
 
     const chartContainer = document.getElementById('chart-container');
     if (!chartContainer) return;

--- a/angular-client/src/pages/graph-page/graph/graph.component.ts
+++ b/angular-client/src/pages/graph-page/graph/graph.component.ts
@@ -11,8 +11,8 @@ import {
   ApexLegend,
   ApexYAxis
 } from 'ng-apexcharts';
-import { BehaviorSubject, Subscription } from 'rxjs';
-import { GraphInfo } from 'src/utils/types.utils';
+import { Subscription } from 'rxjs';
+import { GraphInfo, ObservableGraphInfo } from 'src/utils/types.utils';
 
 type ChartOptions = {
   chart: ApexChart;
@@ -36,7 +36,7 @@ type ChartOptions = {
 })
 export default class CustomGraphComponent implements OnInit, OnDestroy {
   showMultipleYAxes = input<boolean>(false);
-  valuesSubject = input.required<BehaviorSubject<GraphInfo>[]>();
+  valuesSubject = input.required<ObservableGraphInfo[]>();
   limitRange = input(true);
   isPaused = input<boolean>(false);
   realTime = input<boolean>(false);
@@ -142,11 +142,8 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
       this.timeOuts.forEach((timeout) => clearTimeout(timeout));
       this.timeOuts = [];
 
-      this.valuesSubject().forEach((graphInfo) => {
-        if (this.isPaused()) {
-          return;
-        }
-        this.subscriptions.push(graphInfo.subscribe(this.graphInfoCallback));
+      this.valuesSubject().forEach(({ label, updates }) => {
+        this.subscriptions.push(updates.subscribe((data) => this.graphInfoCallback({ label, data })));
       });
 
       this.updateChart();
@@ -200,20 +197,17 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
     );
   };
 
-  graphInfoCallback = (info: GraphInfo | undefined) => {
+  graphInfoCallback = (info: GraphInfo) => {
     // Skip processing if paused
     if (this.isPaused()) {
       return;
     }
-
-    const values = info?.data ?? [];
-    // if (values.length === 0) this.data = new Map();
-    values.forEach((value, i) => {
-      const label = (info?.label ?? '') + ' ' + i;
-      if (!this.data.has(label)) {
-        this.data.set(label, []);
+    info.data.forEach((value, i) => {
+      const seriesLabel = info.label + ' ' + i;
+      if (!this.data.has(seriesLabel)) {
+        this.data.set(seriesLabel, []);
       }
-      const line = this.data.get(label)!;
+      const line = this.data.get(seriesLabel)!;
 
       value.forEach((val) => {
         const point = { x: val.x, y: Math.round(val.y * 10000) / 10000 };

--- a/angular-client/src/pages/graph-page/graph/graph.component.ts
+++ b/angular-client/src/pages/graph-page/graph/graph.component.ts
@@ -49,9 +49,9 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
   isSliding: boolean = false;
   timeRangeMs: number | undefined = undefined;
   private timeOuts: NodeJS.Timeout[] = [];
-  graphConfig = input.required<{ 
-    maxPoints: number; 
-    yMin: number | null; 
+  graphConfig = input.required<{
+    maxPoints: number;
+    yMin: number | null;
     yMax: number | null;
     rangeMode: 'time' | 'points';
     timeRangeMs: number;
@@ -185,9 +185,7 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
     this.chart.updateSeries(series);
 
     // Use time-based range if in time mode, otherwise use calculated timeRangeMs from point-based logic
-    const effectiveRange = this.graphConfig().rangeMode === 'time' 
-      ? this.graphConfig().timeRangeMs 
-      : this.timeRangeMs;
+    const effectiveRange = this.graphConfig().rangeMode === 'time' ? this.graphConfig().timeRangeMs : this.timeRangeMs;
 
     this.chart.updateOptions({
       ...this.options,
@@ -222,21 +220,19 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
 
         if (this.realTime()) {
           const config = this.graphConfig();
-          
+
           if (config.rangeMode === 'time') {
             // Time-based trimming: remove points older than timeRangeMs
             const cutoffTime = val.x - config.timeRangeMs;
             while (line.length > 0 && line[0].x < cutoffTime) {
               line.shift();
             }
-          } else {
+          } else if (line.length > config.maxPoints) {
             // Point-based trimming: keep only maxPoints
-            if (line.length > config.maxPoints) {
-              const shiftedPoint = line.shift()?.x;
-              // Calculate the actual time range for point-based mode
-              const timeDiff = line.length > 0 && shiftedPoint !== undefined ? val.x - shiftedPoint : 0;
-              this.timeRangeMs = timeDiff < (this.timeRangeMs ?? Number.MAX_SAFE_INTEGER) ? timeDiff : this.timeRangeMs;
-            }
+            const shiftedPoint = line.shift()?.x;
+            // Calculate the actual time range for point-based mode
+            const timeDiff = line.length > 0 && shiftedPoint !== undefined ? val.x - shiftedPoint : 0;
+            this.timeRangeMs = timeDiff < (this.timeRangeMs ?? Number.MAX_SAFE_INTEGER) ? timeDiff : this.timeRangeMs;
           }
         }
       });

--- a/angular-client/src/pages/graph-page/graph/graph.component.ts
+++ b/angular-client/src/pages/graph-page/graph/graph.component.ts
@@ -22,6 +22,8 @@ function binarySearchInsertIndex(arr: { x: number }[], x: number): number {
   let lo = 0;
   let hi = arr.length;
   while (lo < hi) {
+    // shift right, same as mid = Math.floor((lo + hi) / 2) but avoids potential overflow
+    // interesting article: https://research.google/blog/extra-extra-read-all-about-it-nearly-all-binary-searches-and-mergesorts-are-broken/
     const mid = (lo + hi) >>> 1;
     if (arr[mid].x < x) {
       lo = mid + 1;

--- a/angular-client/src/pages/graph-page/graph/graph.component.ts
+++ b/angular-client/src/pages/graph-page/graph/graph.component.ts
@@ -14,6 +14,24 @@ import {
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { GraphInfo } from 'src/utils/types.utils';
 
+/**
+ * Binary search for the insertion index to keep `arr` sorted by `x`.
+ * Returns the index at which `x` should be inserted.
+ */
+function binarySearchInsertIndex(arr: { x: number }[], x: number): number {
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (arr[mid].x < x) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  return lo;
+}
+
 type ChartOptions = {
   chart: ApexChart;
   xaxis: ApexXAxis;
@@ -40,12 +58,14 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
   limitRange = input(true);
   isPaused = input<boolean>(false);
   realTime = input<boolean>(false);
-  clearGraph = input<boolean>(false);
+  clearGraph = input<number>(0);
   options!: ChartOptions;
   chart!: ApexCharts;
   previousDataLength: number = 0;
   // label -> x,y (topic, data point)
   data!: Map<string, Array<{ x: number; y: number }>>;
+  // label -> set of seen x-values for O(1) duplicate detection
+  dataKeys!: Map<string, Set<number>>;
   isSliding: boolean = false;
   timeRangeMs: number | undefined = undefined;
   private timeOuts: NodeJS.Timeout[] = [];
@@ -95,6 +115,8 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
       }
       this.previousDataLength = 0;
       this.data = new Map();
+      this.dataKeys = new Map();
+      this.timeRangeMs = undefined;
     });
 
     effect(() => {
@@ -168,6 +190,7 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
       this.chart.destroy();
     }
     this.data.clear();
+    this.dataKeys.clear();
   }
 
   updateChart = () => {
@@ -205,33 +228,46 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
     const values = info?.data ?? [];
     // if (values.length === 0) this.data = new Map();
     values.forEach((value, i) => {
-      let line: Array<{ x: number; y: number }>;
       const label = (info?.label ?? '') + ' ' + i;
       if (!this.data.has(label)) {
-        line = this.data.set(label, []).get(label)!;
-      } else {
-        line = this.data.get(label)!;
+        this.data.set(label, []);
+        this.dataKeys.set(label, new Set());
       }
+      const line = this.data.get(label)!;
+      const keys = this.dataKeys.get(label)!;
 
       value.forEach((val) => {
-        if (!line.some((v) => v.x === val.x)) {
-          line.push({ x: val.x, y: +val.y.toFixed(3) });
+        // O(1) duplicate check via Set
+        if (!keys.has(val.x)) {
+          const point = { x: val.x, y: +val.y.toFixed(3) };
+          keys.add(val.x);
+
+          // Fast path: in-order append (the common case)
+          if (line.length === 0 || val.x >= line[line.length - 1].x) {
+            line.push(point);
+          } else {
+            // Out of order: binary search for correct sorted position
+            const idx = binarySearchInsertIndex(line, val.x);
+            line.splice(idx, 0, point);
+          }
         }
 
         if (this.realTime()) {
           const config = this.graphConfig();
 
           if (config.rangeMode === 'time') {
-            // Time-based trimming: remove points older than timeRangeMs
-            const cutoffTime = val.x - config.timeRangeMs;
-            while (line.length > 0 && line[0].x < cutoffTime) {
-              line.shift();
+            // Time-based trimming: bulk-remove points outside the time range + 10% buffer
+            const buffer = config.timeRangeMs * 0.1;
+            const cutoff = val.x - config.timeRangeMs - buffer;
+            while (line.length > 0 && line[0].x < cutoff) {
+              keys.delete(line.shift()!.x);
             }
-          } else if (line.length > config.maxPoints) {
-            // Point-based trimming: keep only maxPoints
-            const shiftedPoint = line.shift()?.x;
+          } else if (line.length > config.maxPoints * 1.1) {
+            // Point-based trimming: keep maxPoints + 10% buffer
+            const shiftedPoint = line.shift();
+            if (shiftedPoint) keys.delete(shiftedPoint.x);
             // Calculate the actual time range for point-based mode
-            const timeDiff = line.length > 0 && shiftedPoint !== undefined ? val.x - shiftedPoint : 0;
+            const timeDiff = line.length > 0 && shiftedPoint !== undefined ? val.x - shiftedPoint.x : 0;
             this.timeRangeMs = timeDiff < (this.timeRangeMs ?? Number.MAX_SAFE_INTEGER) ? timeDiff : this.timeRangeMs;
           }
         }
@@ -243,6 +279,7 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.data = new Map();
+    this.dataKeys = new Map();
 
     const chartContainer = document.getElementById('chart-container');
     if (!chartContainer) return;

--- a/angular-client/src/utils/array.utils.ts
+++ b/angular-client/src/utils/array.utils.ts
@@ -1,0 +1,17 @@
+/**
+ * Binary search for the insertion index to keep `arr` sorted by `x`.
+ * Returns the index at which `x` should be inserted.
+ */
+export function binarySearchInsertIndex(arr: { x: number }[], x: number): number {
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (arr[mid].x < x) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  return lo;
+}

--- a/angular-client/src/utils/array.utils.ts
+++ b/angular-client/src/utils/array.utils.ts
@@ -6,6 +6,8 @@ export function binarySearchInsertIndex(arr: { x: number }[], x: number): number
   let lo = 0;
   let hi = arr.length;
   while (lo < hi) {
+    // shift right, same as mid = Math.floor((lo + hi) / 2) but avoids potential overflow
+    // interesting article: https://research.google/blog/extra-extra-read-all-about-it-nearly-all-binary-searches-and-mergesorts-are-broken/
     const mid = (lo + hi) >>> 1;
     if (arr[mid].x < x) {
       lo = mid + 1;

--- a/angular-client/src/utils/types.utils.ts
+++ b/angular-client/src/utils/types.utils.ts
@@ -51,10 +51,20 @@ export type GraphData = {
   y: number;
 };
 
-export type GraphInfo = {
+interface GraphInfoBase {
   label: string;
+}
+
+export interface GraphInfo extends GraphInfoBase {
   data: GraphData[][];
-};
+}
+
+// Used for both live and historical graphs,
+// because the historical graph may also need to update
+// from time to time in the future.
+export interface ObservableGraphInfo extends GraphInfoBase {
+  updates: BehaviorSubject<GraphData[][]>;
+}
 
 export type DoubleGraphData = {
   x1: number;

--- a/scylla-server/src/rule_structs.rs
+++ b/scylla-server/src/rule_structs.rs
@@ -14,7 +14,6 @@ use std::borrow::Borrow;
 use std::hash::Hash;
 use std::time::Duration;
 use tokio::sync::RwLock;
-use tracing::trace;
 use tracing::warn;
 
 use crate::rule_structs::BiMapRemoveResult::*;


### PR DESCRIPTION
## Changes

Added time based range to graph screen (now set as default, with a toggle to switch to point based range). Ultimately it forced a change to data tracking in the graph-page component, which was never really needed (duplication of tracked data, which wouldn't leak, but contributed to more memory usage). Because of that I changed the data type slightly to only be observable in the part that needed observation - the data (via an ObservableGraphInfo interface)

## Notes

The double data tracking was contributing to likely double the points being rendered in live mode. Which ultimately exposed a problem that would cause incorrect graphing if we ever got out of order points, now we have support for that edge case (via a binary insertion). 

Also for another ticket I would like to now support dynamic refresh rate for slower laptops (or maybe if you are rendering longer periods of data in live mode)


## Screenshots
<img width="1920" height="967" alt="Screenshot 2026-02-16 at 1 05 46 PM" src="https://github.com/user-attachments/assets/27b0c3d3-ce4d-4631-85df-0d7382180df6" />


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #467 