### PR TITLE
#595 - show dash placeholders in segment overview

### DIFF
--- a/angular-client/src/components/stat-summary/stat-summary.component.ts
+++ b/angular-client/src/components/stat-summary/stat-summary.component.ts
@@ -17,6 +17,6 @@ export class StatSummaryComponent {
   configs = input.required<StatConfig[]>();
 
   formatStat(config: StatConfig): string {
-    return config.value !== undefined ? config.formatFn(config.value) : '-';
+    return Number.isFinite(config.value) ? config.formatFn(config.value!) : '-';
   }
 }

--- a/angular-client/src/pages/bms-debug-page/components/segment-overview/segment-overview.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/segment-overview/segment-overview.component.ts
@@ -24,13 +24,12 @@ export class SegmentOverviewComponent implements OnInit, OnDestroy {
   private subscriptions: Subscription[] = [];
 
   segment = input.required<Segment>();
-  segmentStats = input<StatConfig[]>(DEFAULT_SEGMENT_STATS);
 
   statConfigs = signal<StatConfig[]>(DEFAULT_SEGMENT_STATS);
 
   ngOnInit(): void {
     const info = segmentInfoMap[this.segment()];
-    const configs = [...this.segmentStats()];
+    const configs = [...DEFAULT_SEGMENT_STATS];
 
     SEGMENT_TOPIC_KEYS.forEach((key, i) => {
       this.subscriptions.push(

--- a/angular-client/src/pages/bms-debug-page/components/segment-overview/segment-overview.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/segment-overview/segment-overview.component.ts
@@ -26,7 +26,7 @@ export class SegmentOverviewComponent implements OnInit, OnDestroy {
   segment = input.required<Segment>();
   segmentStats = input<StatConfig[]>(DEFAULT_SEGMENT_STATS);
 
-  statConfigs = signal<StatConfig[]>([]);
+  statConfigs = signal<StatConfig[]>(DEFAULT_SEGMENT_STATS);
 
   ngOnInit(): void {
     const info = segmentInfoMap[this.segment()];


### PR DESCRIPTION
## Changes

Fixes the BMS segment overview tiles rendering blank before any MQTT data arrived. The statConfigs signal starts as an empty array, so the `@for` had nothing to iterate over until storage.get emitted — which for a fresh subscription is never guaranteed immediately.

- Seed statConfigs with DEFAULT_SEGMENT_STATS so Avg Temp / Avg Voltage / Total Voltage labels render with dashes on first paint
- Widen the formatStat guard from value !== undefined to Number.isFinite(value) so NaN (from parseFloat of empty payloads) also falls back to the dash
- Drop the unused segmentStats input on SegmentOverviewComponent — no caller was setting it, so it was just dead flexibility that duplicated the default array

## Notes

formatStat now also treats Infinity as missing data, which is intentional — the prior code would have rendered the string "Infinity", which is worse than a dash for segment telemetry.

Follow-up worth scoping into a separate ticket: the StatConfig-with-closures abstraction is at odds with Angular idioms (signals, computed). A more component-oriented shape — e.g., per-stat tile components that subscribe to their own topic — would replace the array-of-configs indirection.

## Test Cases

- With the stack up but calypso stopped: segment overview shows the three labels with dashes across all five segments (previously the tiles were empty)
- With calypso running: values stream in and replace the dashes as subscriptions emit
- Values revert to dashes if the payload ever parses to NaN

## Screenshots

_screenshot pending_

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No package-lock.json changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #595
