### PR TITLE
#582 Add topic autocomplete to rule creation dialog

### DIFF
--- a/angular-client/src/main.ts
+++ b/angular-client/src/main.ts
@@ -34,6 +34,7 @@ import { PasswordModule } from 'primeng/password';
 import { importProvidersFrom, provideExperimentalZonelessChangeDetection } from '@angular/core';
 import AppContextComponent from './app/context/app-context.component';
 import { ToggleSwitchModule } from 'primeng/toggleswitch';
+import { AutoCompleteModule } from 'primeng/autocomplete';
 
 bootstrapApplication(AppContextComponent, {
   providers: [
@@ -67,7 +68,8 @@ bootstrapApplication(AppContextComponent, {
       InputTextModule,
       InputNumberModule,
       PasswordModule,
-      ToggleSwitchModule
+      ToggleSwitchModule,
+      AutoCompleteModule
     ),
     DialogService,
     MessageService,

--- a/angular-client/src/pages/notification-rules-page/add-rule-dialog/add-rule-dialog.component.html
+++ b/angular-client/src/pages/notification-rules-page/add-rule-dialog/add-rule-dialog.component.html
@@ -9,7 +9,15 @@
 
   <div class="field">
     <label for="rule-topic">Topic</label>
-    <input id="rule-topic" pInputText formControlName="topic" placeholder="e.g. BMS/Pack/Voltage" />
+    <p-autoComplete
+      id="rule-topic"
+      formControlName="topic"
+      [suggestions]="filteredTopics()"
+      (completeMethod)="filterTopics($event)"
+      [forceSelection]="true"
+      placeholder="e.g. BMS/Pack/Voltage"
+      [fluid]="true"
+    />
     @if (form.get('topic')?.touched && form.get('topic')?.hasError('required')) {
       <small class="error" role="alert">Topic is required</small>
     }

--- a/angular-client/src/pages/notification-rules-page/add-rule-dialog/add-rule-dialog.component.ts
+++ b/angular-client/src/pages/notification-rules-page/add-rule-dialog/add-rule-dialog.component.ts
@@ -1,20 +1,29 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { DynamicDialogRef } from 'primeng/dynamicdialog';
 import { InputText } from 'primeng/inputtext';
+import { AutoComplete, AutoCompleteCompleteEvent } from 'primeng/autocomplete';
 import { ButtonDirective } from 'primeng/button';
 import { RulePayload } from 'src/api/rules.api';
+import { getAllDatatypes } from 'src/api/datatype.api';
+import APIService from 'src/services/api.service';
+import { DataType } from 'src/utils/types.utils';
+import { filter, take } from 'rxjs';
 
 @Component({
   selector: 'add-rule-dialog',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ReactiveFormsModule, InputText, ButtonDirective],
+  imports: [ReactiveFormsModule, InputText, AutoComplete, ButtonDirective],
   templateUrl: './add-rule-dialog.component.html',
   styleUrls: ['./add-rule-dialog.component.css']
 })
-export class AddRuleDialogComponent {
+export class AddRuleDialogComponent implements OnInit {
   private ref = inject(DynamicDialogRef);
   private fb = inject(FormBuilder);
+  private serverService = inject(APIService);
+
+  allTopics: string[] = [];
+  filteredTopics = signal<string[]>([]);
 
   form = this.fb.group({
     id: ['', Validators.required],
@@ -22,6 +31,28 @@ export class AddRuleDialogComponent {
     expr: ['', Validators.required],
     debounce_time: [60, [Validators.required, Validators.min(0)]]
   });
+
+  ngOnInit(): void {
+    const query = this.serverService.query<DataType[]>(getAllDatatypes);
+    query.data
+      .pipe(
+        filter((d): d is DataType[] => d !== null && d !== undefined),
+        take(1)
+      )
+      .subscribe((dataTypes) => {
+        this.allTopics = dataTypes.map((dt) => dt.name);
+      });
+  }
+
+  filterTopics(event: AutoCompleteCompleteEvent): void {
+    const search = event.query.toLowerCase();
+    const lower = (t: string) => t.toLowerCase();
+    this.filteredTopics.set(
+      this.allTopics.filter(
+        (topic) => lower(topic).includes(search) || topic.split('/').some((seg) => lower(seg).includes(search))
+      )
+    );
+  }
 
   onSubmit(): void {
     if (this.form.invalid) {


### PR DESCRIPTION
## Changes

Replaces the plain text input for the topic field in the add-rule dialog with a PrimeNG AutoComplete component. Topics are fetched from the backend via getAllDatatypes and filtered as the user types, matching case-insensitively against any segment of the "/" delimited path as well as partial paths. forceSelection ensures only valid topics can be submitted.

- Swapped pInputText for p-autoComplete with forceSelection and fluid layout
- Fetches topic list on dialog open via APIService.query with auto-cleanup (filter + take(1))
- Registered AutoCompleteModule globally in main.ts

## Notes

The edit-rule dialog does not have a topic field (it only edits expression and debounce time), so no changes were needed there.

## Test Cases

- Typing a partial segment like "volt" surfaces all voltage-related topics across BMS, VCU, DTI, etc.
- Typing a partial path like "BMS/Pack" correctly matches topics under that hierarchy
- Selecting a suggestion populates the form with the full topic name
- Typing a non-matching string and blurring clears the field (forceSelection)
- Form validation still requires a non-empty topic before submission

## Screenshots
<img width="1200" height="708" alt="autocomplete-suggestions" src="https://github.com/user-attachments/assets/9231c507-77d6-4d67-a012-6c8aa2d51b00" />



## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #582
