### PR TITLE
Added Notices to eFuse Cards

### DIFF
--- a/angular-client/package-lock.json
+++ b/angular-client/package-lock.json
@@ -459,7 +459,6 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-19.2.11.tgz",
       "integrity": "sha512-NR33bZVho7EgTc1fmCnmkwc2/U266n311Wfvk7VVtz+0Q9WliNdDLBon654V8IWSKvlqKXyU3W+fp0VjH/FvSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -660,7 +659,6 @@
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-19.2.11.tgz",
       "integrity": "sha512-G568yWIJlnsuS563WxvCofmxc1405+wRQvDGQ32+qWOblJScFkHgr4jeDkZGcyt/r8OudaW0H0/rNeg1dzdnIQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "parse5": "^7.1.2",
         "tslib": "^2.3.0"
@@ -736,7 +734,6 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.2.11.tgz",
       "integrity": "sha512-/ZnF2Nfp6S6TAu3VlvUAIp4NVd81WE1Q95wuwSSuoEx2aSyXzI+1myyKWSYe/jYCyGuppmocjTciEh8mAInmOw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -753,7 +750,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.2.11.tgz",
       "integrity": "sha512-/ZGFAEO2TyqkaE4neR8lGL9I2QeO2sRVFqulQv7Bu8zKTPStjcsFCwNkp+TNX8Oq/1rLcY9XWAOsUk1//AZd8Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -766,7 +762,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.2.11.tgz",
       "integrity": "sha512-15aoOg+qj7Z3Uap1JKHMy51y12M09AOnseDBa0SYKidSx15XwZi8d01hv7sRaQJX/6Ie5cug9GiAbLKts6R33w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.26.9",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -840,7 +835,6 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.2.11.tgz",
       "integrity": "sha512-kmtJQB7B5F2V1JIzy1oBPS6WrRyedSYkuge+XoX1mCSFJDef8HRNd7GopnQ0Zaz0vOTGvCCkWvvaH/+7s2lmAQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -857,7 +851,6 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-19.2.11.tgz",
       "integrity": "sha512-ZH9ccuT6rTirNSbiMRtGRkRrj69a2/+BVaa/kEpUHjh41wDQXxhOlOfPZd/sfj04QiAzIpsYmVJrmoV7/LxPSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -893,7 +886,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.2.11.tgz",
       "integrity": "sha512-wAPJtgzmxBEpW31sa2eg9QssCHBZ52Zc9nm6azTflDlOAyfm9bzqec7y3wqy5sgVue/qID2gzHqmpS3Nx3o0xg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -934,7 +926,6 @@
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-19.2.11.tgz",
       "integrity": "sha512-nBwMwRgQ3s1c1CPItPnTJTf81NDOQHvK41r2MIJGHa3H9LONlcbY07q/9p49fqt/xn/dgoOmQTtJ22b/nbIJAQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -976,7 +967,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -3397,7 +3387,6 @@
       "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.3.2.tgz",
       "integrity": "sha512-G1ytyOoHh5BphmEBxSwALin3n1KGNYB6yImbICcRQdzXfOGbuJ9Jske/Of5Sebk339NSGGNfUshnzK8YWkTPsQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.1.2",
         "@inquirer/confirm": "^5.1.6",
@@ -5105,7 +5094,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.34.8",
@@ -5325,6 +5315,7 @@
       "resolved": "https://registry.npmjs.org/@svgdotjs/svg.draggable.js/-/svg.draggable.js-3.0.6.tgz",
       "integrity": "sha512-7iJFm9lL3C40HQcqzEfezK2l+dW2CpoVY3b77KQGqc8GXWa6LhhmX5Ckv7alQfUXBuZbjpICZ+Dvq1czlGx7gA==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@svgdotjs/svg.js": "^3.2.4"
       }
@@ -5334,6 +5325,7 @@
       "resolved": "https://registry.npmjs.org/@svgdotjs/svg.filter.js/-/svg.filter.js-3.0.9.tgz",
       "integrity": "sha512-/69XMRCDoam2HgC4ldHIaDgeQf1ViHIsa0Ld4uWgiXtZ+E24DWHe/9Ib6kbNiZ7WRIdlVokUDR1Fg0kjIpkfbw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@svgdotjs/svg.js": "^3.2.4"
       },
@@ -5357,6 +5349,7 @@
       "resolved": "https://registry.npmjs.org/@svgdotjs/svg.resize.js/-/svg.resize.js-2.0.5.tgz",
       "integrity": "sha512-4heRW4B1QrJeENfi7326lUPYBCevj78FJs8kfeDxn5st0IYPIRXoTtOSYvTzFWgaWWXd3YCDE6ao4fmv91RthA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14.18"
       },
