### PR TITLE
Remove Battbox eFuse Unlock Button

### DIFF
--- a/angular-client/src/pages/efuses-page/efuses-page.component.html
+++ b/angular-client/src/pages/efuses-page/efuses-page.component.html
@@ -100,7 +100,14 @@
     />
 
     <!-- Battbox eFuse -->
-    <efuse-card efuseName="Battbox" [efuseTopicKey]="'Battbox'" commandKey="Battbox" [maxCurrent]="'2'" />
+    <efuse-card
+      efuseName="Battbox"
+      [efuseTopicKey]="'Battbox'"
+      commandKey="Battbox"
+      [maxCurrent]="'2'"
+      [notice]="'Note: Battbox eFuse can\'t be turned off from here.'"
+      [lockButtonEnabled]="false"
+    />
 
     <!-- MC eFuse -->
     <efuse-card efuseName="Motor Controller" [efuseTopicKey]="'MC'" commandKey="MC" [maxCurrent]="'2'" />


### PR DESCRIPTION
Battbox eFuse is now configured to always be on in Cerberus-2.0, so I updated the UI here to reflect that (i.e., I disabled the unlock button like for LV and Shutdown).