### PR TITLE
Enable Certain eFuses

### DIFF
--- a/angular-client/src/pages/efuses-page/components/efuse-card/efuse-card.component.html
+++ b/angular-client/src/pages/efuses-page/components/efuse-card/efuse-card.component.html
@@ -77,7 +77,7 @@
                 [disabled]="effectivelyLocked()"
                 (stateChange)="onSwitchStateChange($event)"
               />
-              @if (lockMode() === 'Unlockable') {
+              @if (showsLockButton()) {
                 <lock-button [locked]="isLocked()" (pressed)="onLockButtonClick()"></lock-button>
               }
             </hstack>

--- a/angular-client/src/pages/efuses-page/components/efuse-card/efuse-card.component.html
+++ b/angular-client/src/pages/efuses-page/components/efuse-card/efuse-card.component.html
@@ -74,10 +74,10 @@
                 [fontSize]="14"
                 [options]="switchOptions()"
                 [selectedState]="switchState()"
-                [disabled]="isLocked()"
+                [disabled]="effectivelyLocked()"
                 (stateChange)="onSwitchStateChange($event)"
               />
-              @if (lockButtonEnabled()) {
+              @if (lockMode() === 'Unlockable') {
                 <lock-button [locked]="isLocked()" (pressed)="onLockButtonClick()"></lock-button>
               }
             </hstack>

--- a/angular-client/src/pages/efuses-page/components/efuse-card/efuse-card.component.ts
+++ b/angular-client/src/pages/efuses-page/components/efuse-card/efuse-card.component.ts
@@ -13,7 +13,11 @@ import EfuseSwitchComponent, { EfuseSwitchState } from '../efuse-switch/efuse-sw
 import { LockButtonComponent } from '../lock-button/lock-button.component';
 import { inject } from '@angular/core';
 
-export type EfuseLockMode = 'Unlocked' | 'Unlockable' | 'Locked';
+export enum EfuseLockMode {
+  Unlocked,
+  UnlockToEdit,
+  ReadOnly
+}
 
 /**
  * Component to display individual eFuse status.
@@ -71,7 +75,7 @@ export default class EfuseCardComponent implements OnInit, OnDestroy {
   autoDigits = input<number>(3);
   autoDecimals = input<number>(1);
   notice = input<string>(''); // Component param allowing you to put a note/warning/etc, in the top-right corner of the card.
-  lockMode = input<EfuseLockMode>('Unlockable');
+  lockMode = input<EfuseLockMode>(EfuseLockMode.UnlockToEdit);
 
   // ── Shared seven-segment display inputs ──
   readonly largeDisplayFontSize: number = 80;
@@ -93,12 +97,13 @@ export default class EfuseCardComponent implements OnInit, OnDestroy {
   // ── Locking state ──
   isLocked = signal<boolean>(true);
 
-  effectivelyLocked = computed(() => {
-    const mode = this.lockMode();
-    if (mode === 'Unlocked') return false;
-    if (mode === 'Locked') return true;
-    return this.isLocked();
-  });
+  showsLockButton = computed(() => this.lockMode() === EfuseLockMode.UnlockToEdit);
+  private isForceLocked = computed(() => this.lockMode() === EfuseLockMode.ReadOnly);
+  private relockAfterCommand = computed(() => this.lockMode() === EfuseLockMode.UnlockToEdit);
+
+  effectivelyLocked = computed(() =>
+    this.isForceLocked() ? true : this.lockMode() === EfuseLockMode.Unlocked ? false : this.isLocked()
+  );
 
   /** Whether this card supports AUTO mode (Type 2) */
   hasAutoMode = computed(() => this.autoDataType() !== undefined);
@@ -234,7 +239,7 @@ export default class EfuseCardComponent implements OnInit, OnDestroy {
     sendConfig(this.resolvedCommandKey(), [payload]).catch((error) => {
       console.error(`Failed to send ${this.efuseName()} command`, error);
     });
-    if (this.lockMode() === 'Unlockable') {
+    if (this.relockAfterCommand()) {
       this.lockEfuse();
     }
   }

--- a/angular-client/src/pages/efuses-page/components/efuse-card/efuse-card.component.ts
+++ b/angular-client/src/pages/efuses-page/components/efuse-card/efuse-card.component.ts
@@ -13,6 +13,8 @@ import EfuseSwitchComponent, { EfuseSwitchState } from '../efuse-switch/efuse-sw
 import { LockButtonComponent } from '../lock-button/lock-button.component';
 import { inject } from '@angular/core';
 
+export type EfuseLockMode = 'Unlocked' | 'Unlockable' | 'Locked';
+
 /**
  * Component to display individual eFuse status.
  *
@@ -69,7 +71,7 @@ export default class EfuseCardComponent implements OnInit, OnDestroy {
   autoDigits = input<number>(3);
   autoDecimals = input<number>(1);
   notice = input<string>(''); // Component param allowing you to put a note/warning/etc, in the top-right corner of the card.
-  lockButtonEnabled = input<boolean>(true);
+  lockMode = input<EfuseLockMode>('Unlockable');
 
   // ── Shared seven-segment display inputs ──
   readonly largeDisplayFontSize: number = 80;
@@ -90,6 +92,13 @@ export default class EfuseCardComponent implements OnInit, OnDestroy {
 
   // ── Locking state ──
   isLocked = signal<boolean>(true);
+
+  effectivelyLocked = computed(() => {
+    const mode = this.lockMode();
+    if (mode === 'Unlocked') return false;
+    if (mode === 'Locked') return true;
+    return this.isLocked();
+  });
 
   /** Whether this card supports AUTO mode (Type 2) */
   hasAutoMode = computed(() => this.autoDataType() !== undefined);
@@ -220,12 +229,14 @@ export default class EfuseCardComponent implements OnInit, OnDestroy {
 
   /** Handle switch state change — sends the appropriate CAN message */
   onSwitchStateChange(state: EfuseSwitchState): void {
-    if (this.isLocked()) return;
+    if (this.effectivelyLocked()) return;
     const payload = state === 'ON' ? 0 : state === 'AUTO' ? 1 : 2;
     sendConfig(this.resolvedCommandKey(), [payload]).catch((error) => {
       console.error(`Failed to send ${this.efuseName()} command`, error);
     });
-    this.lockEfuse();
+    if (this.lockMode() === 'Unlockable') {
+      this.lockEfuse();
+    }
   }
 
   onLockButtonClick(): void {

--- a/angular-client/src/pages/efuses-page/components/rtds-debug-card/rtds-debug-card.component.css
+++ b/angular-client/src/pages/efuses-page/components/rtds-debug-card/rtds-debug-card.component.css
@@ -1,6 +1,4 @@
 .rtds-card-shell {
-  max-width: 1200px;
-  margin: 0 auto;
   width: 100%;
 }
 
@@ -164,10 +162,10 @@
 }
 
 .rtds-display-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 12px 16px;
-  justify-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px 50px;
 }
 
 .rtds-display {

--- a/angular-client/src/pages/efuses-page/efuses-page.component.css
+++ b/angular-client/src/pages/efuses-page/efuses-page.component.css
@@ -7,13 +7,6 @@
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-.title-style {
-  display: grid;
-  align-items: center;
-  margin-top: -20px;
-  line-height: 1;
-}
-
 .rtds-section {
   margin-top: 0px;
   margin-left: -20px;

--- a/angular-client/src/pages/efuses-page/efuses-page.component.css
+++ b/angular-client/src/pages/efuses-page/efuses-page.component.css
@@ -15,5 +15,19 @@
 }
 
 .rtds-section {
-  margin-top: 20px;
+  margin-top: 0px;
+  margin-left: -20px;
+  margin-right: -20px;
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
+.zone-title {
+  padding-top: 20px;
+  font-weight: 900;
+  font-size: 50px;
+}
+
+.zone-subtext {
+  padding-bottom: 10px;
 }

--- a/angular-client/src/pages/efuses-page/efuses-page.component.html
+++ b/angular-client/src/pages/efuses-page/efuses-page.component.html
@@ -12,7 +12,7 @@
       [efuseTopicKey]="'Dashboard'"
       commandKey="Dashboard"
       [maxCurrent]="'3'"
-      [lockMode]="'Unlocked'"
+      [lockMode]="EfuseLockMode.Unlocked"
     />
 
     <!-- Brake eFuse (Type 2: AUTO based on braking state) -->
@@ -26,7 +26,7 @@
       [autoUnit]="''"
       [autoDecimals]="0"
       [autoDigits]="1"
-      [lockMode]="'Unlocked'"
+      [lockMode]="EfuseLockMode.Unlocked"
     />
 
     <!-- Radfan eFuse (Type 2: AUTO based on DTI motor temp) -->
@@ -38,7 +38,7 @@
       [autoDataType]="topics.VCU.Echo.Motor_Temp"
       [autoLabel]="'Motor Temp'"
       [autoUnit]="'°C'"
-      [lockMode]="'Unlocked'"
+      [lockMode]="EfuseLockMode.Unlocked"
     />
 
     <!-- Fanbatt eFuse (Type 2: AUTO based on BMS battbox temp) -->
@@ -50,7 +50,7 @@
       [autoDataType]="topics.VCU.Echo.Battbox_Temp"
       [autoLabel]="'Battbox Temp'"
       [autoUnit]="'°C'"
-      [lockMode]="'Unlocked'"
+      [lockMode]="EfuseLockMode.Unlocked"
     />
 
     <!-- PumpOne eFuse (Type 2: AUTO based on DTI motor temp) -->
@@ -62,7 +62,7 @@
       [autoDataType]="topics.VCU.Echo.Motor_Temp"
       [autoLabel]="'Motor Temp'"
       [autoUnit]="'°C'"
-      [lockMode]="'Unlocked'"
+      [lockMode]="EfuseLockMode.Unlocked"
     />
 
     <!-- PumpTwo eFuse (Type 2: AUTO based on DTI controller temp) -->
@@ -74,7 +74,7 @@
       [autoDataType]="topics.VCU.Echo.Controller_Temp"
       [autoLabel]="'Controller Temp'"
       [autoUnit]="'°C'"
-      [lockMode]="'Unlocked'"
+      [lockMode]="EfuseLockMode.Unlocked"
     />
 
     <!-- Spare eFuse (Type 2: AUTO based on DTI controller temp) -->
@@ -87,7 +87,7 @@
       [autoLabel]="'Controller Temp'"
       [autoUnit]="'°C'"
       [notice]="'Note: Spare eFuse doesn\'t support current reading.'"
-      [lockMode]="'Unlocked'"
+      [lockMode]="EfuseLockMode.Unlocked"
     />
   </grid-layout>
 
@@ -104,7 +104,7 @@
       commandKey="Shutdown"
       [maxCurrent]="'1'"
       [notice]="'Warning: Disabling this eFuse will literally turn the car off.'"
-      [lockMode]="'Unlockable'"
+      [lockMode]="EfuseLockMode.UnlockToEdit"
     />
 
     <!-- LV eFuse -->
@@ -114,7 +114,7 @@
       commandKey="LV"
       [maxCurrent]="'3'"
       [notice]="'Warning: Disabling this eFuse will literally turn off the car\'s entire low-voltage system.'"
-      [lockMode]="'Unlockable'"
+      [lockMode]="EfuseLockMode.UnlockToEdit"
     />
 
     <!-- Battbox eFuse -->
@@ -123,7 +123,7 @@
       [efuseTopicKey]="'Battbox'"
       commandKey="Battbox"
       [maxCurrent]="'2'"
-      [lockMode]="'Unlockable'"
+      [lockMode]="EfuseLockMode.UnlockToEdit"
     />
 
     <!-- MC eFuse -->
@@ -132,7 +132,7 @@
       [efuseTopicKey]="'MC'"
       commandKey="MC"
       [maxCurrent]="'2'"
-      [lockMode]="'Unlockable'"
+      [lockMode]="EfuseLockMode.UnlockToEdit"
     />
   </grid-layout>
 

--- a/angular-client/src/pages/efuses-page/efuses-page.component.html
+++ b/angular-client/src/pages/efuses-page/efuses-page.component.html
@@ -1,14 +1,19 @@
 <div style="padding: 20px">
-  <typography
-    class="title-style"
-    variant="x-large-title"
-    content="eFuses!"
-    additionalStyles="font-size: 4vw; letter-spacing: 0.2rem; word-spacing: 0.2rem; text-align: center; margin-top: 0;"
-  />
+  <div class="zone-title" style="padding-top: 0px">Normal eFuses</div>
+  <div class="zone-subtext">
+    Note: You shouldn't have to manually override the states of these eFuses during normal operation, but you can for
+    debugging.
+  </div>
 
   <grid-layout minWidth="520px" gap="15px" style="margin-top: 20px">
     <!-- Dashboard eFuse -->
-    <efuse-card efuseName="Dashboard" [efuseTopicKey]="'Dashboard'" commandKey="Dashboard" [maxCurrent]="'3'" />
+    <efuse-card
+      efuseName="Dashboard"
+      [efuseTopicKey]="'Dashboard'"
+      commandKey="Dashboard"
+      [maxCurrent]="'3'"
+      [lockMode]="'Unlocked'"
+    />
 
     <!-- Brake eFuse (Type 2: AUTO based on braking state) -->
     <efuse-card
@@ -21,26 +26,7 @@
       [autoUnit]="''"
       [autoDecimals]="0"
       [autoDigits]="1"
-    />
-
-    <!-- Shutdown eFuse -->
-    <efuse-card
-      efuseName="Shutdown"
-      [efuseTopicKey]="'Shutdown'"
-      commandKey="Shutdown"
-      [maxCurrent]="'1'"
-      [notice]="'Note: Shutdown eFuse can\'t be turned off from here.'"
-      [lockButtonEnabled]="false"
-    />
-
-    <!-- LV eFuse -->
-    <efuse-card
-      efuseName="LV"
-      [efuseTopicKey]="'LV'"
-      commandKey="LV"
-      [maxCurrent]="'3'"
-      [notice]="'Note: LV eFuse can\'t be turned off from here.'"
-      [lockButtonEnabled]="false"
+      [lockMode]="'Unlocked'"
     />
 
     <!-- Radfan eFuse (Type 2: AUTO based on DTI motor temp) -->
@@ -52,6 +38,7 @@
       [autoDataType]="topics.VCU.Echo.Motor_Temp"
       [autoLabel]="'Motor Temp'"
       [autoUnit]="'°C'"
+      [lockMode]="'Unlocked'"
     />
 
     <!-- Fanbatt eFuse (Type 2: AUTO based on BMS battbox temp) -->
@@ -63,6 +50,7 @@
       [autoDataType]="topics.VCU.Echo.Battbox_Temp"
       [autoLabel]="'Battbox Temp'"
       [autoUnit]="'°C'"
+      [lockMode]="'Unlocked'"
     />
 
     <!-- PumpOne eFuse (Type 2: AUTO based on DTI motor temp) -->
@@ -74,6 +62,7 @@
       [autoDataType]="topics.VCU.Echo.Motor_Temp"
       [autoLabel]="'Motor Temp'"
       [autoUnit]="'°C'"
+      [lockMode]="'Unlocked'"
     />
 
     <!-- PumpTwo eFuse (Type 2: AUTO based on DTI controller temp) -->
@@ -85,6 +74,7 @@
       [autoDataType]="topics.VCU.Echo.Controller_Temp"
       [autoLabel]="'Controller Temp'"
       [autoUnit]="'°C'"
+      [lockMode]="'Unlocked'"
     />
 
     <!-- Spare eFuse (Type 2: AUTO based on DTI controller temp) -->
@@ -97,6 +87,34 @@
       [autoLabel]="'Controller Temp'"
       [autoUnit]="'°C'"
       [notice]="'Note: Spare eFuse doesn\'t support current reading.'"
+      [lockMode]="'Unlocked'"
+    />
+  </grid-layout>
+
+  <div class="zone-title">Caution Zone</div>
+  <div class="zone-subtext">
+    Note: The states of these eFuses shouldn't be messed with unless there's a really good reason to.
+  </div>
+
+  <grid-layout minWidth="520px" gap="15px" style="margin-top: 20px">
+    <!-- Shutdown eFuse -->
+    <efuse-card
+      efuseName="Shutdown"
+      [efuseTopicKey]="'Shutdown'"
+      commandKey="Shutdown"
+      [maxCurrent]="'1'"
+      [notice]="'Warning: Disabling this eFuse will literally turn the car off.'"
+      [lockMode]="'Unlockable'"
+    />
+
+    <!-- LV eFuse -->
+    <efuse-card
+      efuseName="LV"
+      [efuseTopicKey]="'LV'"
+      commandKey="LV"
+      [maxCurrent]="'3'"
+      [notice]="'Warning: Disabling this eFuse will literally turn off the car\'s entire low-voltage system.'"
+      [lockMode]="'Unlockable'"
     />
 
     <!-- Battbox eFuse -->
@@ -105,14 +123,23 @@
       [efuseTopicKey]="'Battbox'"
       commandKey="Battbox"
       [maxCurrent]="'2'"
-      [notice]="'Note: Battbox eFuse can\'t be turned off from here.'"
-      [lockButtonEnabled]="false"
+      [lockMode]="'Unlockable'"
     />
 
     <!-- MC eFuse -->
-    <efuse-card efuseName="Motor Controller" [efuseTopicKey]="'MC'" commandKey="MC" [maxCurrent]="'2'" />
+    <efuse-card
+      efuseName="Motor Controller"
+      [efuseTopicKey]="'MC'"
+      commandKey="MC"
+      [maxCurrent]="'2'"
+      [lockMode]="'Unlockable'"
+    />
   </grid-layout>
 
+  <div class="zone-title">RTDS Zone</div>
+  <div class="zone-subtext">
+    Note: You shouldn't need to force an RTDS state during normal operation, since VCU does this automatically.
+  </div>
   <div class="rtds-section">
     <rtds-debug-card />
   </div>

--- a/angular-client/src/pages/efuses-page/efuses-page.component.ts
+++ b/angular-client/src/pages/efuses-page/efuses-page.component.ts
@@ -3,7 +3,7 @@ import { Subscription } from 'rxjs';
 import { EFUSE_TOPICS } from './efuses-page.topics';
 
 import TypographyComponent from 'src/components/typography/typography.component';
-import EfuseCardComponent from './components/efuse-card/efuse-card.component';
+import EfuseCardComponent, { EfuseLockMode } from './components/efuse-card/efuse-card.component';
 import RtdsDebugCardComponent from './components/rtds-debug-card/rtds-debug-card.component';
 import GridLayoutComponent from 'src/components/grid-layout/grid-layout.component';
 
@@ -20,7 +20,7 @@ import GridLayoutComponent from 'src/components/grid-layout/grid-layout.componen
 export default class EfusesPageComponent implements OnInit, OnDestroy {
   private subscriptions: Subscription[] = [];
 
-  // Expose eFuse topics for template
+  readonly EfuseLockMode = EfuseLockMode;
   readonly topics = EFUSE_TOPICS;
 
   ngOnInit() {


### PR DESCRIPTION
This PR makes some changes to the eFuses page, since all eFuses are now able to be enabled/disabled again by VCU firmware. I decided to split the eFuses into two sections: A "Normal" section, and a "Caution" section.
- The eFuses in the "Normal" section can easily be toggled from Argos with nothing bad happening. You shouldn't really need to mess with their states from Argos during normal operation, but you can if you want/need to.
- The LV, Shutdown, Battbox, and MC eFuses are in the "Caution" section. Since these eFuses control certain more-critical functions in the car, you have to "unlock" them to override their state. There's a notice above the section stating that these eFuses shouldn't really have their states messed with during normal operation, aside from an emergency. In particular, the Shutdown and LV eFuses will literally turn off TPU, so if you disable them via Argos, you'd have to physically go back up to the car to reset it.