### PR TITLE
#578 Fix historical graph x-axis always constrained to 30 seconds

### DIFF
--- a/angular-client/src/pages/graph-page/graph/graph.component.ts
+++ b/angular-client/src/pages/graph-page/graph/graph.component.ts
@@ -179,8 +179,11 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
       yaxis: index
     }));
 
-    // Use time-based range if in time mode, otherwise use calculated timeRangeMs from point-based logic
-    const effectiveRange = this.graphConfig().rangeMode === 'time' ? this.graphConfig().timeRangeMs : this.timeRangeMs;
+    // Only constrain the x-axis range in real-time mode; historical mode should auto-fit all data
+    let effectiveRange: number | undefined = undefined;
+    if (this.realTime()) {
+      effectiveRange = this.graphConfig().rangeMode === 'time' ? this.graphConfig().timeRangeMs : this.timeRangeMs;
+    }
 
     // Single updateOptions call with series included — avoids two separate re-renders
     // Pass false, false to skip animation bookkeeping (getPreviousPaths) and animate flag


### PR DESCRIPTION
## Changes

- Fixed a bug where the graph component's `updateChart()` always set the x-axis `range` to the real-time sliding window value (default 30 seconds), even in historical mode
- Historical queries now let ApexCharts auto-fit the x-axis to the full data extent by setting `range` to `undefined` when not in real-time mode

## Notes

The backend was correctly fetching the full requested time range (e.g. 30 minutes). The issue was purely in the frontend display — `effectiveRange` was always computed from `graphConfig().timeRangeMs` (default 30000ms), which constrained the visible x-axis window to 30 seconds regardless of how much data was returned.

## Test Cases

- Select a historical time range (e.g. 30 min) and verify the full range of data is displayed on the graph
- Verify real-time mode still uses the configured sliding window (default 30 seconds)
- Verify point-based range mode still works correctly in real-time
- Verify run-based historical queries display full data extent

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] No package-lock.json changes (unless dependencies have changed)
- [x] Remove any non-applicable sections of this template

Closes #578