@@ -5590,7 +5583,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.50.tgz",
       "integrity": "sha512-Mxiq0ULv/zo1OzOhwPqOA13I81CV/W3nvd3ChtQZRT5Cwz3cr0FKo/wMSsbTqL3EXpaBAEQhva2B8ByRkOIh9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -5772,7 +5764,6 @@
       "integrity": "sha512-yimw99teuaXVWsBcPO1Ais02kwJ1jmNA1KxE7ng0aT7ndr1pT1wqj0OJnsYVGKKlc4QJai86l/025L6z8CljOg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.11.0",
         "@typescript-eslint/types": "7.11.0",
@@ -5996,6 +5987,7 @@
       "integrity": "sha512-7IsIaIDeZn7kffk7qXC3o6Z4UblZJKV3UBpkvRNpr5NSyLji7tvTcvmnMNYuYLyh26mN8W723xpo3i4MlD33vA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.32.1",
         "@typescript-eslint/visitor-keys": "8.32.1"
@@ -6014,6 +6006,7 @@
       "integrity": "sha512-Y3AP9EIfYwBb4kWGb+simvPaqQoT5oJuzzj9m0i6FCY6SPvlomY2Ei4UEMm7+FXtlNJbor80ximyslzaQF6xhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.32.1",
         "@typescript-eslint/visitor-keys": "8.32.1",
@@ -6041,6 +6034,7 @@
       "integrity": "sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.32.1",
         "eslint-visitor-keys": "^4.2.0"
@@ -6059,6 +6053,7 @@
       "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -6072,6 +6067,7 @@
       "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.12"
       },
@@ -6298,7 +6294,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@yr/monotone-cubic-spline/-/monotone-cubic-spline-1.0.3.tgz",
       "integrity": "sha512-FQXkOta0XBSUPHndIKON2Y9JeQz5ZeMqLYZVVK93FliNBFm7LNMIZmY6FrMEB9XPcDbE2bekMbZD6kzDkxwYjA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/abbrev": {
       "version": "3.0.1",
@@ -6336,7 +6333,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6395,7 +6391,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6868,7 +6863,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001716",
         "electron-to-chromium": "^1.5.149",
@@ -8334,7 +8328,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8391,7 +8384,6 @@
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -10115,8 +10107,7 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.6.1.tgz",
       "integrity": "sha512-VYz/BjjmC3klLJlLwA4Kw8ytk0zDSmbbDLNs794VnWmkcCB7I9aAL/D48VNQtmITyPvea2C3jdUMfc3kAoy0PQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -10152,7 +10143,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -10265,7 +10255,6 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -10397,7 +10386,6 @@
       "integrity": "sha512-i/zQLFrfEpRyQoJF9fsCdTMOF5c2dK7C7OmsuKg2D0YSsuZSfQDiLuaiktbuio6F2wiCsZSnSnieIQ0ant/uzQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "jasmine-core": "^4.1.0"
       },
@@ -10658,7 +10646,6 @@
       "resolved": "https://registry.npmjs.org/less/-/less-4.2.2.tgz",
       "integrity": "sha512-tkuLHQlvWUTeQ3doAqnHbNn8T6WX1KA8yvbKG9x4VtKtIjHsVKQZCH11zRgAfbDAXC2UNIg/K9BYAAcEzUIrNg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -12647,7 +12634,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -12794,7 +12780,6 @@
       "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13358,7 +13343,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -13412,7 +13396,6 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.85.0.tgz",
       "integrity": "sha512-3ToiC1xZ1Y8aU7+CkgCI/tqyuPXEmYGJXO7H4uqp0xkLXUqp88rQQ4j1HmP37xSJLbCJPaIiv+cT1y+grssrww==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -14560,7 +14543,6 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
       "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -14728,8 +14710,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tuf-js": {
       "version": "3.0.1",
@@ -14794,7 +14775,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15042,6 +15022,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -15122,7 +15103,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-android-arm64": {
       "version": "4.41.0",
@@ -15135,7 +15117,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.41.0",
@@ -15148,7 +15131,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.41.0",
@@ -15161,7 +15145,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.41.0",
@@ -15174,7 +15159,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.41.0",
@@ -15187,7 +15173,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.41.0",
@@ -15200,7 +15187,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.41.0",
@@ -15213,7 +15201,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.41.0",
@@ -15226,7 +15215,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.41.0",
@@ -15239,7 +15229,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-loongarch64-gnu": {
       "version": "4.41.0",
@@ -15252,7 +15243,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
       "version": "4.41.0",
@@ -15265,7 +15257,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.41.0",
@@ -15278,7 +15271,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.41.0",
@@ -15291,7 +15285,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.41.0",
@@ -15304,7 +15299,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.41.0",
@@ -15317,7 +15313,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.41.0",
@@ -15330,7 +15327,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.41.0",
@@ -15343,7 +15341,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.41.0",
@@ -15356,13 +15355,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/vite/node_modules/postcss": {
       "version": "8.5.3",
@@ -15383,6 +15384,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -15397,6 +15399,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.41.0.tgz",
       "integrity": "sha512-HqMFpUbWlf/tvcxBFNKnJyzc7Lk+XO3FGc3pbNBLqEbOz0gPLRgcrlS3UF4MfUrVlstOaP/q0kM6GVvi+LrLRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.7"
       },
