### PR TITLE
#601 Move eFuses to main nav bar

### DIFF
--- a/angular-client/src/app/app-nav-bar/app-nav-bar.component.ts
+++ b/angular-client/src/app/app-nav-bar/app-nav-bar.component.ts
@@ -151,7 +151,13 @@ export class AppNavBarComponent implements OnInit, OnDestroy {
       onClick: () => this.navigateTo(appRoutes.graphRoute()),
       icon: 'bar_chart'
     },
-    { id: appRoutes.bmsRoute(), label: 'BMS', onClick: () => this.navigateTo(appRoutes.bmsRoute()), icon: 'action_key' }
+    { id: appRoutes.bmsRoute(), label: 'BMS', onClick: () => this.navigateTo(appRoutes.bmsRoute()), icon: 'action_key' },
+    {
+      id: appRoutes.efusesRoute(),
+      label: 'eFuses',
+      onClick: () => this.navigateTo(appRoutes.efusesRoute()),
+      icon: 'electrical_services'
+    }
   ];
 
   onlyDesktopNavItems: NavItem[] = [...this.mostUsedNavItems];
@@ -171,12 +177,6 @@ export class AppNavBarComponent implements OnInit, OnDestroy {
       label: 'Fault',
       onClick: () => this.navigateTo(appRoutes.faultsRoute()),
       icon: 'error'
-    },
-    {
-      id: appRoutes.efusesRoute(),
-      label: 'eFuses',
-      onClick: () => this.navigateTo(appRoutes.efusesRoute()),
-      icon: 'electrical_services'
     },
     {
       id: appRoutes.mapRoute(),


### PR DESCRIPTION
## Changes

Promotes the eFuses page from the overflow apps-menu popup into the primary desktop nav bar alongside Charging, Graph, and BMS, so it's one click away during a run. Single-file change in app-nav-bar.component.ts — moves the NavItem between the mostUsedNavItems and navMenuItems arrays.

## Notes

- onlyDesktopNavItems and allNavItems are derived from the two arrays via spread, so the mobile sidebar keeps showing eFuses exactly once and the overflow menu drops it automatically
- Existing electrical_services icon and efusesRoute helper are reused — no new routes, imports, or types
- Backend was down during local verification; dynamic content in the nav bar (run display, messages/sec, notifications) was not exercised, but the moved link is pure layout

## Test Cases

- eFuses renders in the primary nav bar at desktop widths, to the right of BMS
- Active-state highlight applies when on /efuses
- Mobile sidebar lists eFuses exactly once (no duplicate from the spread)
- Overflow apps menu no longer shows eFuses
- Three responsive breakpoints: >1160px, 768–1160px, ≤768px

## Screenshots

_screenshot pending_

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #601
