### PR TITLE
Disable Shutdown Unlock Button

### DIFF
--- a/angular-client/src/pages/efuses-page/components/efuse-card/efuse-card.component.html
+++ b/angular-client/src/pages/efuses-page/components/efuse-card/efuse-card.component.html
@@ -77,7 +77,9 @@
                 [disabled]="isLocked()"
                 (stateChange)="onSwitchStateChange($event)"
               />
-              <lock-button [locked]="isLocked()" (pressed)="onLockButtonClick()"></lock-button>
+              @if (lockButtonEnabled()) {
+                <lock-button [locked]="isLocked()" (pressed)="onLockButtonClick()"></lock-button>
+              }
             </hstack>
             <seven-segment-display
               [value]="controlStateDisplay()"

--- a/angular-client/src/pages/efuses-page/components/efuse-card/efuse-card.component.ts
+++ b/angular-client/src/pages/efuses-page/components/efuse-card/efuse-card.component.ts
@@ -69,6 +69,7 @@ export default class EfuseCardComponent implements OnInit, OnDestroy {
   autoDigits = input<number>(3);
   autoDecimals = input<number>(1);
   notice = input<string>(''); // Component param allowing you to put a note/warning/etc, in the top-right corner of the card.
+  lockButtonEnabled = input<boolean>(true);
 
   // ── Shared seven-segment display inputs ──
   readonly largeDisplayFontSize: number = 80;

--- a/angular-client/src/pages/efuses-page/efuses-page.component.html
+++ b/angular-client/src/pages/efuses-page/efuses-page.component.html
@@ -30,6 +30,7 @@
       commandKey="Shutdown"
       [maxCurrent]="'1'"
       [notice]="'Note: Shutdown eFuse can\'t be turned off from here.'"
+      [lockButtonEnabled]="false"
     />
 
     <!-- LV eFuse -->


### PR DESCRIPTION
Made it possible to disable the lock/unlock buttons on the eFuse cards (via an optional component parameter), and used this to disable the Shutdown eFuse card's lock/unlock button. This makes it so you can't interact with the state switches for that card. Technically you already couldn't change the state of the shutdown eFuse since it is hardcoded ON in the firmware, but this makes it clearer from a UI perspective probably