@@ -15495,7 +15498,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
       "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -15571,7 +15573,6 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.0.tgz",
       "integrity": "sha512-90SqqYXA2SK36KcT6o1bvwvZfJFcmoamqeJY7+boioffX9g9C0wjjJRGUrQIuh43pb0ttX7+ssavmj/WN2RHtA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -16080,8 +16081,7 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.0.tgz",
       "integrity": "sha512-9oxn0IIjbCZkJ67L+LkhYWRyAy7axphb3VgE2MBDlOqnmHMPWGYMxJxBYFueFq/JGY2GMwS0rU+UCLunEmy5UA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     }
   }
 }

--- a/angular-client/src/components/info-background/info-background.component.html
+++ b/angular-client/src/components/info-background/info-background.component.html
@@ -42,7 +42,11 @@
       }
       @if (this.topRightInfo(); as topRightInfo) {
         <div class="top-right-info">
-          <typography variant="info-subtitle" [content]="topRightInfo" [additionalStyles]="'fontSize: ' + topRightInfoSize() + ';'" />
+          <typography
+            variant="info-subtitle"
+            [content]="topRightInfo"
+            [additionalStyles]="'fontSize: ' + topRightInfoSize() + ';'"
+          />
         </div>
       }
     </div>

--- a/angular-client/src/components/info-background/info-background.component.html
+++ b/angular-client/src/components/info-background/info-background.component.html
@@ -42,7 +42,7 @@
       }
       @if (this.topRightInfo(); as topRightInfo) {
         <div class="top-right-info">
-          <typography variant="info-subtitle" [content]="topRightInfo" additionalStyles="fontSize: 19px;" />
+          <typography variant="info-subtitle" [content]="topRightInfo" [additionalStyles]="'fontSize: ' + topRightInfoSize() + ';'" />
         </div>
       }
     </div>

