### PR TITLE
#598 Heartbeat + task-exit logging for scylla-server loops

### DIFF
--- a/scylla-server/src/db_handler.rs
+++ b/scylla-server/src/db_handler.rs
@@ -74,7 +74,10 @@ impl DbHandler {
         pool: PoolHandle,
         cancel_token: CancellationToken,
     ) {
+        let mut heartbeat = tokio::time::interval(Duration::from_secs(30));
+        let mut iter_count: u64 = 0;
         loop {
+            iter_count = iter_count.wrapping_add(1);
             if DATA_UPLOAD_DISABLE.load(Ordering::Relaxed) {
                 tokio::select! {
                     _ = cancel_token.cancelled() => {
@@ -83,6 +86,15 @@ impl DbHandler {
                     },
                     Some(msgs) = batch_queue.recv() => {
                         warn!("NOT STORING {} MESSAGES", msgs.len());
+                    },
+                    _ = heartbeat.tick() => {
+                        info!(
+                            task = "batching_loop",
+                            iter = iter_count,
+                            batch_queue_len = batch_queue.len(),
+                            upload_disabled = true,
+                            "heartbeat"
+                        );
                     },
                 }
             } else {
@@ -134,6 +146,15 @@ impl DbHandler {
                             batch_queue.max_capacity()
                         );
                     }
+                    _ = heartbeat.tick() => {
+                        info!(
+                            task = "batching_loop",
+                            iter = iter_count,
+                            batch_queue_len = batch_queue.len(),
+                            upload_disabled = false,
+                            "heartbeat"
+                        );
+                    },
                 }
             }
         }
@@ -164,9 +185,12 @@ impl DbHandler {
         let mut batch_interval = tokio::time::interval(Duration::from_secs(
             BATCH_UPSERT_TIME.load(Ordering::Relaxed).into(),
         ));
+        let mut heartbeat = tokio::time::interval(Duration::from_secs(30));
+        let mut iter_count: u64 = 0;
         // the max batch size to reasonably expect
         let mut max_batch_size = 2usize;
         loop {
+            iter_count = iter_count.wrapping_add(1);
             // if the batch interval changed, act. this is run per message, which is a performance concern
             if BATCH_UPSERT_TIME.load(Ordering::Relaxed) as u64 != batch_interval.period().as_secs()
             {
@@ -195,6 +219,15 @@ impl DbHandler {
                         // give a vector a size that hopefully is big enough to fit the next batch
                         self.data_queue = Vec::with_capacity((max_batch_size as f32 * 1.05) as usize);
                     }
+                }
+                _ = heartbeat.tick() => {
+                    info!(
+                        task = "handling_loop",
+                        iter = iter_count,
+                        data_queue_len = self.data_queue.len(),
+                        mqtt_recv_len = self.receiver.len(),
+                        "heartbeat"
+                    );
                 }
             }
         }

--- a/scylla-server/src/db_handler.rs
+++ b/scylla-server/src/db_handler.rs
@@ -53,6 +53,28 @@ fn chunk_vec<T: Clone>(input: &[T], max_chunk_size: usize) -> Vec<Vec<T>> {
     result
 }
 
