### PR TITLE
Endpoint for batch rule subscription

### DIFF
--- a/scylla-server/src/controllers/rule_controller.rs
+++ b/scylla-server/src/controllers/rule_controller.rs
@@ -5,12 +5,19 @@ use axum_extra::{
     headers::{authorization::Basic, Authorization},
     TypedHeader,
 };
+use serde::Deserialize;
 use tracing::debug;
 
 use crate::{
     error::ScyllaError,
     rule_structs::{ClientId, Rule, RuleId, RuleManager, RulesResponse},
 };
+
+#[derive(Deserialize)]
+pub struct SubscribeRulesRequest {
+    rule_ids: Vec<String>,
+    client_id: String,
+}
 
 #[debug_handler]
 pub async fn add_rule(
@@ -71,4 +78,26 @@ pub async fn get_all_rules_with_client_info(
             .get_all_rules_with_subscription_status(ClientId(client_id))
             .await,
     ))
+}
+
+#[debug_handler]
+pub async fn subscribe_rules(
+    Extension(rules_manager): Extension<Arc<RuleManager>>,
+    Json(request): Json<SubscribeRulesRequest>,
+) -> Result<Json<String>, ScyllaError> {
+    debug!(
+        "Subscribing client {} to {} rules",
+        request.client_id,
+        request.rule_ids.len()
+    );
+
+    let rule_ids: Vec<RuleId> = request.rule_ids.into_iter().map(RuleId).collect();
+
+    match rules_manager
+        .subscribe_rules(ClientId(request.client_id), rule_ids)
+        .await
+    {
+        Ok(_) => Ok(Json::from("Successfully subscribed to rules".to_owned())),
+        Err(err) => Err(ScyllaError::RuleError(err)),
+    }
 }

--- a/scylla-server/src/main.rs
+++ b/scylla-server/src/main.rs
@@ -25,7 +25,9 @@ use scylla_server::{
         self,
         car_command_controller::{self},
         data_type_controller, file_insertion_controller,
-        rule_controller::{add_rule, delete_rule, get_all_rules, get_all_rules_with_client_info},
+        rule_controller::{
+            add_rule, delete_rule, get_all_rules, get_all_rules_with_client_info, subscribe_rules,
+        },
         run_controller, scylla_config_controller,
         video_streamer_controller::{self},
         OutputDirectory, VideoSuffix,
@@ -408,6 +410,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .route("/rules/delete/{rule_id}", post(delete_rule))
                 .route("/rules", get(get_all_rules))
                 .route("/rules/{client_id}", get(get_all_rules_with_client_info))
+                .route("/rules/subscribe", post(subscribe_rules))
                 //.route("/rules/delete/{rule_id}", post()).route("/rules/poll")
                 .layer(Extension(rules_manager)),
         )

--- a/scylla-server/src/rule_structs.rs
+++ b/scylla-server/src/rule_structs.rs
@@ -14,7 +14,6 @@ use std::borrow::Borrow;
 use std::hash::Hash;
 use std::time::Duration;
 use tokio::sync::RwLock;
-use tracing::trace;
 use tracing::warn;
 
 use crate::rule_structs::BiMapRemoveResult::*;
@@ -529,5 +528,30 @@ impl RuleManager {
 
     pub async fn get_all_clients(&self) -> Vec<ClientId> {
         self.subscriptions.read().await.lefts()
+    }
+
+    /// Subscribe a client to multiple existing rules
+    pub async fn subscribe_rules(
+        &self,
+        client_id: ClientId,
+        rule_ids: Vec<RuleId>,
+    ) -> Result<(), RuleManagerError> {
+        let rules_guard = self.rules.read().await;
+
+        // First, verify all rules exist
+        for rule_id in &rule_ids {
+            if !rules_guard.contains_key(rule_id) {
+                return Err(RuleManagerError::NoMatchingRule);
+            }
+        }
+        drop(rules_guard);
+
+        // Now subscribe to all rules
+        let mut subscriptions = self.subscriptions.write().await;
+        for rule_id in rule_ids {
+            subscriptions.insert(&client_id, &rule_id);
+        }
+
+        Ok(())
     }
 }

--- a/scylla-server/tests/rule_structs_test.rs
+++ b/scylla-server/tests/rule_structs_test.rs
@@ -586,7 +586,9 @@ async fn test_subscribe_rules_success() -> Result<(), RuleManagerError> {
         RuleId("rule_3".to_string()),
     ];
 
-    rule_manager.subscribe_rules(client2.clone(), rule_ids).await?;
+    rule_manager
+        .subscribe_rules(client2.clone(), rule_ids)
+        .await?;
 
     // Verify client2 is now subscribed
     let clients = rule_manager.get_all_clients().await;
@@ -666,7 +668,9 @@ async fn test_subscribe_rules_concurrent() -> Result<(), RuleManagerError> {
     }
 
     // Prepare all rule IDs
-    let all_rule_ids: Vec<RuleId> = (0..num_rules).map(|i| RuleId(format!("rule_{}", i))).collect();
+    let all_rule_ids: Vec<RuleId> = (0..num_rules)
+        .map(|i| RuleId(format!("rule_{}", i)))
+        .collect();
 
     // Concurrently subscribe multiple clients to all rules
     let results: Vec<_> = (0..num_clients)

