### PR TITLE
Shutdown Notice on RTDS Card

### DIFF
--- a/angular-client/src/pages/efuses-page/components/rtds-debug-card/rtds-debug-card.component.css
+++ b/angular-client/src/pages/efuses-page/components/rtds-debug-card/rtds-debug-card.component.css
@@ -79,6 +79,21 @@
   padding-bottom: 10px;
 }
 
+.rtds-button-subtext-2 {
+  text-align: center;
+  font-size: 15px;
+  margin-top: 1px;
+  margin-bottom: 2px;
+  line-height: 1.2;
+  font-family: 'Highway Gothic', 'Roboto', sans-serif;
+  padding-bottom: 10px;
+}
+
+.shutdown-indicator {
+  text-align: center;
+  padding-top: 10px;
+}
+
 .rtds-button:not(:disabled):active {
   transform: translateY(3px);
   box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.3);

--- a/angular-client/src/pages/efuses-page/components/rtds-debug-card/rtds-debug-card.component.html
+++ b/angular-client/src/pages/efuses-page/components/rtds-debug-card/rtds-debug-card.component.html
@@ -85,6 +85,10 @@
             <div class="rtds-display-label">Error State</div>
           </div>
         </div>
+        <div class="shutdown-indicator">
+          <indicator-light [label]="'SHUTDOWN'" [active]="shutdown" [color]="'red'" [fontSize]="14" />
+          <div class="rtds-button-subtext-2">(RTDS will not sound if shutdown is active.)</div>
+        </div>
       </vstack>
     </div>
   </info-background>

--- a/angular-client/src/pages/efuses-page/components/rtds-debug-card/rtds-debug-card.component.ts
+++ b/angular-client/src/pages/efuses-page/components/rtds-debug-card/rtds-debug-card.component.ts
@@ -7,19 +7,27 @@ import { InfoBackgroundComponent } from 'src/components/info-background/info-bac
 import VStackComponent from 'src/components/vstack/vstack.component';
 import SevenSegmentDisplayComponent from '../seven-segment-display/seven-segment-display.component';
 import { LockButtonComponent } from '../lock-button/lock-button.component';
+import IndicatorLightComponent from '../indicator-light/indicator-light.component';
 
 @Component({
   selector: 'rtds-debug-card',
   templateUrl: './rtds-debug-card.component.html',
   styleUrls: ['./rtds-debug-card.component.css'],
   standalone: true,
-  imports: [InfoBackgroundComponent, VStackComponent, SevenSegmentDisplayComponent, LockButtonComponent]
+  imports: [
+    InfoBackgroundComponent,
+    VStackComponent,
+    SevenSegmentDisplayComponent,
+    LockButtonComponent,
+    IndicatorLightComponent
+  ]
 })
 export default class RtdsDebugCardComponent implements OnInit, OnDestroy {
   private storage = inject(Storage);
   private subscriptions: Subscription[] = [];
 
   readonly rtdsTopics = EFUSE_TOPICS.VCU.RTDS;
+  readonly echo = EFUSE_TOPICS.VCU.Echo;
 
   isLocked = signal<boolean>(true);
 
@@ -27,12 +35,14 @@ export default class RtdsDebugCardComponent implements OnInit, OnDestroy {
   soundingState = 0;
   reverseState = 0;
   errorState = 0;
+  shutdown = false;
 
   ngOnInit(): void {
     this.subscribeState(this.rtdsTopics.Pin_State, (value) => (this.pinState = value));
     this.subscribeState(this.rtdsTopics.Sounding_State, (value) => (this.soundingState = value));
     this.subscribeState(this.rtdsTopics.Reverse_State, (value) => (this.reverseState = value));
     this.subscribeState(this.rtdsTopics.Error_State, (value) => (this.errorState = value));
+    this.subscribeState(this.echo.BMS_Shutdown, (value) => (this.shutdown = value !== 0));
   }
 
   ngOnDestroy(): void {

--- a/angular-client/src/pages/efuses-page/efuses-page.topics.ts
+++ b/angular-client/src/pages/efuses-page/efuses-page.topics.ts
@@ -17,7 +17,8 @@ export const EFUSE_TOPICS = {
       Motor_Temp: 'VCU/Echo/Motor_Temp',
       Controller_Temp: 'VCU/Echo/Controller_Temp',
       Battbox_Temp: 'VCU/Echo/Battbox_Temp',
-      Brake_State: 'VCU/Echo/Brake_State'
+      Brake_State: 'VCU/Echo/Brake_State',
+      BMS_Shutdown: 'VCU/Echo/BMS_Shutdown_From_VCU'
     },
 
     // RTDS Messages


### PR DESCRIPTION
Added an indicator light on the RTDS card that displays the BMS Shutdown state, as tracked by VCU. This is because VCU blocks RTDS if shutdown is active.