### PR TITLE
#584 Fix client bootstrap crash on LAN deploys from crypto.randomUUID

### DIFF
--- a/angular-client/package-lock.json
+++ b/angular-client/package-lock.json
@@ -33,6 +33,7 @@
         "select": "^1.1.2",
         "socket.io-client": "^4.7.2",
         "tslib": "^2.3.0",
+        "uuid": "^13.0.0",
         "zone.js": "~0.15.0"
       },
       "devDependencies": {
@@ -14057,6 +14058,15 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/socks": {
       "version": "2.8.4",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
@@ -14987,12 +14997,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/angular-client/package.json
+++ b/angular-client/package.json
@@ -40,6 +40,7 @@
     "select": "^1.1.2",
     "socket.io-client": "^4.7.2",
     "tslib": "^2.3.0",
+    "uuid": "^13.0.0",
     "zone.js": "~0.15.0"
   },
   "devDependencies": {

--- a/angular-client/src/app/context/app-context.component.ts
+++ b/angular-client/src/app/context/app-context.component.ts
@@ -11,13 +11,15 @@ import { MatIconRegistry } from '@angular/material/icon';
 import { DomSanitizer } from '@angular/platform-browser';
 import { EnvService } from 'src/services/env.service';
 import { NotificationLogService } from 'src/services/notification-log.service';
+import { v4 as uuidv4 } from 'uuid';
 
-/** Generate or retrieve a stable client ID for notifications */
+// crypto.randomUUID is only defined in secure contexts (https or loopback);
+// uuidv4 falls back to crypto.getRandomValues so it works on insecure origins.
 function getOrCreateClientId(): string {
   const key = 'notification_rules_client_id';
   let id = localStorage.getItem(key);
   if (!id) {
-    id = crypto.randomUUID();
+    id = uuidv4();
     localStorage.setItem(key, id);
   }
   return id;


### PR DESCRIPTION
## Changes

The notification-log client-ID helper called crypto.randomUUID, which is only defined in secure contexts (https or loopback). Serving the built client over plain http on a LAN IP (e.g. http://192.168.100.11/) crashed at bootstrap with a TypeError, leaving the page blank. Swapped it for v4 from the uuid library, which falls back to crypto.getRandomValues and works in insecure contexts.

- Added uuid as a direct dependency (v13.0.0) and replaced the crypto.randomUUID call in angular-client/src/app/context/app-context.component.ts
- uuid's v4 uses a native fast-path when crypto.randomUUID exists, but falls through to getRandomValues when it doesn't — verified in the installed source

## Notes

Dev never caught this because ng serve runs on localhost, which is a secure-context exception. Only the deployed build on a non-loopback host hits the code path.

uuid 13 was already partially in the lockfile as a sockjs transitive — the direct install promotes it to a top-level dependency so we aren't relying on another package to keep it around.

## Test Cases

- Reproduced the failing case on the live LAN deploy (http://192.168.100.11/) — two crypto.randomUUID TypeErrors at bootstrap, blank page
- Built the fix, ran the dev client bound to 0.0.0.0:4201, loaded it from the Mac's LAN IP (http://192.168.100.41:4201/) — another insecure origin — and confirmed zero crypto.randomUUID errors, bootstrap completes, router navigates to /landing, and localStorage stores a valid UUIDv4 (which is also used as the socket.io clientId query param)
- Real-time graph still works as before over localhost
- Lint and prettier clean

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] package-lock.json changes are intentional (uuid added as direct dep)
- [x] PR is linked to the ticket

Closes #584