--- a/scylla-server/tests/rule_structs_test.rs
+++ b/scylla-server/tests/rule_structs_test.rs
@@ -542,3 +542,155 @@ async fn test_concurrent_high_frequency_messages() -> Result<(), RuleManagerErro
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_subscribe_rules_success() -> Result<(), RuleManagerError> {
+    let rule_manager = RuleManager::new();
+    let client1 = ClientId("client1".to_string());
+    let client2 = ClientId("client2".to_string());
+
+    // Create rules via client1
+    let rule1 = Rule::new(
+        RuleId("rule_1".to_string()),
+        Topic("topic/1".to_string()),
+        core::time::Duration::from_secs(60),
+        "a > 10".to_owned(),
+    );
+
+    let rule2 = Rule::new(
+        RuleId("rule_2".to_string()),
+        Topic("topic/2".to_string()),
+        core::time::Duration::from_secs(30),
+        "b < 5".to_owned(),
+    );
+
+    let rule3 = Rule::new(
+        RuleId("rule_3".to_string()),
+        Topic("topic/3".to_string()),
+        core::time::Duration::from_secs(45),
+        "c == 7".to_owned(),
+    );
+
+    rule_manager.add_rule(client1.clone(), rule1).await?;
+    rule_manager.add_rule(client1.clone(), rule2).await?;
+    rule_manager.add_rule(client1.clone(), rule3).await?;
+
+    // Verify initial state
+    assert_eq!(rule_manager.get_all_rules().await.len(), 3);
+    assert_eq!(rule_manager.get_all_clients().await.len(), 1);
+
+    // Subscribe client2 to multiple rules
+    let rule_ids = vec![
+        RuleId("rule_1".to_string()),
+        RuleId("rule_2".to_string()),
+        RuleId("rule_3".to_string()),
+    ];
+
+    rule_manager.subscribe_rules(client2.clone(), rule_ids).await?;
+
+    // Verify client2 is now subscribed
+    let clients = rule_manager.get_all_clients().await;
+    assert_eq!(clients.len(), 2);
+    assert!(clients.contains(&client1));
+    assert!(clients.contains(&client2));
+
+    // Verify rules still exist
+    assert_eq!(rule_manager.get_all_rules().await.len(), 3);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_subscribe_rules_nonexistent_rule() -> Result<(), RuleManagerError> {
+    let rule_manager = RuleManager::new();
+    let client = ClientId("test_client".to_string());
+
+    let rule = Rule::new(
+        RuleId("rule_1".to_string()),
+        Topic("topic/1".to_string()),
+        core::time::Duration::from_secs(60),
+        "a > 10".to_owned(),
+    );
+
+    rule_manager.add_rule(client.clone(), rule).await?;
+
+    // Try to subscribe to a mix of existing and non-existing rules
+    let rule_ids = vec![
+        RuleId("rule_1".to_string()),
+        RuleId("nonexistent_rule".to_string()),
+    ];
+
+    let client2 = ClientId("client2".to_string());
+    let result = rule_manager.subscribe_rules(client2, rule_ids).await;
+
+    // Should fail because one rule doesn't exist
+    assert!(result.is_err());
+
+    // Verify client2 was not added (transaction-like behavior)
+    assert_eq!(rule_manager.get_all_clients().await.len(), 1);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_subscribe_rules_empty_list() -> Result<(), RuleManagerError> {
+    let rule_manager = RuleManager::new();
+    let client = ClientId("test_client".to_string());
+
+    // Subscribe to empty list of rules (should succeed, doing nothing)
+    let rule_ids = vec![];
+    let result = rule_manager.subscribe_rules(client.clone(), rule_ids).await;
+
+    assert!(result.is_ok());
+    assert_eq!(rule_manager.get_all_clients().await.len(), 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_subscribe_rules_concurrent() -> Result<(), RuleManagerError> {
+    let num_rules = 10;
+    let num_clients = 5;
+    let rule_manager = std::sync::Arc::new(RuleManager::new());
+
+    // Create rules using one client
+    let initial_client = ClientId("initial_client".to_string());
+    for i in 0..num_rules {
+        let rule = Rule::new(
+            RuleId(format!("rule_{}", i)),
+            Topic(format!("topic/{}", i)),
+            core::time::Duration::from_secs(60),
+            "a > 5".to_owned(),
+        );
+        rule_manager.add_rule(initial_client.clone(), rule).await?;
+    }
+
+    // Prepare all rule IDs
+    let all_rule_ids: Vec<RuleId> = (0..num_rules).map(|i| RuleId(format!("rule_{}", i))).collect();
+
+    // Concurrently subscribe multiple clients to all rules
+    let results: Vec<_> = (0..num_clients)
+        .fold(JoinSet::new(), |mut set, i| {
+            let rm = rule_manager.clone();
+            let rule_ids = all_rule_ids.clone();
+            set.spawn(async move {
+                let client = ClientId(format!("client_{}", i));
+                rm.subscribe_rules(client, rule_ids).await
+            });
+            set
+        })
+        .join_all()
+        .await;
+
+    // Verify all operations succeeded
+    assert!(results.iter().all(|r| r.is_ok()));
+
+    // Verify all clients were added (including initial client)
+    let clients = rule_manager.get_all_clients().await;
+    assert_eq!(clients.len(), num_clients + 1); // +1 for initial_client
+
+    // Verify rules still exist
+    assert_eq!(rule_manager.get_all_rules().await.len(), num_rules);
+
+    Ok(())
+}


### PR DESCRIPTION
## Changes

Added `POST /rules/subscribe` endpoint for batch rule subscription. Takes `rule_ids` and `client_id` in request body.

Implementation validates all rules exist before subscribing to any (atomic behavior). O(n) time complexity as specified.

## Test Cases

- Success case with multiple rules
- Error handling for nonexistent rules
- Empty list edge case
- Concurrent subscription stress test

All tests pass.

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (see below)

Closes #497
