### PR TITLE
#575 Add extra decimal place to BMS average voltage

### DIFF
--- a/angular-client/src/app/app-nav-bar/app-nav-bar.component.ts
+++ b/angular-client/src/app/app-nav-bar/app-nav-bar.component.ts
@@ -143,14 +143,7 @@ export class AppNavBarComponent implements OnInit, OnDestroy {
       onClick: () => this.navigateTo(appRoutes.graphRoute()),
       icon: 'bar_chart'
     },
-    { id: appRoutes.faultsRoute(), label: 'Fault', onClick: () => this.navigateTo(appRoutes.faultsRoute()), icon: 'error' },
-    { id: appRoutes.bmsRoute(), label: 'BMS', onClick: () => this.navigateTo(appRoutes.bmsRoute()), icon: 'action_key' },
-    {
-      id: appRoutes.efusesRoute(),
-      label: 'eFuses',
-      onClick: () => this.navigateTo(appRoutes.efusesRoute()),
-      icon: 'electrical_services'
-    }
+    { id: appRoutes.bmsRoute(), label: 'BMS', onClick: () => this.navigateTo(appRoutes.bmsRoute()), icon: 'action_key' }
   ];
 
   onlyDesktopNavItems: NavItem[] = [...this.mostUsedNavItems];
@@ -166,6 +159,18 @@ export class AppNavBarComponent implements OnInit, OnDestroy {
 
   allNavItems: NavItem[] = [this.homeNavItem, ...this.mostUsedNavItems];
   navMenuItems: NavItem[] = [
+    {
+      id: appRoutes.faultsRoute(),
+      label: 'Fault',
+      onClick: () => this.navigateTo(appRoutes.faultsRoute()),
+      icon: 'error'
+    },
+    {
+      id: appRoutes.efusesRoute(),
+      label: 'eFuses',
+      onClick: () => this.navigateTo(appRoutes.efusesRoute()),
+      icon: 'electrical_services'
+    },
     {
       id: appRoutes.mapRoute(),
       label: 'Map',

--- a/angular-client/src/app/app-nav-bar/app-nav-bar.component.ts
+++ b/angular-client/src/app/app-nav-bar/app-nav-bar.component.ts
@@ -157,7 +157,6 @@ export class AppNavBarComponent implements OnInit, OnDestroy {
     }
   }
 
-  allNavItems: NavItem[] = [this.homeNavItem, ...this.mostUsedNavItems];
   navMenuItems: NavItem[] = [
     {
       id: appRoutes.faultsRoute(),
@@ -196,6 +195,8 @@ export class AppNavBarComponent implements OnInit, OnDestroy {
       icon: 'electrical_services'
     }
   ];
+
+  allNavItems: NavItem[] = [this.homeNavItem, ...this.mostUsedNavItems, ...this.navMenuItems];
 
   openMenu() {
     this.menuRef = this.dialogService.open(NavOptionsMenuComponent, {

--- a/angular-client/src/components/stat-display-list/stat-display-list.component.css
+++ b/angular-client/src/components/stat-display-list/stat-display-list.component.css
@@ -5,17 +5,8 @@
 .stat-display-list {
   display: flex;
   align-items: stretch;
-  justify-content: space-evenly;
   min-height: 0;
   padding: 0;
   gap: 0;
   margin-top: -12px;
-}
-
-.divider {
-  width: 2px;
-  align-self: center;
-  height: 70px;
-  background-color: var(--color-divider);
-  flex-shrink: 0;
 }

--- a/angular-client/src/components/stat-display-list/stat-display-list.component.html
+++ b/angular-client/src/components/stat-display-list/stat-display-list.component.html
@@ -1,34 +1,3 @@
 <div class="stat-display-list">
-  @for (statConfig of this.configs(); track statConfig.key; let last = $last) {
-    <stat-display
-      [value]="statConfig.value"
-      [unit]="statConfig.unit"
-      [subtitle]="statConfig.subtitle"
-      [precision]="statConfig.precision ?? 1"
-      [unitBelow]="statConfig.unitBelow ?? false"
-      [headerLabel]="statConfig.headerLabel ?? ''"
-      [headerIcon]="statConfig.headerIcon ?? ''"
-    >
-      @if (this.enableWidgets() && statConfig.widget?.type === 'connection-dot') {
-        <connection-dot-with-message
-          [getStatusColor]="statConfig.widget?.getStatusColor ?? this.defaultStatusColor"
-          style="margin-left: 5px"
-        />
-      }
-      @if (this.enableWidgets() && statConfig.widget?.type === 'thermometer') {
-        <glance-thermometer
-          [temperature]="statConfig.widget?.value ?? statConfig.value ?? 0"
-          [min]="statConfig.widget?.min ?? -15"
-          [max]="statConfig.widget?.max ?? 30"
-        />
-      }
-      @if (this.enableWidgets() && statConfig.widget?.type === 'battery-level-indicator') {
-        <battery-level-indicator [percentage]="statConfig.widget?.value ?? statConfig.value ?? 0"></battery-level-indicator>
-      }
-    </stat-display>
-
-    @if (!last) {
-      <div class="divider"></div>
-    }
-  }
+  <ng-content />
 </div>

--- a/angular-client/src/components/stat-display-list/stat-display-list.component.ts
+++ b/angular-client/src/components/stat-display-list/stat-display-list.component.ts
@@ -1,48 +1,9 @@
-import { Component, input } from '@angular/core';
-import { BatteryLevelIndicatorComponent } from '../battery-level-indicator/battery-level-indicator.component';
-import { ConnectionDotWithMessageComponent } from '../connection-dot-with-message/connection-dot-with-message.component';
-import { GlanceThermometerComponent } from '../glance-thermometer/glance-thermometer.component';
-import { StatDisplayComponent } from '../stat-display/stat-display.component';
-
-export type StatDisplayWidgetType = 'connection-dot' | 'thermometer' | 'battery-level-indicator';
-
-export interface StatDisplayWidgetConfig {
-  type: StatDisplayWidgetType;
-  min?: number;
-  max?: number;
-  value?: number;
-  getStatusColor?: () => string;
-}
-
-export interface StatDisplayListConfig {
-  key: string;
-  value: number | undefined;
-  unit: string;
-  subtitle: string;
-  precision?: number;
-  unitBelow?: boolean;
-  headerLabel?: string;
-  headerIcon?: string;
-  widget?: StatDisplayWidgetConfig;
-}
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 @Component({
   selector: 'stat-display-list',
   templateUrl: './stat-display-list.component.html',
   styleUrl: './stat-display-list.component.css',
-  standalone: true,
-  imports: [
-    StatDisplayComponent,
-    ConnectionDotWithMessageComponent,
-    GlanceThermometerComponent,
-    BatteryLevelIndicatorComponent
-  ]
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class StatDisplayListComponent {
-  configs = input<StatDisplayListConfig[]>([]);
-  enableWidgets = input<boolean>(true);
-
-  defaultStatusColor = (): string => {
-    return 'var(--color-text-subtitle)';
-  };
-}
+export class StatDisplayListComponent {}

--- a/angular-client/src/components/stat-display/stat-display.component.css
+++ b/angular-client/src/components/stat-display/stat-display.component.css
@@ -3,7 +3,8 @@
   flex-direction: column;
   align-items: center;
   justify-content: flex-end;
-  flex-shrink: 0;
+  flex: 1 1 0;
+  min-width: 0;
 }
 
 /* ---- Header row (Cell/Chip label) ---- */

--- a/angular-client/src/components/stat-display/stat-display.component.html
+++ b/angular-client/src/components/stat-display/stat-display.component.html
@@ -8,8 +8,11 @@
 }
 
 <div class="value-row">
-  <span class="value">{{ formattedValue }}</span>
+  <span class="value">{{ formattedValue() }}</span>
   <span class="unit" [class.unit-below]="unitBelow()">{{ unit() }}</span>
+  @if (connectionDotStatusColor(); as statusColor) {
+    <connection-dot-with-message [getStatusColor]="statusColor" style="margin-left: 5px" />
+  }
   <ng-content />
 </div>
 

--- a/angular-client/src/components/stat-display/stat-display.component.ts
+++ b/angular-client/src/components/stat-display/stat-display.component.ts
@@ -1,37 +1,30 @@
-import { Component, input, OnChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import { MatIcon } from '@angular/material/icon';
+import { ConnectionDotWithMessageComponent } from '../connection-dot-with-message/connection-dot-with-message.component';
 
-/**
- * Lightweight stat display component designed for the At A Glance bar.
- * Renders value + unit + subtitle with optional header label and widget slot.
- * Uses pure CSS — no nested hstack/vstack/typography wrappers.
- */
 @Component({
   selector: 'stat-display',
   templateUrl: './stat-display.component.html',
   styleUrl: './stat-display.component.css',
-  standalone: true,
-  imports: [MatIcon],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [MatIcon, ConnectionDotWithMessageComponent],
   host: {
     '[class.unit-below-mode]': 'unitBelow()'
   }
 })
-export class StatDisplayComponent implements OnChanges {
+export class StatDisplayComponent {
   value = input<number>();
   unit = input<string>('');
   subtitle = input<string>('');
   precision = input<number>(1);
-  /** Optional header label (e.g. "Cell: 114 | Chip: A") */
   headerLabel = input<string>('');
-  /** SVG icon name to show in header (registered via matIconRegistry) */
   headerIcon = input<string>('');
-  /** When true, render the unit below the value instead of inline */
   unitBelow = input<boolean>(false);
+  connectionDotStatusColor = input<() => string>();
 
-  formattedValue = '-';
-
-  ngOnChanges(): void {
+  formattedValue = computed(() => {
     const val = this.value();
-    this.formattedValue = (val?.toFixed(this.precision()) ?? '-') + (this.unit() === 'C' ? '°' : '');
-  }
+    if (!Number.isFinite(val)) return '-';
+    return val!.toFixed(this.precision()) + (this.unit() === 'C' ? '°' : '');
+  });
 }

--- a/angular-client/src/pages/bms-debug-page/bms-debug-page.component.html
+++ b/angular-client/src/pages/bms-debug-page/bms-debug-page.component.html
@@ -4,7 +4,7 @@
   } @else {
     <mat-grid-list cols="6" gutterSize="15px" rowHeight="1.5rem" style="margin-top: -20px">
       <mat-grid-tile [colspan]="6" rowspan="3">
-        <bms-header style="width: 100%" [pageTitle]="this.windowSize < 1200 ? 'ACCU' : 'Accumulator'" />
+        <bms-header style="width: 100%" [pageTitle]="this.windowSize < 1300 ? 'ACCU' : 'Accumulator'" />
       </mat-grid-tile>
       <mat-grid-tile [colspan]="6" rowspan="3">
         <bms-at-a-glance style="height: 100%; width: 100%" />

--- a/angular-client/src/pages/bms-debug-page/components/bms-at-a-glance/bms-at-a-glance.component.css
+++ b/angular-client/src/pages/bms-debug-page/components/bms-at-a-glance/bms-at-a-glance.component.css
@@ -1,3 +1,11 @@
 :host {
   display: block;
 }
+
+.stat-divider {
+  width: 2px;
+  height: 70px;
+  align-self: center;
+  background-color: var(--color-divider);
+  flex-shrink: 0;
+}

--- a/angular-client/src/pages/bms-debug-page/components/bms-at-a-glance/bms-at-a-glance.component.html
+++ b/angular-client/src/pages/bms-debug-page/components/bms-at-a-glance/bms-at-a-glance.component.html
@@ -1,3 +1,61 @@
 <info-panel title="At A Glance" svgIcon="battery_charging_2" padding="6px 20px 14px">
-  <stat-display-list [configs]="this.statDisplayConfigs" [enableWidgets]="this.enableWidgets"></stat-display-list>
+  <stat-display-list>
+    <stat-display
+      [value]="packVoltage()"
+      unit="V"
+      subtitle="Pack Voltage"
+      [connectionDotStatusColor]="enableWidgets() ? getPackVoltageStatusColor : undefined"
+    />
+    <div class="stat-divider"></div>
+
+    <stat-display [value]="packTemp()" unit="C" subtitle="Average Temp." [unitBelow]="true">
+      @if (enableWidgets()) {
+        <glance-thermometer [temperature]="packTemp() ?? 0" [min]="-15" [max]="30" />
+      }
+    </stat-display>
+    <div class="stat-divider"></div>
+
+    <stat-display [value]="chargeState()" unit="%" subtitle="Charge State" [unitBelow]="true">
+      @if (enableWidgets()) {
+        <battery-level-indicator [percentage]="chargeState() ?? 0" />
+      }
+    </stat-display>
+    <div class="stat-divider"></div>
+
+    <stat-display [value]="ccl()" unit="A" subtitle="CCL" />
+    <div class="stat-divider"></div>
+
+    <stat-display [value]="dcl()" unit="A" subtitle="DCL" />
+    <div class="stat-divider"></div>
+
+    <stat-display
+      [value]="highVoltsValue()"
+      unit="V"
+      [precision]="3"
+      subtitle="High Voltage"
+      headerIcon="battery"
+      [headerLabel]="highVoltsLabel()"
+    />
+    <div class="stat-divider"></div>
+
+    <stat-display
+      [value]="lowVoltsValue()"
+      unit="V"
+      [precision]="3"
+      subtitle="Low Voltage"
+      headerIcon="battery"
+      [headerLabel]="lowVoltsLabel()"
+    />
+    <div class="stat-divider"></div>
+
+    <stat-display
+      [value]="highTempValue()"
+      unit="C"
+      [precision]="2"
+      subtitle="High Temp."
+      [unitBelow]="true"
+      headerIcon="battery"
+      [headerLabel]="highTempLabel()"
+    />
+  </stat-display-list>
 </info-panel>

--- a/angular-client/src/pages/bms-debug-page/components/bms-at-a-glance/bms-at-a-glance.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/bms-at-a-glance/bms-at-a-glance.component.ts
@@ -43,7 +43,6 @@ export class BmsAtAGlanceComponent implements OnInit, OnDestroy {
         key: 'pack-voltage',
         value: this.voltage,
         unit: 'V',
-        precision: 0,
         subtitle: 'Pack Voltage',
         widget: { type: 'connection-dot', getStatusColor: this.getStatusColor }
       },

--- a/angular-client/src/pages/bms-debug-page/components/bms-at-a-glance/bms-at-a-glance.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/bms-at-a-glance/bms-at-a-glance.component.ts
@@ -1,174 +1,63 @@
-import { Component, HostListener, inject, OnDestroy, OnInit } from '@angular/core';
-import { Subscription } from 'rxjs';
+import { ChangeDetectionStrategy, Component, computed, HostListener, inject, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { map } from 'rxjs';
 import Storage from 'src/services/storage.service';
-import { Chip, chipToString, getConnectionDotStatusColor } from 'src/utils/bms.utils';
+import { getCellChipLabel, getChipFromTopicValue, getConnectionDotStatusColor } from 'src/utils/bms.utils';
 import { topics } from 'src/utils/topic.utils';
+import { BatteryLevelIndicatorComponent } from '../../../../components/battery-level-indicator/battery-level-indicator.component';
+import { GlanceThermometerComponent } from '../../../../components/glance-thermometer/glance-thermometer.component';
 import { InfoPanelComponent } from '../../../../components/info-panel/info-panel.component';
-import {
-  StatDisplayListComponent,
-  StatDisplayListConfig
-} from '../../../../components/stat-display-list/stat-display-list.component';
+import { StatDisplayListComponent } from '../../../../components/stat-display-list/stat-display-list.component';
+import { StatDisplayComponent } from '../../../../components/stat-display/stat-display.component';
 
 @Component({
   selector: 'bms-at-a-glance',
   templateUrl: './bms-at-a-glance.component.html',
   styleUrl: './bms-at-a-glance.component.css',
-  standalone: true,
-  imports: [InfoPanelComponent, StatDisplayListComponent]
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    InfoPanelComponent,
+    StatDisplayListComponent,
+    StatDisplayComponent,
+    GlanceThermometerComponent,
+    BatteryLevelIndicatorComponent
+  ]
 })
-export class BmsAtAGlanceComponent implements OnInit, OnDestroy {
+export class BmsAtAGlanceComponent {
   private storage = inject(Storage);
-  private subscriptions: Subscription[] = [];
-  voltage: number = 0;
-  temperature: number = 0;
-  chargeState: number = 0;
-  ccl: number = 0;
-  dcl: number = 0;
-  highVoltage: number | undefined = undefined;
-  highVoltageChip: Chip | undefined = undefined;
-  highVoltageCell: number | undefined = undefined;
-  lowVoltage: number | undefined = undefined;
-  lowVoltageChip: Chip | undefined = undefined;
-  lowVoltageCell: number | undefined = undefined;
-  highTemp: number | undefined = undefined;
-  highTempChip: Chip | undefined = undefined;
-  highTempCell: number | undefined = undefined;
-  getStatusColor = (): string => {
-    return getConnectionDotStatusColor(this.voltage);
-  };
 
-  get statDisplayConfigs(): StatDisplayListConfig[] {
-    return [
-      {
-        key: 'pack-voltage',
-        value: this.voltage,
-        unit: 'V',
-        subtitle: 'Pack Voltage',
-        widget: { type: 'connection-dot', getStatusColor: this.getStatusColor }
-      },
-      {
-        key: 'pack-temp',
-        value: this.temperature,
-        unit: 'C',
-        subtitle: 'Average Temp.',
-        unitBelow: true,
-        widget: { type: 'thermometer', value: this.temperature, min: -15, max: 30 }
-      },
-      {
-        key: 'charge-state',
-        value: this.chargeState,
-        unit: '%',
-        subtitle: 'Charge State',
-        unitBelow: true,
-        widget: { type: 'battery-level-indicator', value: this.chargeState }
-      },
-      {
-        key: 'ccl',
-        value: this.ccl,
-        unit: 'A',
-        subtitle: 'CCL'
-      },
-      {
-        key: 'dcl',
-        value: this.dcl,
-        unit: 'A',
-        subtitle: 'DCL'
-      },
-      {
-        key: 'high-voltage',
-        value: this.highVoltage,
-        unit: 'V',
-        precision: 3,
-        subtitle: 'High Voltage',
-        headerLabel: this.getCellChipLabel(this.highVoltageCell, this.highVoltageChip),
-        headerIcon: 'battery'
-      },
-      {
-        key: 'low-voltage',
-        value: this.lowVoltage,
-        unit: 'V',
-        precision: 3,
-        subtitle: 'Low Voltage',
-        headerLabel: this.getCellChipLabel(this.lowVoltageCell, this.lowVoltageChip),
-        headerIcon: 'battery'
-      },
-      {
-        key: 'high-temp',
-        value: this.highTemp,
-        unit: 'C',
-        precision: 2,
-        subtitle: 'High Temp.',
-        unitBelow: true,
-        headerLabel: this.getCellChipLabel(this.highTempCell, this.highTempChip),
-        headerIcon: 'battery'
-      }
-    ];
-  }
+  protected packVoltage = toSignal(this.storage.get(topics.packVoltage()).pipe(map((v) => parseFloat(v.values[0]))));
+  protected packTemp = toSignal(this.storage.get(topics.packTemp()).pipe(map((v) => parseInt(v.values[0]))));
+  protected chargeState = toSignal(this.storage.get(topics.stateOfCharge()).pipe(map((v) => parseInt(v.values[0]))));
+  protected ccl = toSignal(this.storage.get(topics.accCCL()).pipe(map((v) => parseInt(v.values[0]))));
+  protected dcl = toSignal(this.storage.get(topics.accDCL()).pipe(map((v) => parseInt(v.values[0]))));
 
-  enableWidgets = window.innerWidth >= 1000;
+  protected highVoltsValue = toSignal(this.storage.get(topics.highVoltsValue()).pipe(map((v) => parseFloat(v.values[0]))));
+  private highVoltsChip = toSignal(
+    this.storage.get(topics.highVoltsChip()).pipe(map((v) => getChipFromTopicValue(parseInt(v.values[0]))))
+  );
+  private highVoltsCell = toSignal(this.storage.get(topics.highVoltsCell()).pipe(map((v) => parseInt(v.values[0]))));
+  protected highVoltsLabel = computed(() => getCellChipLabel(this.highVoltsCell(), this.highVoltsChip()));
+
+  protected lowVoltsValue = toSignal(this.storage.get(topics.lowVoltsValue()).pipe(map((v) => parseFloat(v.values[0]))));
+  private lowVoltsChip = toSignal(
+    this.storage.get(topics.lowVoltsChip()).pipe(map((v) => getChipFromTopicValue(parseInt(v.values[0]))))
+  );
+  private lowVoltsCell = toSignal(this.storage.get(topics.lowVoltsCell()).pipe(map((v) => parseInt(v.values[0]))));
+  protected lowVoltsLabel = computed(() => getCellChipLabel(this.lowVoltsCell(), this.lowVoltsChip()));
+
+  protected highTempValue = toSignal(this.storage.get(topics.highTempValue()).pipe(map((v) => parseFloat(v.values[0]))));
+  private highTempChip = toSignal(
+    this.storage.get(topics.highTempChip()).pipe(map((v) => getChipFromTopicValue(parseInt(v.values[0]))))
+  );
+  private highTempCell = toSignal(this.storage.get(topics.highTempCell()).pipe(map((v) => parseInt(v.values[0]))));
+  protected highTempLabel = computed(() => getCellChipLabel(this.highTempCell(), this.highTempChip()));
+
+  protected enableWidgets = signal(window.innerWidth >= 1000);
+  protected getPackVoltageStatusColor = () => getConnectionDotStatusColor(this.packVoltage() ?? 0);
+
   @HostListener('window:resize')
   onResize() {
-    this.enableWidgets = window.innerWidth >= 1000;
+    this.enableWidgets.set(window.innerWidth >= 1000);
   }
-
-  ngOnInit(): void {
-    this.subscriptions.push(
-      this.storage.get(topics.packVoltage()).subscribe((value) => {
-        this.voltage = parseFloat(value.values[0]);
-      }),
-      this.storage.get(topics.packTemp()).subscribe((value) => {
-        this.temperature = parseInt(value.values[0]);
-      }),
-      this.storage.get(topics.stateOfCharge()).subscribe((value) => {
-        this.chargeState = parseInt(value.values[0]);
-      }),
-      this.storage.get(topics.accCCL()).subscribe((value) => {
-        this.ccl = parseInt(value.values[0]);
-      }),
-      this.storage.get(topics.accDCL()).subscribe((value) => {
-        this.dcl = parseInt(value.values[0]);
-      }),
-      this.storage.get(topics.highVoltsValue()).subscribe((value) => {
-        this.highVoltage = parseFloat(value.values[0]);
-      }),
-      this.storage.get(topics.highVoltsChip()).subscribe((value) => {
-        this.highVoltageChip = this.getChipFromTopicValue(parseInt(value.values[0]));
-      }),
-      this.storage.get(topics.highVoltsCell()).subscribe((value) => {
-        this.highVoltageCell = parseInt(value.values[0]);
-      }),
-      this.storage.get(topics.lowVoltsValue()).subscribe((value) => {
-        this.lowVoltage = parseFloat(value.values[0]);
-      }),
-      this.storage.get(topics.lowVoltsChip()).subscribe((value) => {
-        this.lowVoltageChip = this.getChipFromTopicValue(parseInt(value.values[0]));
-      }),
-      this.storage.get(topics.lowVoltsCell()).subscribe((value) => {
-        this.lowVoltageCell = parseInt(value.values[0]);
-      }),
-      this.storage.get(topics.highTempValue()).subscribe((value) => {
-        this.highTemp = parseFloat(value.values[0]);
-      }),
-      this.storage.get(topics.highTempChip()).subscribe((value) => {
-        this.highTempChip = this.getChipFromTopicValue(parseInt(value.values[0]));
-      }),
-      this.storage.get(topics.highTempCell()).subscribe((value) => {
-        this.highTempCell = parseInt(value.values[0]);
-      })
-    );
-  }
-
-  ngOnDestroy(): void {
-    this.subscriptions.forEach((sub) => sub.unsubscribe());
-  }
-
-  getCellChipLabel = (cell: number | undefined, chip: Chip | undefined): string => {
-    const cellLabel = cell !== undefined ? `Cell: ${cell}` : 'No Cell';
-    const chipLabel = chip !== undefined ? `Chip: ${chipToString(chip, true)}` : 'No Chip';
-    return `${cellLabel} | ${chipLabel}`;
-  };
-
-  private getChipFromTopicValue = (chipValue: number): Chip => {
-    return chipValue % 2 === 0 ? Chip.Alpha : Chip.Beta;
-  };
 }

--- a/angular-client/src/pages/bms-debug-page/components/bms-at-a-glance/bms-at-a-glance.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/bms-at-a-glance/bms-at-a-glance.component.ts
@@ -43,6 +43,7 @@ export class BmsAtAGlanceComponent implements OnInit, OnDestroy {
         key: 'pack-voltage',
         value: this.voltage,
         unit: 'V',
+        precision: 2,
         subtitle: 'Average Voltage',
         widget: { type: 'connection-dot', getStatusColor: this.getStatusColor }
       },

--- a/angular-client/src/pages/bms-debug-page/components/bms-at-a-glance/bms-at-a-glance.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/bms-at-a-glance/bms-at-a-glance.component.ts
@@ -43,8 +43,8 @@ export class BmsAtAGlanceComponent implements OnInit, OnDestroy {
         key: 'pack-voltage',
         value: this.voltage,
         unit: 'V',
-        precision: 2,
-        subtitle: 'Average Voltage',
+        precision: 0,
+        subtitle: 'Pack Voltage',
         widget: { type: 'connection-dot', getStatusColor: this.getStatusColor }
       },
       {

--- a/angular-client/src/pages/bms-debug-page/components/bms-at-a-glance/bms-at-a-glance.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/bms-at-a-glance/bms-at-a-glance.component.ts
@@ -114,7 +114,7 @@ export class BmsAtAGlanceComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.subscriptions.push(
       this.storage.get(topics.packVoltage()).subscribe((value) => {
-        this.voltage = parseInt(value.values[0]);
+        this.voltage = parseFloat(value.values[0]);
       }),
       this.storage.get(topics.packTemp()).subscribe((value) => {
         this.temperature = parseInt(value.values[0]);

--- a/angular-client/src/pages/bms-debug-page/components/segment-at-a-glance/segment-at-a-glance.component.html
+++ b/angular-client/src/pages/bms-debug-page/components/segment-at-a-glance/segment-at-a-glance.component.html
@@ -5,7 +5,7 @@
       [value]="this.voltage"
       unit="V"
       [precision]="2"
-      subtitle="Average Voltage"
+      subtitle="Avg Voltage"
       [widget]="this.connectionDotConfig"
       [enableWidget]="this.enableWidgets"
     />

--- a/angular-client/src/pages/bms-debug-page/components/segment-at-a-glance/segment-at-a-glance.component.html
+++ b/angular-client/src/pages/bms-debug-page/components/segment-at-a-glance/segment-at-a-glance.component.html
@@ -4,6 +4,7 @@
     <info-value-display
       [value]="this.voltage"
       unit="V"
+      [precision]="2"
       subtitle="Average Voltage"
       [widget]="this.connectionDotConfig"
       [enableWidget]="this.enableWidgets"

--- a/angular-client/src/pages/bms-debug-page/components/segment-at-a-glance/segment-at-a-glance.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/segment-at-a-glance/segment-at-a-glance.component.ts
@@ -64,6 +64,9 @@ export class SegmentAtAGlanceComponent implements OnDestroy {
 
   subscribeToData = (segment: number) => {
     this.valueSubscriptions.push(
+      this.storage.get(topics.segmentVoltage(segment)).subscribe((value) => {
+        this.voltage = parseFloat(value.values[0]);
+      }),
       this.storage.get(topics.segmentTemp(segment)).subscribe((value) => {
         this.temperature = parseFloat(value.values[0]);
         this.thermometerConfigSegment.currentValue = this.temperature;

--- a/angular-client/src/pages/bms-debug-page/components/segment-at-a-glance/segment-at-a-glance.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/segment-at-a-glance/segment-at-a-glance.component.ts
@@ -2,7 +2,7 @@ import { Component, effect, HostListener, inject, input, OnDestroy } from '@angu
 import { Subscription } from 'rxjs';
 import { ConnectionDotConfig, ThermometerConfig } from 'src/components/info-value-dispaly/info-value-display.component';
 import Storage from 'src/services/storage.service';
-import { Chip, getConnectionDotStatusColor, Segment } from 'src/utils/bms.utils';
+import { Chip, getCellVoltageStatusColor, Segment } from 'src/utils/bms.utils';
 import { topics } from 'src/utils/topic.utils';
 import { InfoBackgroundComponent } from '../../../../components/info-background/info-background.component';
 
@@ -16,7 +16,6 @@ import HStackComponent from 'src/components/hstack/hstack.component';
   selector: 'segment-at-a-glance',
   templateUrl: './segment-at-a-glance.component.html',
   styleUrl: './segment-at-a-glance.component.css',
-  standalone: true,
   imports: [
     InfoBackgroundComponent,
     InfoValueDisplayComponent,
@@ -98,7 +97,7 @@ export class SegmentAtAGlanceComponent implements OnDestroy {
     return this.betaCrc === 0 ? 'green' : 'red';
   };
   getStatusColor = (): string => {
-    return getConnectionDotStatusColor(this.voltage);
+    return getCellVoltageStatusColor(this.voltage);
   };
   connectionDotConfig: ConnectionDotConfig = {
     type: 'connection-dot-config',

--- a/angular-client/src/pages/bms-debug-page/components/segment-overview/segment-overview.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/segment-overview/segment-overview.component.ts
@@ -6,7 +6,7 @@ import { StatConfig, StatSummaryComponent } from 'src/components/stat-summary/st
 
 const DEFAULT_SEGMENT_STATS: StatConfig[] = [
   { label: 'Avg Temp', unit: '°C', value: undefined, formatFn: (v) => v.toFixed(0) },
-  { label: 'Avg Voltage', unit: 'V', value: undefined, formatFn: (v) => v.toFixed(1) },
+  { label: 'Avg Voltage', unit: 'V', value: undefined, formatFn: (v) => v.toFixed(2) },
   { label: 'Total Voltage', unit: 'V', value: undefined, formatFn: (v) => v.toFixed(1) }
 ];
 

--- a/angular-client/src/pages/bms-debug-page/components/segment-summary/segment-summary.component.html
+++ b/angular-client/src/pages/bms-debug-page/components/segment-summary/segment-summary.component.html
@@ -3,7 +3,7 @@
     <info-value-display style="margin-top: 10px" [value]="this.temperature" unit="C" subtitle="Temperature" />
 
     <divider style="width: 100px; margin-top: 15px" />
-    <info-value-display style="margin-top: -5px" [value]="this.voltage" unit="V" subtitle="Voltages" />
+    <info-value-display style="margin-top: -5px" [value]="this.voltage" unit="V" [precision]="2" subtitle="Avg Voltage" />
     <divider style="width: 100px; margin-top: 25px" />
     <info-value-display style="margin-top: -5px" [value]="this.alphaChipTemp" unit="C" subtitle="Chip Temp" />
     <toast-button

--- a/angular-client/src/pages/charging-page/components/battery-info-display/battery-info-desktop/battery-info-desktop.component.html
+++ b/angular-client/src/pages/charging-page/components/battery-info-display/battery-info-desktop/battery-info-desktop.component.html
@@ -23,7 +23,7 @@
     <hstack>
       <typography variant="info-value" [content]="voltage.toString() + 'V'" />
     </hstack>
-    <typography variant="info-subtitle" content="Voltage" />
+    <typography variant="info-subtitle" content="Pack Voltage" />
   </vstack>
 
   <divider />

--- a/angular-client/src/pages/charging-page/components/battery-info-display/battery-info-desktop/battery-info-desktop.component.html
+++ b/angular-client/src/pages/charging-page/components/battery-info-display/battery-info-desktop/battery-info-desktop.component.html
@@ -21,7 +21,7 @@
   <divider />
   <vstack style="width: 20%">
     <hstack>
-      <typography variant="info-value" [content]="voltage.toString() + 'V'" />
+      <typography variant="info-value" [content]="voltage.toFixed(1) + 'V'" />
     </hstack>
     <typography variant="info-subtitle" content="Pack Voltage" />
   </vstack>

--- a/angular-client/src/pages/charging-page/components/battery-info-display/battery-info-display.ts
+++ b/angular-client/src/pages/charging-page/components/battery-info-display/battery-info-display.ts
@@ -31,7 +31,7 @@ export class BatteryInfoDisplayComponent implements OnInit, OnDestroy {
         this.packTemp = floatPipe(value.values[0]);
       }),
       this.storage.get(topics.packVoltage()).subscribe((value) => {
-        this.voltage = floatPipe(value.values[0]);
+        this.voltage = parseFloat(value.values[0]);
       }),
       this.storage.get(topics.stateOfCharge()).subscribe((value) => {
         this.stateOfCharge = floatPipe(value.values[0]);

--- a/angular-client/src/pages/charging-page/components/battery-info-display/battery-info-display.ts
+++ b/angular-client/src/pages/charging-page/components/battery-info-display/battery-info-display.ts
@@ -31,7 +31,7 @@ export class BatteryInfoDisplayComponent implements OnInit, OnDestroy {
         this.packTemp = floatPipe(value.values[0]);
       }),
       this.storage.get(topics.packVoltage()).subscribe((value) => {
-        this.voltage = Math.round(floatPipe(value.values[0]));
+        this.voltage = floatPipe(value.values[0]);
       }),
       this.storage.get(topics.stateOfCharge()).subscribe((value) => {
         this.stateOfCharge = floatPipe(value.values[0]);

--- a/angular-client/src/pages/charging-page/components/battery-info-display/battery-info-display.ts
+++ b/angular-client/src/pages/charging-page/components/battery-info-display/battery-info-display.ts
@@ -31,7 +31,7 @@ export class BatteryInfoDisplayComponent implements OnInit, OnDestroy {
         this.packTemp = floatPipe(value.values[0]);
       }),
       this.storage.get(topics.packVoltage()).subscribe((value) => {
-        this.voltage = floatPipe(value.values[0]);
+        this.voltage = Math.round(floatPipe(value.values[0]));
       }),
       this.storage.get(topics.stateOfCharge()).subscribe((value) => {
         this.stateOfCharge = floatPipe(value.values[0]);

--- a/angular-client/src/pages/charging-page/components/battery-info-display/battery-info-mobile/battery-info-mobile.component.html
+++ b/angular-client/src/pages/charging-page/components/battery-info-display/battery-info-mobile/battery-info-mobile.component.html
@@ -21,7 +21,7 @@
   <divider style="height: 100px" />
   <vstack style="width: 33%">
     <hstack style="width: 100%" justifyContent="space-between">
-      <typography variant="info-subtitle" content="Voltage" />
+      <typography variant="info-subtitle" content="Pack Voltage" />
       <typography variant="info-value-mobile" [content]="voltage.toString() + 'V'" />
     </hstack>
 

--- a/angular-client/src/pages/charging-page/components/battery-info-display/battery-info-mobile/battery-info-mobile.component.html
+++ b/angular-client/src/pages/charging-page/components/battery-info-display/battery-info-mobile/battery-info-mobile.component.html
@@ -22,7 +22,7 @@
   <vstack style="width: 33%">
     <hstack style="width: 100%" justifyContent="space-between">
       <typography variant="info-subtitle" content="Pack Voltage" />
-      <typography variant="info-value-mobile" [content]="voltage.toString() + 'V'" />
+      <typography variant="info-value-mobile" [content]="voltage.toFixed(1) + 'V'" />
     </hstack>
 
     <hstack style="width: 100%" justifyContent="space-between">

--- a/angular-client/src/pages/charging-page/components/pack-voltage/pack-voltage-display/pack-voltage-display.component.html
+++ b/angular-client/src/pages/charging-page/components/pack-voltage/pack-voltage-display/pack-voltage-display.component.html
@@ -2,7 +2,7 @@
   <info-background svgIcon="electric_meter" title="Pack Voltage" [button]="resetGraphButton">
     <hstack>
       <hstack style="width: 15%; margin-bottom: 40px">
-        <typography variant="info-value" [content]="voltage.toString() + 'V'" />
+        <typography variant="info-value" [content]="voltage.toFixed(1) + 'V'" />
       </hstack>
       <pack-voltage-graph style="width: 80%; padding-bottom: 30px" [packVoltData]="packVoltData" />
     </hstack>

--- a/angular-client/src/pages/charging-page/components/pack-voltage/pack-voltage-display/pack-voltage-display.component.html
+++ b/angular-client/src/pages/charging-page/components/pack-voltage/pack-voltage-display/pack-voltage-display.component.html
@@ -1,5 +1,5 @@
 @if (isDesktop) {
-  <info-background svgIcon="electric_meter" title="Pack. Voltage" [button]="resetGraphButton">
+  <info-background svgIcon="electric_meter" title="Pack Voltage" [button]="resetGraphButton">
     <hstack>
       <hstack style="width: 15%; margin-bottom: 40px">
         <typography variant="info-value" [content]="voltage.toString() + 'V'" />

--- a/angular-client/src/pages/charging-page/components/pack-voltage/pack-voltage-display/pack-voltage-display.component.ts
+++ b/angular-client/src/pages/charging-page/components/pack-voltage/pack-voltage-display/pack-voltage-display.component.ts
@@ -1,7 +1,6 @@
 import { Component, HostListener, OnInit, inject } from '@angular/core';
 import Storage from 'src/services/storage.service';
 import { topics } from 'src/utils/topic.utils';
-import { floatPipe } from 'src/utils/pipes.utils';
 import { GraphData } from 'src/utils/types.utils';
 import { InfoBackgroundComponent } from '../../../../../components/info-background/info-background.component';
 import PackVoltageMobileDisplayComponent from './pack-voltage-mobile/pack-voltage-mobile.component';
@@ -42,7 +41,7 @@ export default class PackVoltageDisplayComponent implements OnInit {
 
   ngOnInit() {
     this.storage.get(topics.packVoltage()).subscribe((value) => {
-      this.voltage = floatPipe(value.values[0]);
+      this.voltage = parseFloat(value.values[0]);
       this.packVoltData.push({ x: +value.time, y: this.voltage });
     });
   }

--- a/angular-client/src/pages/charging-page/components/pack-voltage/pack-voltage-display/pack-voltage-display.component.ts
+++ b/angular-client/src/pages/charging-page/components/pack-voltage/pack-voltage-display/pack-voltage-display.component.ts
@@ -42,8 +42,9 @@ export default class PackVoltageDisplayComponent implements OnInit {
 
   ngOnInit() {
     this.storage.get(topics.packVoltage()).subscribe((value) => {
-      this.voltage = floatPipe(value.values[0]);
-      this.packVoltData.push({ x: +value.time, y: this.voltage });
+      const rawVoltage = floatPipe(value.values[0]);
+      this.voltage = Math.round(rawVoltage);
+      this.packVoltData.push({ x: +value.time, y: rawVoltage });
     });
   }
 }

--- a/angular-client/src/pages/charging-page/components/pack-voltage/pack-voltage-display/pack-voltage-display.component.ts
+++ b/angular-client/src/pages/charging-page/components/pack-voltage/pack-voltage-display/pack-voltage-display.component.ts
@@ -42,9 +42,8 @@ export default class PackVoltageDisplayComponent implements OnInit {
 
   ngOnInit() {
     this.storage.get(topics.packVoltage()).subscribe((value) => {
-      const rawVoltage = floatPipe(value.values[0]);
-      this.voltage = Math.round(rawVoltage);
-      this.packVoltData.push({ x: +value.time, y: rawVoltage });
+      this.voltage = floatPipe(value.values[0]);
+      this.packVoltData.push({ x: +value.time, y: this.voltage });
     });
   }
 }

--- a/angular-client/src/pages/charging-page/components/pack-voltage/pack-voltage-display/pack-voltage-mobile/pack-voltage-mobile.component.html
+++ b/angular-client/src/pages/charging-page/components/pack-voltage/pack-voltage-display/pack-voltage-mobile/pack-voltage-mobile.component.html
@@ -1,4 +1,4 @@
-<info-background svgIcon="electric_meter" title="Pack. Voltage" [button]="resetGraphButton">
+<info-background svgIcon="electric_meter" title="Pack Voltage" [button]="resetGraphButton">
   <vstack>
     <hstack style="width: 15%">
       <typography variant="info-value" [content]="voltage.toString() + 'V'" />

--- a/angular-client/src/pages/charging-page/components/pack-voltage/pack-voltage-display/pack-voltage-mobile/pack-voltage-mobile.component.html
+++ b/angular-client/src/pages/charging-page/components/pack-voltage/pack-voltage-display/pack-voltage-mobile/pack-voltage-mobile.component.html
@@ -1,7 +1,7 @@
 <info-background svgIcon="electric_meter" title="Pack Voltage" [button]="resetGraphButton">
   <vstack>
     <hstack style="width: 15%">
-      <typography variant="info-value" [content]="voltage.toString() + 'V'" />
+      <typography variant="info-value" [content]="voltage.toFixed(1) + 'V'" />
     </hstack>
     <pack-voltage-graph style="width: 100%; padding-bottom: 30px" [packVoltData]="packVoltData" />
   </vstack>

--- a/angular-client/src/utils/bms.utils.ts
+++ b/angular-client/src/utils/bms.utils.ts
@@ -63,3 +63,19 @@ export const getConnectionDotStatusColor = (voltage: number): string => {
   // anything above 3.5 * 125 cells for scaling, is good
   return '#19ff30';
 };
+
+export const getCellVoltageStatusColor = (avgCellVoltage: number): string => {
+  if (avgCellVoltage <= 3.0) return 'red';
+  if (avgCellVoltage <= 3.5) return 'yellow';
+  return '#19ff30';
+};
+
+export const getChipFromTopicValue = (chipValue: number): Chip => {
+  return chipValue % 2 === 0 ? Chip.Alpha : Chip.Beta;
+};
+
+export const getCellChipLabel = (cell: number | undefined, chip: Chip | undefined): string => {
+  const cellLabel = cell !== undefined ? `Cell: ${cell}` : 'No Cell';
+  const chipLabel = chip !== undefined ? `Chip: ${chipToString(chip, true)}` : 'No Chip';
+  return `${cellLabel} | ${chipLabel}`;
+};


### PR DESCRIPTION
## Changes

Voltage labels are now unambiguous everywhere — Pack / Avg / Total / High / Low — Avg Voltage readouts show 2 decimals instead of 1, and Pack Voltage now uses parseFloat so it actually shows its real sub-volt value.

- Renamed every bare "Voltage" / "Voltages" / "Average Voltage" subtitle. bms-at-a-glance's pack tile was mislabeled "Average Voltage" but subscribed to the pack total topic — now reads Pack Voltage.
- Avg Voltage shows 2 decimals in segment overview, segment-at-a-glance, and segment-summary.
- Pack Voltage subscriptions now use parseFloat instead of floatPipe/parseInt — the old values were silently rounded to integers (floatPipe is misleadingly named: it calls Math.round). Pack Voltage graph on the charging page is now smooth instead of stepped.
- Fixed segment-at-a-glance missing its segmentVoltage subscription (tile always read 0V).
- Moved Fault and eFuses into the nav overflow menu, and bumped the BMS page title breakpoint 1200→1300 so "Accumulator" fits.

## Notes

Nav reorg is manual — follow-up ticket will automate overflow based on available width.

floatPipe's name is still misleading across the codebase; that's a larger cleanup that belongs in its own ticket.

## Test Cases

- Avg Voltage reads 2 decimals across all BMS views
- Pack Voltage displays actual sub-volt values on BMS at-a-glance and charging page
- Pack Voltage graph renders as a smooth line, not stepped
- Segment detail tile shows live voltage
- Fault and eFuses reachable via overflow menu
- BMS page title swaps at 1300px

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No package-lock.json changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #575
