### PR TITLE
#587 Fix graph x-axis + legend clipped on load

### DIFF
--- a/angular-client/src/pages/graph-page/graph-page.component.css
+++ b/angular-client/src/pages/graph-page/graph-page.component.css
@@ -1,16 +1,18 @@
 :host {
-  max-height: inherit;
+  display: block;
+  height: calc(100vh - 60px); /* 60px = app nav bar height */
 }
 
 .container {
   display: flex;
   flex-flow: column;
+  height: 100%;
 }
 
 /* Toolbar: replaces the old inline-styled hstack */
 .toolbar {
   display: flex;
-  align-items: start;
+  align-items: center;
   justify-content: space-between;
   align-self: flex-start;
   width: 100%;
@@ -40,7 +42,6 @@
 }
 
 .toolbar-header {
-  margin-top: 5px;
   margin-bottom: 0;
   padding-right: 15px;
   flex-shrink: 0;
@@ -65,9 +66,10 @@
   flex: 1 1 auto;
   display: flex;
   flex-flow: column;
-  height: 85vh;
+  min-height: 0;
   overflow: hidden;
   padding-right: 16px;
+  padding-bottom: 40px; /* reserve space for ApexCharts legend when multiple topics are plotted */
 }
 
 .mobile-sidebar {

--- a/angular-client/src/pages/graph-page/graph-page.component.html
+++ b/angular-client/src/pages/graph-page/graph-page.component.html
@@ -88,7 +88,12 @@
           </div>
         </div>
 
-        <typography variant="large-header" class="toolbar-header" [content]="this.rightHeader" />
+        <typography
+          variant="large-header"
+          class="toolbar-header"
+          [content]="this.rightHeader"
+          additionalStyles="margin: 0; font-size: 1.5rem;"
+        />
       </div>
 
       @if (selectedDataTypes.length > 0) {


### PR DESCRIPTION
## Changes

Fixes the graph page so the x-axis number labels and the multi-topic legend are both visible without scrolling on initial load. Two issues were stacking: the mode header (Real Time / Fault / Run #N / Hist Range) was rendered with xx-large font inside a plain p tag whose default top/bottom margins inflated the toolbar row to ~90-100px, and the graph container was pinned to height: 85vh which combined with the nav bar and bloated toolbar pushed the chart past the viewport.

- Shrunk the toolbar header to 1.5rem and killed the default p-margin via the typography additionalStyles input, and switched the toolbar to align-items: center so the header sits inline with the buttons on one compact row.
- Replaced the hardcoded 85vh on the graph container with flex-fill, anchored the host to calc(100vh - 60px) so the page tracks the nav bar height, and reserved 40px of padding-bottom on the right container so ApexCharts' legend has room to render when multiple topics are plotted.

## Notes

- The 60px and 40px constants are a pragmatic match for the current nav bar height and ApexCharts legend row. Promoting them to a shared CSS custom property would be cleaner but is cross-cutting and deferred.
- The mobile (<768px) breakpoint still uses its own 50vh graph rule and was verified untouched.
- Kept variant="large-header" rather than switching to a smaller typography variant because the smaller variants have a pre-existing fontSize (camelCase) typo in theme.service.ts that silently drops the font size — out of scope here, worth a follow-up.

## Test Cases

- Single-topic plot at 1920x1080, 1440x900, 1280x800 — x-axis time labels visible without scrolling; graph flex-fills available vertical space.
- Three-topic plot (Voltage, Current, SOC) at all three desktop sizes — x-axis AND ApexCharts legend visible at bottom without scrolling.
- Mobile 375x812 — toolbar collapses to stacked rows (existing behavior), graph still sized by the mobile 50vh rule.
- Mode switches — Pause/Play, Time/Point Range — header re-renders at the new size with no layout jump.

## Screenshots

_screenshot pending_

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No package-lock.json changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #587
