### PR TITLE
Remove Ability to Turn off LV eFuse

### DIFF
--- a/angular-client/src/pages/efuses-page/efuses-page.component.html
+++ b/angular-client/src/pages/efuses-page/efuses-page.component.html
@@ -34,7 +34,14 @@
     />
 
     <!-- LV eFuse -->
-    <efuse-card efuseName="LV" [efuseTopicKey]="'LV'" commandKey="LV" [maxCurrent]="'3'" />
+    <efuse-card
+      efuseName="LV"
+      [efuseTopicKey]="'LV'"
+      commandKey="LV"
+      [maxCurrent]="'3'"
+      [notice]="'Note: LV eFuse can\'t be turned off from here.'"
+      [lockButtonEnabled]="false"
+    />
 
     <!-- Radfan eFuse (Type 2: AUTO based on DTI motor temp) -->
     <efuse-card


### PR DESCRIPTION
Removed the ability to turn off the LV eFuse. You can still see the eFuse's control state via the buttons, but the buttons are greyed out and can't be interacted with. 

This was done because being able to turn off the LV eFuse is somewhat of a self-destruct button. Even though VCU remains on after turning off the eFuse, TPU does not remain on, meaning that you wouldn't be able to turn the eFuse back on via Argos and would have to physically go and press the reset button on VCU.