### PR TITLE
#597 Drop stale car command label map

### DIFF
--- a/angular-client/src/utils/topic.utils.ts
+++ b/angular-client/src/utils/topic.utils.ts
@@ -2,27 +2,8 @@ import { BMS_CONFIG } from './bms.config';
 import { Chip, chipToString, Segment } from './bms.utils';
 import { CarCommand, CarCommandRow, DataType } from './types.utils';
 
-export type CarCommandSide = 'A' | 'B';
-
-export const pumpStatus = (side: CarCommandSide) => `Calypso/Bidir/State/PumpStatus/${side}`;
-export const rtdsOverride = (side: CarCommandSide) => `Calypso/Bidir/State/RTDSOverride/${side}`;
-export const fanBattBoxStatus = (side: CarCommandSide) => `Calypso/Bidir/State/FanBattBoxStatus/${side}`;
-export const radFanStatus = (side: CarCommandSide) => `Calypso/Bidir/State/RadFanStatus/${side}`;
-
-const CAR_COMMAND_ROW_LABELS: Record<string, string> = {
-  [pumpStatus('A')]: 'Pump A',
-  [pumpStatus('B')]: 'Pump B',
-  [rtdsOverride('A')]: 'RTDS A',
-  [fanBattBoxStatus('A')]: 'Fan Batt Box A',
-  [radFanStatus('A')]: 'Rad Fan A',
-  [radFanStatus('B')]: 'Rad Fan B'
-};
-
-export const carCommandRowLabel = (topic: string): string => CAR_COMMAND_ROW_LABELS[topic] ?? '';
-
 // Group MQTT datatypes under the Calypso/Bidir namespace into per-command
-// structures. All topic-name parsing is contained here so the component never
-// sees a split('/').
+// structures. Row label is the last topic segment; title is the one before.
 export const groupCarCommands = (dataTypes: DataType[]): CarCommand[] => {
   const byTitle = new Map<string, CarCommandRow[]>();
   for (const dt of dataTypes) {
@@ -30,7 +11,7 @@ export const groupCarCommands = (dataTypes: DataType[]): CarCommand[] => {
     const parts = dt.name.split('/');
     const title = parts[parts.length - 2];
     const rows = byTitle.get(title) ?? [];
-    rows.push({ dataType: dt, label: carCommandRowLabel(dt.name) });
+    rows.push({ dataType: dt, label: parts[parts.length - 1] ?? '' });
     byTitle.set(title, rows);
   }
   return [...byTitle.entries()].map(([title, rows]) => ({ title, rows }));
@@ -188,10 +169,6 @@ export const topics = {
   accCCL,
   accDCL,
   msgsPerSecond,
-  pumpStatus,
-  rtdsOverride,
-  fanBattBoxStatus,
-  radFanStatus,
   driver,
   location,
   viewers,


### PR DESCRIPTION
## Changes

The Car Commands page was rendering a blank Name column for every row because the hardcoded CAR_COMMAND_ROW_LABELS map in topic.utils.ts only covered 6 topics that the firmware no longer publishes — the real live topics (eFuses slots, FanBMSPercent, BalancingBMSDutyCycle, State/RTDS) all fell through to an empty string.

- Deleted the stale map, the four unused Calypso/Bidir topic helpers (pumpStatus / rtdsOverride / fanBattBoxStatus / radFanStatus), the CarCommandSide type, and carCommandRowLabel
- groupCarCommands now takes the last `/`-segment of each topic as the row label, so every row automatically gets an identifiable name

## Notes

The helpers and the labels map were pointing at `Calypso/Bidir/State/PumpStatus/{A,B}` and friends, none of which exist in the live datatype set today. If firmware ever reintroduces them, the last-segment fallback still shows something readable — no rehardcoding needed.

## Test Cases

- Loaded /commands against a live backend with real datatypes — every row in eFuses, FanBMSPercent, BalancingBMSDutyCycle, and State cards now shows a Name (PumpTwo, Battbox, PumpOne, Dashboard, MC, LV, Shutdown, Radfan, Spare, Brake, Fanbatt, A, RTDS, A)
- Prettier and ng lint both clean


## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #597
