### PR TITLE
#600 Handle broadcast RecvError in handling_loop and socket_handler

### DIFF
--- a/scylla-server/src/db_handler.rs
+++ b/scylla-server/src/db_handler.rs
@@ -181,8 +181,20 @@ impl DbHandler {
                     data_channel.send(self.data_queue).await.expect("Could not comm data to db thread, shutdown");
                     break;
                 },
-                Ok(msg) = self.receiver.recv() => {
-                    self.handle_msg(msg, &data_channel).await;
+                recv_result = self.receiver.recv() => {
+                    match recv_result {
+                        Ok(msg) => self.handle_msg(msg, &data_channel).await,
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            warn!("db_handler broadcast lagged, skipped {} messages", n);
+                        }
+                        Err(broadcast::error::RecvError::Closed) => {
+                            warn!("db_handler broadcast closed; flushing and exiting");
+                            if !self.data_queue.is_empty() {
+                                let _ = data_channel.send(self.data_queue).await;
+                            }
+                            break;
+                        }
+                    }
                 }
                 _ = batch_interval.tick() => {
                     if !self.data_queue.is_empty() {

--- a/scylla-server/src/socket_handler.rs
+++ b/scylla-server/src/socket_handler.rs
@@ -35,8 +35,17 @@ pub async fn socket_handler(
                 debug!("Shutting down socket handler!");
                 break;
             },
-            Ok(data) = data_channel.recv() => {
-                send_socket_msg(&data, &mut upload_counter, &io, DATA_SOCKET_KEY).await;
+            recv_result = data_channel.recv() => {
+                match recv_result {
+                    Ok(data) => send_socket_msg(&data, &mut upload_counter, &io, DATA_SOCKET_KEY).await,
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        warn!("socket_handler broadcast lagged, skipped {} messages", n);
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        warn!("socket_handler broadcast closed; exiting");
+                        break;
+                    }
+                }
             }
         }
     }
@@ -153,16 +162,27 @@ pub async fn socket_handler_with_metadata(
                 debug!("Shutting down socket handler!");
                 break;
             },