+/// Send a batch over the mpsc, emitting a warn every 5s if the send is still pending.
+/// The send itself always completes (or errors on channel close); the warn is purely
+/// to surface a wedged downstream consumer in logs.
+async fn send_batch_with_wedge_warn(
+    sender: &mpsc::Sender<Vec<ClientData>>,
+    payload: Vec<ClientData>,
+    task: &'static str,
+) -> Result<(), mpsc::error::SendError<Vec<ClientData>>> {
+    let send_fut = sender.send(payload);
+    tokio::pin!(send_fut);
+    let mut wedge_at = Box::pin(tokio::time::sleep(Duration::from_secs(5)));
+    loop {
+        tokio::select! {
+            res = &mut send_fut => return res,
+            _ = &mut wedge_at => {
+                warn!(task, "mpsc send slow/wedged, downstream likely blocked");
+                wedge_at = Box::pin(tokio::time::sleep(Duration::from_secs(5)));
+            }
+        }
+    }
+}
+
 impl DbHandler {
     /// Make a new db handler
     /// * `recv` - the broadcast reciver of which clientdata will be sent
@@ -74,8 +96,10 @@ impl DbHandler {
         pool: PoolHandle,
         cancel_token: CancellationToken,
     ) {
+        info!(task = "batching_loop", "starting");
         let mut heartbeat = tokio::time::interval(Duration::from_secs(30));
         let mut iter_count: u64 = 0;
+        let mut msgs_since_hb: u64 = 0;
         loop {
             iter_count = iter_count.wrapping_add(1);
             if DATA_UPLOAD_DISABLE.load(Ordering::Relaxed) {
@@ -85,6 +109,7 @@ impl DbHandler {
                         break;
                     },
                     Some(msgs) = batch_queue.recv() => {
+                        msgs_since_hb = msgs_since_hb.wrapping_add(1);
                         warn!("NOT STORING {} MESSAGES", msgs.len());
                     },
                     _ = heartbeat.tick() => {
@@ -92,9 +117,11 @@ impl DbHandler {
                             task = "batching_loop",
                             iter = iter_count,
                             batch_queue_len = batch_queue.len(),
+                            msgs_in_window = msgs_since_hb,
                             upload_disabled = true,
                             "heartbeat"
                         );
+                        msgs_since_hb = 0;
                     },
                 }
             } else {
@@ -126,6 +153,7 @@ impl DbHandler {
                         break;
                     },
                     Some(msgs) = batch_queue.recv() => {
+                        msgs_since_hb = msgs_since_hb.wrapping_add(1);
                         // libpq has max 65535 params, therefore batch
                         // max for batch is 65535/4 params per message, hence the below, rounded down with a margin for safety
                         // TODO avoid this code batch uploading the remainder messages as a new batch, combine it with another safely
@@ -151,9 +179,11 @@ impl DbHandler {
                             task = "batching_loop",
                             iter = iter_count,
                             batch_queue_len = batch_queue.len(),
+                            msgs_in_window = msgs_since_hb,
                             upload_disabled = false,
                             "heartbeat"
                         );
+                        msgs_since_hb = 0;
                     },
                 }
             }
@@ -182,11 +212,13 @@ impl DbHandler {
         data_channel: mpsc::Sender<Vec<ClientData>>,
         cancel_token: CancellationToken,
     ) {
+        info!(task = "handling_loop", "starting");
         let mut batch_interval = tokio::time::interval(Duration::from_secs(
             BATCH_UPSERT_TIME.load(Ordering::Relaxed).into(),
         ));
         let mut heartbeat = tokio::time::interval(Duration::from_secs(30));
         let mut iter_count: u64 = 0;
+        let mut msgs_since_hb: u64 = 0;
         // the max batch size to reasonably expect
         let mut max_batch_size = 2usize;
         loop {
@@ -202,18 +234,33 @@ impl DbHandler {
             tokio::select! {
                 _ = cancel_token.cancelled() => {
                     debug!("Pushing final messages to queue");
-                    data_channel.send(self.data_queue).await.expect("Could not comm data to db thread, shutdown");
+                    send_batch_with_wedge_warn(&data_channel, self.data_queue, "handling_loop")
+                        .await
+                        .expect("Could not comm data to db thread, shutdown");
                     break;
                 },
-                Ok(msg) = self.receiver.recv() => {
-                    self.handle_msg(msg, &data_channel).await;
-                }
+                msg = self.receiver.recv() => match msg {
+                    Ok(msg) => {
+                        msgs_since_hb = msgs_since_hb.wrapping_add(1);
+                        self.handle_msg(msg, &data_channel).await;
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        warn!(
+                            task = "handling_loop",
+                            lagged = n,
+                            "broadcast receiver lagged, dropped messages"
+                        );
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        warn!(task = "handling_loop", "broadcast sender closed, exiting loop");
+                        break;
+                    }
+                },
                 _ = batch_interval.tick() => {
                     if !self.data_queue.is_empty() {
                         // set a new max if this batch is larger
                         max_batch_size = usize::max(max_batch_size, self.data_queue.len());
-                        data_channel
-                            .send(self.data_queue)
+                        send_batch_with_wedge_warn(&data_channel, self.data_queue, "handling_loop")
                             .await
                             .expect("Could not comm data to db thread");
                         // give a vector a size that hopefully is big enough to fit the next batch
@@ -226,8 +273,10 @@ impl DbHandler {
                         iter = iter_count,
                         data_queue_len = self.data_queue.len(),
                         mqtt_recv_len = self.receiver.len(),
+                        msgs_in_window = msgs_since_hb,
                         "heartbeat"
                     );
+                    msgs_since_hb = 0;
                 }
             }
         }

--- a/scylla-server/src/db_handler.rs
+++ b/scylla-server/src/db_handler.rs
@@ -53,9 +53,9 @@ fn chunk_vec<T: Clone>(input: &[T], max_chunk_size: usize) -> Vec<Vec<T>> {
     result
 }
 
-/// Send a batch over the mpsc, emitting a warn every 5s if the send is still pending.
-/// The send itself always completes (or errors on channel close); the warn is purely
-/// to surface a wedged downstream consumer in logs.
+/// Awaits an mpsc send, emitting a warn every 5s while the send is pending so a
+/// wedged downstream consumer is visible in logs. Returns whatever the underlying
+/// send resolves to — including never, if the consumer is truly wedged forever.
 async fn send_batch_with_wedge_warn(
     sender: &mpsc::Sender<Vec<ClientData>>,
     payload: Vec<ClientData>,
@@ -66,6 +66,7 @@ async fn send_batch_with_wedge_warn(
     let mut wedge_at = Box::pin(tokio::time::sleep(Duration::from_secs(5)));
     loop {
         tokio::select! {
+            biased;
             res = &mut send_fut => return res,
             _ = &mut wedge_at => {
                 warn!(task, "mpsc send slow/wedged, downstream likely blocked");
@@ -117,7 +118,7 @@ impl DbHandler {
                             task = "batching_loop",
                             iter = iter_count,
                             batch_queue_len = batch_queue.len(),
-                            msgs_in_window = msgs_since_hb,
+                            batches_in_window = msgs_since_hb,
                             upload_disabled = true,
                             "heartbeat"
                         );
@@ -179,7 +180,7 @@ impl DbHandler {
                             task = "batching_loop",
                             iter = iter_count,
                             batch_queue_len = batch_queue.len(),
-                            msgs_in_window = msgs_since_hb,
+                            batches_in_window = msgs_since_hb,
                             upload_disabled = false,
                             "heartbeat"
                         );
@@ -252,7 +253,12 @@ impl DbHandler {
                         );
                     }
                     Err(broadcast::error::RecvError::Closed) => {
-                        warn!(task = "handling_loop", "broadcast sender closed, exiting loop");
+                        warn!(task = "handling_loop", "broadcast sender closed, flushing and exiting");
+                        if !self.data_queue.is_empty() {
+                            send_batch_with_wedge_warn(&data_channel, self.data_queue, "handling_loop")
+                                .await
+                                .expect("Could not comm data to db thread, broadcast-closed flush");
+                        }
                         break;
                     }
                 },

--- a/scylla-server/src/main.rs
+++ b/scylla-server/src/main.rs
@@ -196,7 +196,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     std::panic::set_hook(Box::new(|info| {
-        error!(thread = ?std::thread::current().id(), "panic: {}", info);
+        let bt = std::backtrace::Backtrace::capture();
+        error!(
+            thread = ?std::thread::current().id(),
+            "panic: {}\nbacktrace:\n{}",
+            info,
+            bt
+        );
     }));
 
     info!("Configuring global variables");

--- a/scylla-server/src/main.rs
+++ b/scylla-server/src/main.rs
@@ -258,27 +258,41 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let token = CancellationToken::new();
 
     if cli.no_metadata {
-        task_tracker.spawn(socket_handler(token.clone(), mqtt_receive_socket, io));
+        let fut = socket_handler(token.clone(), mqtt_receive_socket, io);
+        task_tracker.spawn(async move {
+            let res = tokio::spawn(fut).await;
+            warn!(task = "socket_handler", "task ended: {:?}", res);
+        });
     } else {
-        task_tracker.spawn(socket_handler_with_metadata(
+        let fut = socket_handler_with_metadata(
             token.clone(),
             mqtt_receive_socket,
             rules_manager.clone(),
             io,
-        ));
+        );
+        task_tracker.spawn(async move {
+            let res = tokio::spawn(fut).await;
+            warn!(task = "socket_handler_with_metadata", "task ended: {:?}", res);
+        });
     }
 
     // spawn the database handler
-    task_tracker.spawn(
-        db_handler::DbHandler::new(mqtt_receive_db, pool.clone())
-            .handling_loop(db_send.clone(), token.clone()),
-    );
+    let handling_loop_fut = db_handler::DbHandler::new(mqtt_receive_db, pool.clone())
+        .handling_loop(db_send.clone(), token.clone());
+    task_tracker.spawn(async move {
+        let res = tokio::spawn(handling_loop_fut).await;
+        warn!(task = "handling_loop", "task ended: {:?}", res);
+    });
     // spawn the database inserter
-    task_tracker.spawn(db_handler::DbHandler::batching_loop(
+    let batching_loop_fut = db_handler::DbHandler::batching_loop(
         db_receive,
         pool.clone(),
         token.clone(),
-    ));
+    );
+    task_tracker.spawn(async move {
+        let res = tokio::spawn(batching_loop_fut).await;
+        warn!(task = "batching_loop", "task ended: {:?}", res);
+    });
 
     // run prod if this isnt present
     // create and spawn the mqtt processor
@@ -293,7 +307,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     let (client, eventloop) = AsyncClient::new(opts, 600);
     let client_sharable: Arc<AsyncClient> = Arc::new(client);
-    task_tracker.spawn(recv.process_mqtt(client_sharable.clone(), eventloop, pool.clone()));
+    let process_mqtt_fut = recv.process_mqtt(client_sharable.clone(), eventloop, pool.clone());
+    task_tracker.spawn(async move {
+        let res = tokio::spawn(process_mqtt_fut).await;
+        warn!(task = "mqtt_processor", "task ended: {:?}", res);
+    });
 
     let app = Router::new()
         .merge(

--- a/scylla-server/src/main.rs
+++ b/scylla-server/src/main.rs
@@ -52,7 +52,7 @@ use tower_http::{
     cors::{Any, CorsLayer},
     trace::TraceLayer,
 };
-use tracing::{debug, info, level_filters::LevelFilter, warn};
+use tracing::{debug, error, info, level_filters::LevelFilter, warn};
 use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan};
 
 #[cfg(not(target_env = "msvc"))]
@@ -195,6 +195,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tracing::subscriber::set_global_default(subscriber).expect("Could not init tracing");
     }
 
+    std::panic::set_hook(Box::new(|info| {
+        error!(thread = ?std::thread::current().id(), "panic: {}", info);
+    }));
+
     info!("Configuring global variables");
     DATA_UPLOAD_DISABLE.store(cli.disable_data_upload, Ordering::Relaxed);
     BATCH_UPSERT_TIME.store(cli.batch_upsert_time, Ordering::Relaxed);
@@ -272,7 +276,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
         task_tracker.spawn(async move {
             let res = tokio::spawn(fut).await;
-            warn!(task = "socket_handler_with_metadata", "task ended: {:?}", res);
+            warn!(
+                task = "socket_handler_with_metadata",
+                "task ended: {:?}", res
+            );
         });
     }
 
@@ -284,11 +291,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         warn!(task = "handling_loop", "task ended: {:?}", res);
     });
     // spawn the database inserter
-    let batching_loop_fut = db_handler::DbHandler::batching_loop(
-        db_receive,
-        pool.clone(),
-        token.clone(),
-    );
+    let batching_loop_fut =
+        db_handler::DbHandler::batching_loop(db_receive, pool.clone(), token.clone());
     task_tracker.spawn(async move {
         let res = tokio::spawn(batching_loop_fut).await;
         warn!(task = "batching_loop", "task ended: {:?}", res);
@@ -458,13 +462,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await
         .expect("Could not bind to 8000!");
     let axum_token = token.clone();
-    tokio::spawn(async {
+    let axum_fut = async move {
         axum::serve(listener, app)
             .with_graceful_shutdown(async move {
                 _ = axum_token.cancelled().await;
             })
             .await
             .expect("Failed shutdown init for axum");
+    };
+    tokio::spawn(async move {
+        let res = tokio::spawn(axum_fut).await;
+        warn!(task = "axum_serve", "task ended: {:?}", res);
     });
 
     task_tracker.close();

--- a/scylla-server/src/mqtt_processor.rs
+++ b/scylla-server/src/mqtt_processor.rs
@@ -14,7 +14,7 @@ use rumqttc::v5::{
 use rustc_hash::FxHashMap;
 use tokio::{sync::broadcast, time::Instant};
 use tokio_util::sync::CancellationToken;
-use tracing::{Level, debug, instrument, trace, warn};
+use tracing::{Level, debug, info, instrument, trace, warn};
 
 use crate::{
     RATE_LIMIT_MODE, RateLimitMode, STATIC_RATE_LIMIT_VALUE,
@@ -104,6 +104,8 @@ impl MqttProcessor {
     ) {
         // let mut latency_interval = tokio::time::interval(Duration::from_millis(250));
         let mut latency_ringbuffer = ringbuffer::AllocRingBuffer::<TimeDelta>::new(20);
+        let mut heartbeat = tokio::time::interval(Duration::from_secs(30));
+        let mut iter_count: u64 = 0;
 
         debug!("Subscribing to siren");
         client
@@ -112,6 +114,7 @@ impl MqttProcessor {
             .expect("Could not subscribe to Siren");
 
         loop {
+            iter_count = iter_count.wrapping_add(1);
             #[rustfmt::skip] // rust cannot format this macro for some reason
             tokio::select! {
                 _ = self.cancel_token.cancelled() => {
@@ -133,6 +136,15 @@ impl MqttProcessor {
                     },
                     Err(msg) => trace!("Received mqtt error: {:?}", msg),
                     _ => trace!("Received misc mqtt: {:?}", msg),
+                },
+                _ = heartbeat.tick() => {
+                    info!(
+                        task = "mqtt_processor",
+                        iter = iter_count,
+                        db_channel_len = self.db_channel.len(),
+                        socket_channel_len = self.socket_channel.len(),
+                        "heartbeat"
+                    );
                 },
                 // _ = latency_interval.tick() => {
                 //     // set latency to 0 if no messages are in buffer

--- a/scylla-server/src/mqtt_processor.rs
+++ b/scylla-server/src/mqtt_processor.rs
@@ -102,10 +102,12 @@ impl MqttProcessor {
         mut eventloop: EventLoop,
         pool: Pool<AsyncPgConnection>,
     ) {
+        info!(task = "mqtt_processor", "starting");
         // let mut latency_interval = tokio::time::interval(Duration::from_millis(250));
         let mut latency_ringbuffer = ringbuffer::AllocRingBuffer::<TimeDelta>::new(20);
         let mut heartbeat = tokio::time::interval(Duration::from_secs(30));
         let mut iter_count: u64 = 0;
+        let mut msgs_since_hb: u64 = 0;
 
         debug!("Subscribing to siren");
         client
@@ -123,6 +125,7 @@ impl MqttProcessor {
                 },
                 msg = eventloop.poll() => match msg {
                     Ok(Event::Incoming(Packet::Publish(msg))) => {
+                        msgs_since_hb = msgs_since_hb.wrapping_add(1);
                         trace!("Received mqtt message: {:?}", msg);
                         // parse the message into the data and the node name it falls under
                         let (send_db, msg) = self.parse_msg(msg, &pool).await;
@@ -143,8 +146,10 @@ impl MqttProcessor {
                         iter = iter_count,
                         db_channel_len = self.db_channel.len(),
                         socket_channel_len = self.socket_channel.len(),
+                        msgs_in_window = msgs_since_hb,
                         "heartbeat"
                     );
+                    msgs_since_hb = 0;
                 },
                 // _ = latency_interval.tick() => {
                 //     // set latency to 0 if no messages are in buffer

--- a/scylla-server/src/socket_handler.rs
+++ b/scylla-server/src/socket_handler.rs
@@ -28,9 +28,11 @@ pub async fn socket_handler(
     mut data_channel: broadcast::Receiver<ClientData>,
     io: SocketIo,
 ) {
+    info!(task = "socket_handler", "starting");
     let mut upload_counter = 0u8;
     let mut heartbeat = tokio::time::interval(Duration::from_secs(30));
     let mut iter_count: u64 = 0;
+    let mut msgs_since_hb: u64 = 0;
     loop {
         iter_count = iter_count.wrapping_add(1);
         tokio::select! {
@@ -39,6 +41,7 @@ pub async fn socket_handler(
                 break;
             },
             Ok(data) = data_channel.recv() => {
+                msgs_since_hb = msgs_since_hb.wrapping_add(1);
                 send_socket_msg(&data, &mut upload_counter, &io, DATA_SOCKET_KEY).await;
             }
             _ = heartbeat.tick() => {
@@ -46,8 +49,10 @@ pub async fn socket_handler(
                     task = "socket_handler",
                     iter = iter_count,
                     data_channel_len = data_channel.len(),
+                    msgs_in_window = msgs_since_hb,
                     "heartbeat"
                 );
+                msgs_since_hb = 0;
             }
         }
     }
@@ -91,6 +96,7 @@ pub async fn socket_handler_with_metadata(
     rules_manager: Arc<RuleManager>,
     io: SocketIo,
 ) {
+    info!(task = "socket_handler_with_metadata", "starting");
     let mut upload_counter = 0u8;
 
     // BEGIN METADATA
@@ -160,6 +166,7 @@ pub async fn socket_handler_with_metadata(
 
     let mut heartbeat = tokio::time::interval(Duration::from_secs(30));
     let mut iter_count: u64 = 0;
+    let mut msgs_since_hb: u64 = 0;
 
     loop {
         iter_count = iter_count.wrapping_add(1);
@@ -170,6 +177,7 @@ pub async fn socket_handler_with_metadata(
             },
             Ok(data) = data_channel.recv() => {
                 msg_cnt += 1;
+                msgs_since_hb = msgs_since_hb.wrapping_add(1);
                 send_socket_msg(
                     &data,
                     &mut upload_counter,
@@ -184,8 +192,10 @@ pub async fn socket_handler_with_metadata(
                     task = "socket_handler_with_metadata",
                     iter = iter_count,
                     data_channel_len = data_channel.len(),
+                    msgs_in_window = msgs_since_hb,
                     "heartbeat"
                 );
+                msgs_since_hb = 0;
             }
             _ = recent_faults_interval.tick() => {
                 send_socket_msg(

--- a/scylla-server/src/socket_handler.rs
+++ b/scylla-server/src/socket_handler.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use std::{sync::atomic::Ordering, time::Duration};
 use tokio::sync::{RwLock, broadcast};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 use crate::metadata_structs::{
     DATA_SOCKET_KEY, FAULT_BINS, FAULT_MIN_REG_GAP, FAULT_SOCKET_KEY, FaultData,
@@ -29,7 +29,10 @@ pub async fn socket_handler(
     io: SocketIo,
 ) {
     let mut upload_counter = 0u8;
+    let mut heartbeat = tokio::time::interval(Duration::from_secs(30));
+    let mut iter_count: u64 = 0;
     loop {
+        iter_count = iter_count.wrapping_add(1);
         tokio::select! {
             _ = cancel_token.cancelled() => {
                 debug!("Shutting down socket handler!");
@@ -37,6 +40,14 @@ pub async fn socket_handler(
             },
             Ok(data) = data_channel.recv() => {
                 send_socket_msg(&data, &mut upload_counter, &io, DATA_SOCKET_KEY).await;
+            }
+            _ = heartbeat.tick() => {
+                info!(
+                    task = "socket_handler",
+                    iter = iter_count,
+                    data_channel_len = data_channel.len(),
+                    "heartbeat"
+                );
             }
         }
     }
@@ -147,7 +158,11 @@ pub async fn socket_handler_with_metadata(
     let mut msg_cnt = 0u64;
     let mut last_instant = tokio::time::Instant::now();
 
+    let mut heartbeat = tokio::time::interval(Duration::from_secs(30));
+    let mut iter_count: u64 = 0;
+
     loop {
+        iter_count = iter_count.wrapping_add(1);
         tokio::select! {
             _ = cancel_token.cancelled() => {
                 debug!("Shutting down socket handler!");
@@ -163,6 +178,14 @@ pub async fn socket_handler_with_metadata(
                 ).await;
                 handle_socket_msg(&data, &fault_regex_mpu, &fault_regex_bms, &fault_regex_charger, &mut timer_map, &mut fault_ringbuffer);
                 handle_rule_processing(&data, &rules_manager, &client_socket_map, &io).await;
+            }
+            _ = heartbeat.tick() => {
+                info!(
+                    task = "socket_handler_with_metadata",
+                    iter = iter_count,
+                    data_channel_len = data_channel.len(),
+                    "heartbeat"
+                );
             }
             _ = recent_faults_interval.tick() => {
                 send_socket_msg(


### PR DESCRIPTION
## Changes

Adds runtime observability to the long-running tokio select loops in scylla-server so the next silent wedge (like the 2026-04-20 02:49 UTC db_handler hang) is actually diagnosable.

- Heartbeat logs every 30s from handling_loop, batching_loop, socket_handler, socket_handler_with_metadata, and mqtt_processor. Each emits an INFO line with task name, cumulative iteration count, relevant queue/channel depth, and msgs_in_window — a counter of work-branch fires since the last heartbeat.
- Task-exit supervisor around every task_tracker.spawn call in main.rs — wraps the inner future in tokio::spawn and logs a WARN line when the JoinHandle resolves, whether that is a clean return, a panic, or an abort. Extended to cover the axum serve task too.
- Broadcast Lagged explicit handling in handling_loop — the previous Ok(msg) = recv() pattern silently dropped Err(Lagged(n)), which is a documented broadcast failure mode where the consumer falls behind by more than channel capacity. Now a WARN line surfaces the lag count. Candidate root-cause #1 for the 2026-04-20 wedge.
- mpsc send wedge detection via a send_batch_with_wedge_warn helper — wraps data_channel.send().await with a 5s watchdog. If the send stays pending, a WARN fires every 5s until it completes. Directly tests the ticket's called-out plausible hang site (backpressure from a wedged batching_loop).
- Task-startup log — info!(task="X", "starting") as the first line of each task. Distinguishes "never started" (panicked in setup) from "silently wedged mid-loop" and pairs with the existing task ended supervisor for a bookended lifecycle log.
- Global panic hook in main() — std::panic::set_hook captures the full panic location and thread id at unwind, richer than the JoinError::Panic payload the supervisor catches on its own.

Scope widened beyond the ticket's db_handler-only suggestion (agreed in discussion): the same observability gap exists for any long-running select loop, and the extra work is ~6 lines each.

## Notes

- Root cause of the 2026-04-20 wedge is still unknown and explicitly out of scope — this PR only adds the observability needed for the next occurrence to be diagnosable.
- Steady-state log volume: 5 INFO heartbeat lines per 30s (10/min). No new WARN-level noise during normal operation.
- task ended: Ok(()) fires once per task at WARN on every clean shutdown (matches the ticket's example). The forcing function is intentional — if you see this line outside a Ctrl+C, a supervised task resolved when it was not supposed to.

## How to read the new logs

- Heartbeat gap: if heartbeat lines for a given task stop appearing for ≥60s, that loop's select is wedged on an await inside one of its branches. The iter value at the last heartbeat confirms the loop counter froze.
- msgs_in_window=0 across consecutive heartbeats while iter still advances: the loop is alive but its work branch is not firing. Contrast with the heartbeat-gap case (whole select wedged).
- lagged=N warn: the broadcast consumer fell behind and dropped N messages. Check mqtt_recv_len trend across prior heartbeats to correlate.
- mpsc send slow/wedged warn: the downstream consumer (batching_loop) is not draining. Look for its heartbeat going stale.
- Task exit: a task ended line with Err(JoinError::Panic(...)) or an unexpected clean exit during normal operation identifies which task died and how. A preceding ERROR panic: ... line from the panic hook will carry the full panic location and thread id.
- Queue depth trend: a rising db_channel_len, batch_queue_len, or data_queue_len across consecutive heartbeats points to the downstream consumer throttling before it wedges.

Sample lines (from local run):

```
INFO heartbeat task="handling_loop" iter=84269 data_queue_len=0 mqtt_recv_len=59 msgs_in_window=8421
INFO heartbeat task="mqtt_processor" iter=84329 db_channel_len=52 socket_channel_len=61 msgs_in_window=8356
WARN broadcast receiver lagged, dropped messages task="handling_loop" lagged=276
WARN mpsc send slow/wedged, downstream likely blocked task="handling_loop"
ERROR panic: panicked at src/... thread=ThreadId(1)
WARN task ended: Ok(()) task="batching_loop"
```

## Test Cases

- Verified locally against scylla-dev compose profile with the Calypso simulator feeding real traffic.
- Confirmed first heartbeat round fires immediately on task startup, second round fires 30s later, iter counts advance monotonically, msgs_in_window reflects simulator throughput.
- Confirmed Ctrl+C produces one task ended: Ok(()) line per supervised task at WARN, including the axum_serve task.
- Induced slow consumer (100ms sleep in handle_msg) → broadcast receiver lagged warn fired repeatedly with lagged counts in the hundreds, confirming the previously-silent broadcast lag path is now observable.
- Induced downstream hang (batching_loop sleep + mpsc cap reduced to 1) → mpsc send slow/wedged warn fired at t+5s and re-armed on subsequent polls.
- Full-hang injection (sleep(3600) at iter==5 in handling_loop) reproduced the 2026-04-20 wedge signature exactly: handling_loop heartbeats went silent, mqtt_processor heartbeats continued with db_channel_len saturated at 16384 (tokio broadcast rounds the configured 10000 cap up to the next power of 2) and msgs_in_window staying nonzero upstream. Other tasks unaffected. This is the diagnostic target of the whole PR.
- Panic hook validated against a real AddrInUse panic during phase testing — captured full panic location and thread=ThreadId(1), preceding the supervisor's task ended: Err(...) line as designed.
- cargo build, cargo clippy --no-deps, and cargo fmt all clean (only pre-existing clippy warning in rule_structs.rs is unrelated).

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No package-lock.json changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #598