--- a/angular-client/src/components/info-background/info-background.component.ts
+++ b/angular-client/src/components/info-background/info-background.component.ts
@@ -31,7 +31,7 @@ export class InfoBackgroundComponent {
   @Input() button?: ButtonInputs;
   selectorConfigs = input<SelectorConfig[]>([]);
   topRightInfo = input<string | undefined>(undefined);
-  topRightInfoSize = input<string>("19px");
+  topRightInfoSize = input<string>('19px');
 
   slicedLeftCorner = input<boolean>(false); // slice out the upper left corner
   slicePercentage = input<number>(125); // pixel size of the corner slice (used for both clip-path x and y)

--- a/angular-client/src/components/info-background/info-background.component.ts
+++ b/angular-client/src/components/info-background/info-background.component.ts
@@ -31,6 +31,7 @@ export class InfoBackgroundComponent {
   @Input() button?: ButtonInputs;
   selectorConfigs = input<SelectorConfig[]>([]);
   topRightInfo = input<string | undefined>(undefined);
+  topRightInfoSize = input<string>("19px");
 
   slicedLeftCorner = input<boolean>(false); // slice out the upper left corner
   slicePercentage = input<number>(125); // pixel size of the corner slice (used for both clip-path x and y)

--- a/angular-client/src/pages/efuses-page/components/efuse-card/efuse-card.component.html
+++ b/angular-client/src/pages/efuses-page/components/efuse-card/efuse-card.component.html
@@ -1,4 +1,9 @@
-<info-background [svgIcon]="'electrical_services'" [title]="efuseName() + ' - ' + maxCurrent() + 'A'" [topRightInfo]="notice()" [topRightInfoSize]="'12px'">
+<info-background
+  [svgIcon]="'electrical_services'"
+  [title]="efuseName() + ' - ' + maxCurrent() + 'A'"
+  [topRightInfo]="notice()"
+  [topRightInfoSize]="'12px'"
+>
   <div style="padding: 20px 30px 10px 40px; height: 100%; box-sizing: border-box">
     <vstack [align]="'flex-center'" [spacing]="'30px'" style="height: 100%; justify-content: space-between">
       <!-- Current display + ADC displays side by side -->

--- a/angular-client/src/pages/efuses-page/components/efuse-card/efuse-card.component.html
+++ b/angular-client/src/pages/efuses-page/components/efuse-card/efuse-card.component.html
@@ -1,4 +1,4 @@
-<info-background [svgIcon]="'electrical_services'" [title]="efuseName() + ' - ' + maxCurrent() + 'A'">
+<info-background [svgIcon]="'electrical_services'" [title]="efuseName() + ' - ' + maxCurrent() + 'A'" [topRightInfo]="notice()" [topRightInfoSize]="'12px'">
   <div style="padding: 20px 30px 10px 40px; height: 100%; box-sizing: border-box">
     <vstack [align]="'flex-center'" [spacing]="'30px'" style="height: 100%; justify-content: space-between">
       <!-- Current display + ADC displays side by side -->

--- a/angular-client/src/pages/efuses-page/components/efuse-card/efuse-card.component.ts
+++ b/angular-client/src/pages/efuses-page/components/efuse-card/efuse-card.component.ts
@@ -68,6 +68,7 @@ export default class EfuseCardComponent implements OnInit, OnDestroy {
   autoUnit = input<string>('°C');
   autoDigits = input<number>(3);
   autoDecimals = input<number>(1);
+  notice = input<string>(''); // Component param allowing you to put a note/warning/etc, in the top-right corner of the card.
 
   // ── Shared seven-segment display inputs ──
   readonly largeDisplayFontSize: number = 80;

--- a/angular-client/src/pages/efuses-page/efuses-page.component.html
+++ b/angular-client/src/pages/efuses-page/efuses-page.component.html
@@ -8,7 +8,7 @@
 
   <grid-layout minWidth="520px" gap="15px" style="margin-top: 20px">
     <!-- Dashboard eFuse -->
-    <efuse-card efuseName="Dashboard" [efuseTopicKey]="'Dashboard'" commandKey="Dashboard" [maxCurrent]="'3'" />
+    <efuse-card efuseName="Dashboard" [efuseTopicKey]="'Dashboard'" commandKey="Dashboard" [maxCurrent]="'3'"/>
 
     <!-- Brake eFuse (Type 2: AUTO based on braking state) -->
     <efuse-card
@@ -24,7 +24,7 @@
     />
 
     <!-- Shutdown eFuse -->
-    <efuse-card efuseName="Shutdown" [efuseTopicKey]="'Shutdown'" commandKey="Shutdown" [maxCurrent]="'1'" />
+    <efuse-card efuseName="Shutdown" [efuseTopicKey]="'Shutdown'" commandKey="Shutdown" [maxCurrent]="'1'" [notice]="'Note: Shutdown eFuse can\'t be turned off from here.'"/>
 
     <!-- LV eFuse -->
     <efuse-card efuseName="LV" [efuseTopicKey]="'LV'" commandKey="LV" [maxCurrent]="'3'" />
@@ -82,6 +82,7 @@
       [autoDataType]="topics.VCU.Echo.Controller_Temp"
       [autoLabel]="'Controller Temp'"
       [autoUnit]="'°C'"
+      [notice]="'Note: Spare eFuse doesn\'t support current reading.'"
     />
 
     <!-- Battbox eFuse -->

--- a/angular-client/src/pages/efuses-page/efuses-page.component.html
+++ b/angular-client/src/pages/efuses-page/efuses-page.component.html
@@ -8,7 +8,7 @@
 
   <grid-layout minWidth="520px" gap="15px" style="margin-top: 20px">
     <!-- Dashboard eFuse -->
-    <efuse-card efuseName="Dashboard" [efuseTopicKey]="'Dashboard'" commandKey="Dashboard" [maxCurrent]="'3'"/>
+    <efuse-card efuseName="Dashboard" [efuseTopicKey]="'Dashboard'" commandKey="Dashboard" [maxCurrent]="'3'" />
 
     <!-- Brake eFuse (Type 2: AUTO based on braking state) -->
     <efuse-card
@@ -24,7 +24,13 @@
     />
 
     <!-- Shutdown eFuse -->
-    <efuse-card efuseName="Shutdown" [efuseTopicKey]="'Shutdown'" commandKey="Shutdown" [maxCurrent]="'1'" [notice]="'Note: Shutdown eFuse can\'t be turned off from here.'"/>
+    <efuse-card
+      efuseName="Shutdown"
+      [efuseTopicKey]="'Shutdown'"
+      commandKey="Shutdown"
+      [maxCurrent]="'1'"
+      [notice]="'Note: Shutdown eFuse can\'t be turned off from here.'"
+    />
 
     <!-- LV eFuse -->
     <efuse-card efuseName="LV" [efuseTopicKey]="'LV'" commandKey="LV" [maxCurrent]="'3'" />


### PR DESCRIPTION
Added notices to the eFuse cards (Shutdown lets you know that it's not able to be turned off from Argos, and Spare lets you know that it doesn't support current reading).

Note: I had to add a new property to `info-background` called `topRightInfoSize` so I could customize the notice text size. When unspecified, it defaults to `19px`, which was previously the hardcoded size for all instances of the component. So, this new param shouldn't mess with any existing uses of the `info-background`.