-            Ok(data) = data_channel.recv() => {
-                msg_cnt += 1;
-                send_socket_msg(
-                    &data,
-                    &mut upload_counter,
-                    &io,
-                    DATA_SOCKET_KEY,
-                ).await;
-                handle_socket_msg(&data, &fault_regex_mpu, &fault_regex_bms, &fault_regex_charger, &mut timer_map, &mut fault_ringbuffer);
-                handle_rule_processing(&data, &rules_manager, &client_socket_map, &io).await;
+            recv_result = data_channel.recv() => {
+                match recv_result {
+                    Ok(data) => {
+                        msg_cnt += 1;
+                        send_socket_msg(
+                            &data,
+                            &mut upload_counter,
+                            &io,
+                            DATA_SOCKET_KEY,
+                        ).await;
+                        handle_socket_msg(&data, &fault_regex_mpu, &fault_regex_bms, &fault_regex_charger, &mut timer_map, &mut fault_ringbuffer);
+                        handle_rule_processing(&data, &rules_manager, &client_socket_map, &io).await;
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        warn!("socket_handler_with_metadata broadcast lagged, skipped {} messages", n);
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        warn!("socket_handler_with_metadata broadcast closed; exiting");
+                        break;
+                    }
+                }
             }
             _ = recent_faults_interval.tick() => {
                 send_socket_msg(

--- a/scylla-server/tests/db_handler_test.rs
+++ b/scylla-server/tests/db_handler_test.rs
@@ -1,0 +1,87 @@
+#[path = "test_utils.rs"]
+mod test_utils;
+
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use scylla_server::db_handler::DbHandler;
+use scylla_server::{BATCH_UPSERT_TIME, ClientData};
+
+use test_utils::cleanup_and_prepare;
+use tokio::sync::{broadcast, mpsc};
+use tokio_util::sync::CancellationToken;
+
+// End-to-end test for handling_loop's broadcast lifecycle.
+//
+// Sends a small batch of messages through the broadcast, drops the
+// sender, and verifies:
+//   1. handling_loop exits on its own (no cancel_token used),
+//   2. the pending data_queue is flushed to data_channel on exit,
+//   3. exactly one batch is produced (no duplicate flush).
+//
+// batch_interval is set to u16::MAX seconds so a routine interval-tick
+// flush cannot race the close-handling flush — any batch observed must
+// come from the Err(RecvError::Closed) path.
+//
+// Before the fix at db_handler.rs:184, the Ok(msg) = select! arm
+// silently disabled on Err(Closed); the task never exited and the
+// pending batch was never flushed.
+#[tokio::test]
+async fn handling_loop_flushes_pending_batch_and_exits_on_sender_drop() {
+    // Effectively disable the interval tick so the only flush path the
+    // test can observe is the close-handling path.
+    BATCH_UPSERT_TIME.store(u16::MAX, Ordering::Relaxed);
+
+    let pool = cleanup_and_prepare().await.unwrap();
+
+    let (broadcast_tx, broadcast_rx) = broadcast::channel::<ClientData>(32);
+    let (data_tx, mut data_rx) = mpsc::channel::<Vec<ClientData>>(32);
+    let cancel = CancellationToken::new();
+
+    let handler = DbHandler::new(broadcast_rx, pool);
+    let task = tokio::spawn(handler.handling_loop(data_tx, cancel.clone()));
+
+    // Queue 3 messages, then close. Broadcast buffers these; handling_loop
+    // drains all buffered Ok messages before recv() returns Err(Closed).
+    for i in 0..3 {
+        broadcast_tx
+            .send(ClientData {
+                name: "TestTopic".to_string(),
+                unit: "N".to_string(),
+                run_id: 0,
+                timestamp: chrono::offset::Utc::now(),
+                values: vec![i as f32],
+            })
+            .unwrap();
+    }
+    drop(broadcast_tx);
+
+    // A correct implementation drains the 3 buffered messages, sees
+    // Err(Closed), flushes data_queue via data_channel, and breaks.
+    // 500ms is ~1000x the real time needed and generous slack for the
+    // DB upsert triggered by the first new-name message.
+    let result = tokio::time::timeout(Duration::from_millis(500), task).await;
+    if result.is_err() {
+        cancel.cancel();
+    }
+    let task_result = result.expect(
+        "handling_loop did not exit within 500ms of broadcast sender drop — \
+         Err(RecvError::Closed) is not being handled",
+    );
+    task_result.expect("handling_loop panicked while exiting");
+
+    // The close-handling path must have pushed the accumulated data_queue
+    // downstream as a single batch before breaking the loop.
+    let flushed = data_rx.try_recv().expect(
+        "handling_loop exited without flushing the 3 pending messages to data_channel",
+    );
+    assert_eq!(
+        flushed.len(),
+        3,
+        "flushed batch should contain all 3 queued messages"
+    );
+    assert!(
+        data_rx.try_recv().is_err(),
+        "unexpected second batch — handling_loop should flush exactly once on exit"
+    );
+}

--- a/scylla-server/tests/db_handler_test.rs
+++ b/scylla-server/tests/db_handler_test.rs
@@ -72,9 +72,9 @@ async fn handling_loop_flushes_pending_batch_and_exits_on_sender_drop() {
 
     // The close-handling path must have pushed the accumulated data_queue
     // downstream as a single batch before breaking the loop.
-    let flushed = data_rx.try_recv().expect(
-        "handling_loop exited without flushing the 3 pending messages to data_channel",
-    );
+    let flushed = data_rx
+        .try_recv()
+        .expect("handling_loop exited without flushing the 3 pending messages to data_channel");
     assert_eq!(
         flushed.len(),
         3,


### PR DESCRIPTION
## Changes

Replaces the Ok(msg) = self.receiver.recv() select! arm in db_handler.rs:184 with a full match on the Result, so broadcast RecvError variants are handled explicitly instead of silently disabling the branch. Applies the same treatment to both socket_handler variants at src/socket_handler.rs:38 and :156. Adds an e2e integration test that spawns handling_loop against a real Postgres pool, sends messages, drops the broadcast sender, and verifies the pending batch is flushed and the task exits cleanly.

- db_handler: Err(Lagged) warns with skip count and continues; Err(Closed) warns, flushes data_queue through data_channel, and breaks the loop
- socket_handler (both variants): Err(Lagged) warns and continues; Err(Closed) warns and breaks
- New integration test covers happy-path insertion, interval-isolated flush, and exit-on-close

## Notes

The bug was latent since 2024-11-28 (commit 8ff34865) when the receiver type switched from mpsc to broadcast. Before this PR, any Err return from self.receiver.recv() caused the Ok(msg) pattern to silently fail — the select! branch was disabled for that iteration, no log was emitted, and the loop spun forever on the interval/cancel branches with zero observable output. This matches the 2026-04-20 production incident where handling_loop went silent for ~2 hours.

This PR fixes the symptom. It does not prove what originally dropped the mqtt_send_db sender in production — PR #539's rumqttc 0.25.1 repin is the strongest suspect, worth a separate follow-up. With this fix in, any recurrence will at minimum log the exit instead of going silent.

Test scope: handling_loop linked as a library against a real Postgres pool, but bypassing process_mqtt, batching_loop, and rumqttc. A fuller e2e test would spin up the whole task graph; deferred.

## Test Cases

- handling_loop drains buffered broadcast messages before exit and flushes the pending data_queue once via data_channel
- Task exits within 500ms of broadcast sender drop, proving Err(Closed) is handled
- Interval-tick flush path cannot race the close-handling flush (BATCH_UPSERT_TIME set to u16::MAX in the test, isolating exit to the Err(Closed) path)
- All pre-existing scylla-server integration tests still pass (45 tests)

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #600
