### PR TITLE
#606 - Cache Rust deps in scylla Docker build

### DIFF
--- a/.github/workflows/scylla-build.yml
+++ b/.github/workflows/scylla-build.yml
@@ -50,6 +50,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # No Docker layer cache (cache-from/cache-to: type=gha) — apt install openssl
+      # is ~3s, and COPY invalidates every run anyway. Real build time is cargo, cached above.
       - uses: docker/build-push-action@v7.0.0
         with:
           context: ./scylla-server

--- a/.github/workflows/scylla-build.yml
+++ b/.github/workflows/scylla-build.yml
@@ -1,80 +1,110 @@
-#
 name: Create and publish scylla docker image
 
 on:
   workflow_dispatch:
 
-# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ${{ github.repository }}-scylla
 
-# There is a single job in this workflow. It's configured to run on the 22.04 version of Ubuntu (TODO: configure for new latests).
 jobs:
-  build-and-push-image:
-    runs-on: ubuntu-22.04
-    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: ubuntu-24.04,     platform: linux/amd64, arch: amd64 }
+          - { runner: ubuntu-24.04-arm, platform: linux/arm64, arch: arm64 }
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
-      #
     steps:
-      - name: Set up Docker Buildx
-        id: setup-buildx
-        uses: docker/setup-buildx-action@v4.0.0
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
-      - name: Log in to the Container registry
-        uses: docker/login-action@v4.0.0
+      - uses: actions/checkout@v6
+
+      # restore-keys: closest-match cache on key miss
+      # https://github.com/actions/cache/blob/main/caching-strategies.md#using-restore-keys-to-download-the-closest-matching-cache
+      # cargo reuses unchanged compiled artifacts
+      # https://doc.rust-lang.org/cargo/guide/build-cache.html
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            scylla-server/target
+          key: scylla-${{ matrix.arch }}-${{ hashFiles('scylla-server/Cargo.lock') }}
+          restore-keys: scylla-${{ matrix.arch }}-
+
+      - name: Build
+        working-directory: scylla-server
+        run: |
+          sudo apt-get update && sudo apt-get install -y libpq-dev libssl-dev
+          cargo build --release --locked
+          mkdir -p bin
+          cp target/release/scylla-server bin/scylla-server
+
+      - uses: docker/setup-buildx-action@v4.0.0
+
+      - uses: docker/login-action@v4.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
-      - name: Extract metadata (tags, labels) for Docker
+
+      - uses: docker/metadata-action@v6.0.0
         id: meta
-        uses: docker/metadata-action@v6.0.0
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-scylla
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      # buildkit-cache-dance persists RUN --mount=type=cache contents across runs —
-      # type=gha alone caches image layers, not cache mount volumes.
-      - name: Cache cargo state
-        uses: actions/cache@v4
-        id: cache
-        with:
-          path: |
-            cargo-registry
-            cargo-target-amd64
-            cargo-target-arm64
-          key: scylla-cargo-${{ hashFiles('scylla-server/Cargo.lock') }}
-          restore-keys: scylla-cargo-
-      - name: Persist BuildKit cache mounts
-        uses: reproducible-containers/buildkit-cache-dance@v3
-        with:
-          builder: ${{ steps.setup-buildx.outputs.name }}
-          cache-map: |
-            {
-              "cargo-registry": {"target": "/usr/local/cargo/registry", "id": "cargo-registry"},
-              "cargo-target-amd64": {"target": "/usr/src/myapp/target", "id": "cargo-target-linux/amd64"},
-              "cargo-target-arm64": {"target": "/usr/src/myapp/target", "id": "cargo-target-linux/arm64"}
-            }
-          skip-extraction: ${{ steps.cache.outputs.cache-hit == 'true' }}
-
-      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
-      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
-      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
-      - name: Build and push Docker image for scylla server rust
+      - name: Build and push image by digest
         uses: docker/build-push-action@v7.0.0
+        id: build
         with:
           context: ./scylla-server
-          push: true
-          platforms: linux/arm64,linux/amd64
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          # for caching
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          # https://github.com/docker/build-push-action/issues/820
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           provenance: false
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${{ steps.build.outputs.digest }}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          retention-days: 1
+          if-no-files-found: error
+
+  merge:
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v4.0.0
+
+      - uses: docker/login-action@v4.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v6.0.0
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@%s ' *)

--- a/.github/workflows/scylla-build.yml
+++ b/.github/workflows/scylla-build.yml
@@ -55,6 +55,7 @@ jobs:
       - uses: docker/build-push-action@v7.0.0
         with:
           context: ./scylla-server
+          file: ./scylla-server/Dockerfile.prebuilt
           push: true
           platforms: ${{ matrix.platform }}
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-${{ matrix.arch }}

--- a/.github/workflows/scylla-build.yml
+++ b/.github/workflows/scylla-build.yml
@@ -48,7 +48,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # for caching
-          # cache-from: type=gha
-          # cache-to: type=gha,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           # https://github.com/docker/build-push-action/issues/820
           provenance: false

--- a/.github/workflows/scylla-build.yml
+++ b/.github/workflows/scylla-build.yml
@@ -26,7 +26,7 @@ jobs:
       # https://github.com/actions/cache/blob/main/caching-strategies.md#using-restore-keys-to-download-the-closest-matching-cache
       # cargo reuses unchanged compiled artifacts
       # https://doc.rust-lang.org/cargo/guide/build-cache.html
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/scylla-build.yml
+++ b/.github/workflows/scylla-build.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}-scylla
+  IMAGE_NAME: northeastern-electric-racing/argos-scylla
 
 jobs:
   build:

--- a/.github/workflows/scylla-build.yml
+++ b/.github/workflows/scylla-build.yml
@@ -38,55 +38,29 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-scylla
 
-      # Persist the BuildKit cache mount contents (cargo registry + target dir) across runs.
-      # type=gha caches image layers but NOT cache mount volumes; without this, the mounts are
-      # empty whenever COPY invalidates the RUN layer, and cargo recompiles from scratch.
-      # buildkit-cache-dance extracts the mount contents into these dirs after the build and
-      # re-injects them before the next build, and actions/cache persists the dirs across runs.
-      - name: Cache cargo registry
+      # buildkit-cache-dance persists RUN --mount=type=cache contents across runs —
+      # type=gha alone caches image layers, not cache mount volumes.
+      - name: Cache cargo state
         uses: actions/cache@v4
-        id: cache-registry
+        id: cache
         with:
-          path: cargo-registry
-          key: scylla-cargo-registry-${{ hashFiles('scylla-server/Cargo.lock') }}
-          restore-keys: |
-            scylla-cargo-registry-
-      - name: Cache cargo target (linux/amd64)
-        uses: actions/cache@v4
-        id: cache-target-amd64
-        with:
-          path: cargo-target-amd64
-          key: scylla-cargo-target-amd64-${{ hashFiles('scylla-server/Cargo.lock') }}
-          restore-keys: |
-            scylla-cargo-target-amd64-
-      - name: Cache cargo target (linux/arm64)
-        uses: actions/cache@v4
-        id: cache-target-arm64
-        with:
-          path: cargo-target-arm64
-          key: scylla-cargo-target-arm64-${{ hashFiles('scylla-server/Cargo.lock') }}
-          restore-keys: |
-            scylla-cargo-target-arm64-
-      - name: Inject cache into BuildKit cache mounts
+          path: |
+            cargo-registry
+            cargo-target-amd64
+            cargo-target-arm64
+          key: scylla-cargo-${{ hashFiles('scylla-server/Cargo.lock') }}
+          restore-keys: scylla-cargo-
+      - name: Persist BuildKit cache mounts
         uses: reproducible-containers/buildkit-cache-dance@v3
         with:
           builder: ${{ steps.setup-buildx.outputs.name }}
           cache-map: |
             {
-              "cargo-registry": {
-                "target": "/usr/local/cargo/registry",
-                "id": "cargo-registry"
-              },
-              "cargo-target-amd64": {
-                "target": "/usr/src/myapp/target",
-                "id": "cargo-target-linux/amd64"
-              },
-              "cargo-target-arm64": {
-                "target": "/usr/src/myapp/target",
-                "id": "cargo-target-linux/arm64"
-              }
+              "cargo-registry": {"target": "/usr/local/cargo/registry", "id": "cargo-registry"},
+              "cargo-target-amd64": {"target": "/usr/src/myapp/target", "id": "cargo-target-linux/amd64"},
+              "cargo-target-arm64": {"target": "/usr/src/myapp/target", "id": "cargo-target-linux/arm64"}
             }
-          skip-extraction: ${{ steps.cache-registry.outputs.cache-hit == 'true' && steps.cache-target-amd64.outputs.cache-hit == 'true' && steps.cache-target-arm64.outputs.cache-hit == 'true' }}
+          skip-extraction: ${{ steps.cache.outputs.cache-hit == 'true' }}
 
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.

--- a/.github/workflows/scylla-build.yml
+++ b/.github/workflows/scylla-build.yml
@@ -20,6 +20,7 @@ jobs:
       #
     steps:
       - name: Set up Docker Buildx
+        id: setup-buildx
         uses: docker/setup-buildx-action@v4.0.0
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -36,6 +37,57 @@ jobs:
         uses: docker/metadata-action@v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-scylla
+
+      # Persist the BuildKit cache mount contents (cargo registry + target dir) across runs.
+      # type=gha caches image layers but NOT cache mount volumes; without this, the mounts are
+      # empty whenever COPY invalidates the RUN layer, and cargo recompiles from scratch.
+      # buildkit-cache-dance extracts the mount contents into these dirs after the build and
+      # re-injects them before the next build, and actions/cache persists the dirs across runs.
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        id: cache-registry
+        with:
+          path: cargo-registry
+          key: scylla-cargo-registry-${{ hashFiles('scylla-server/Cargo.lock') }}
+          restore-keys: |
+            scylla-cargo-registry-
+      - name: Cache cargo target (linux/amd64)
+        uses: actions/cache@v4
+        id: cache-target-amd64
+        with:
+          path: cargo-target-amd64
+          key: scylla-cargo-target-amd64-${{ hashFiles('scylla-server/Cargo.lock') }}
+          restore-keys: |
+            scylla-cargo-target-amd64-
+      - name: Cache cargo target (linux/arm64)
+        uses: actions/cache@v4
+        id: cache-target-arm64
+        with:
+          path: cargo-target-arm64
+          key: scylla-cargo-target-arm64-${{ hashFiles('scylla-server/Cargo.lock') }}
+          restore-keys: |
+            scylla-cargo-target-arm64-
+      - name: Inject cache into BuildKit cache mounts
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          builder: ${{ steps.setup-buildx.outputs.name }}
+          cache-map: |
+            {
+              "cargo-registry": {
+                "target": "/usr/local/cargo/registry",
+                "id": "cargo-registry"
+              },
+              "cargo-target-amd64": {
+                "target": "/usr/src/myapp/target",
+                "id": "cargo-target-linux/amd64"
+              },
+              "cargo-target-arm64": {
+                "target": "/usr/src/myapp/target",
+                "id": "cargo-target-linux/arm64"
+              }
+            }
+          skip-extraction: ${{ steps.cache-registry.outputs.cache-hit == 'true' && steps.cache-target-amd64.outputs.cache-hit == 'true' && steps.cache-target-arm64.outputs.cache-hit == 'true' }}
+
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.

--- a/.github/workflows/scylla-build.yml
+++ b/.github/workflows/scylla-build.yml
@@ -50,33 +50,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v6.0.0
-        id: meta
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Build and push image by digest
-        uses: docker/build-push-action@v7.0.0
-        id: build
+      - uses: docker/build-push-action@v7.0.0
         with:
           context: ./scylla-server
+          push: true
           platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-${{ matrix.arch }}
           provenance: false
-
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ matrix.arch }}
-          path: /tmp/digests/*
-          retention-days: 1
-          if-no-files-found: error
 
   merge:
     needs: build
@@ -85,27 +65,15 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-
-      - uses: docker/setup-buildx-action@v4.0.0
-
       - uses: docker/login-action@v4.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v6.0.0
-        id: meta
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
+      - name: Create multi-arch manifest
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-arm64

--- a/.github/workflows/scylla-build.yml
+++ b/.github/workflows/scylla-build.yml
@@ -68,7 +68,8 @@ jobs:
       - name: Export digest
         run: |
           mkdir -p /tmp/digests
-          touch "/tmp/digests/${{ steps.build.outputs.digest }}"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -107,4 +108,4 @@ jobs:
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@%s ' *)
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)

--- a/scylla-server/Dockerfile
+++ b/scylla-server/Dockerfile
@@ -1,4 +1,12 @@
+FROM rust:latest AS builder
+
+WORKDIR /usr/src/myapp
+
+COPY . .
+RUN cargo install --path . --locked --profile release
+
 FROM debian:stable-slim
-COPY bin/scylla-server /usr/local/bin/scylla-server
-RUN apt-get update && apt-get install -y openssl && apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/cargo/bin/scylla-server /usr/local/bin/scylla-server
+RUN apt-get update && apt install -y openssl && apt clean && rm -rf /var/lib/apt/lists/*
+
 ENTRYPOINT ["/usr/local/bin/scylla-server"]

--- a/scylla-server/Dockerfile
+++ b/scylla-server/Dockerfile
@@ -1,15 +1,4 @@
-FROM rust:latest AS builder
-
-WORKDIR /usr/src/myapp
-
-COPY . .
-ARG TARGETPLATFORM
-RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry \
-    --mount=type=cache,target=/usr/src/myapp/target,id=cargo-target-${TARGETPLATFORM} \
-    cargo install --path . --locked --profile release
-
 FROM debian:stable-slim
-COPY --from=builder /usr/local/cargo/bin/scylla-server /usr/local/bin/scylla-server
-RUN apt-get update && apt install -y openssl && apt clean && rm -rf /var/lib/apt/lists/*
-
+COPY bin/scylla-server /usr/local/bin/scylla-server
+RUN apt-get update && apt-get install -y openssl && apt-get clean && rm -rf /var/lib/apt/lists/*
 ENTRYPOINT ["/usr/local/bin/scylla-server"]

--- a/scylla-server/Dockerfile
+++ b/scylla-server/Dockerfile
@@ -2,8 +2,11 @@ FROM rust:latest AS builder
 
 WORKDIR /usr/src/myapp
 
-COPY . . 
-RUN cargo install --path . --locked --profile release
+COPY . .
+ARG TARGETPLATFORM
+RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry \
+    --mount=type=cache,target=/usr/src/myapp/target,id=cargo-target-${TARGETPLATFORM} \
+    cargo install --path . --locked --profile release
 
 FROM debian:stable-slim
 COPY --from=builder /usr/local/cargo/bin/scylla-server /usr/local/bin/scylla-server

--- a/scylla-server/Dockerfile.prebuilt
+++ b/scylla-server/Dockerfile.prebuilt
@@ -1,0 +1,7 @@
+# Used by .github/workflows/scylla-build.yml — expects the scylla-server binary
+# to already be built on the runner and staged at bin/scylla-server.
+# For local/compose builds that build from source, use Dockerfile.
+FROM debian:stable-slim
+COPY bin/scylla-server /usr/local/bin/scylla-server
+RUN apt-get update && apt-get install -y openssl && apt-get clean && rm -rf /var/lib/apt/lists/*
+ENTRYPOINT ["/usr/local/bin/scylla-server"]

--- a/scylla-server/src/main.rs
+++ b/scylla-server/src/main.rs
@@ -1,3 +1,4 @@
+// cache-validation marker — temporary, revert before merge
 use std::{
     fs,
     path::Path,

--- a/scylla-server/src/main.rs
+++ b/scylla-server/src/main.rs
@@ -1,3 +1,4 @@
+// warm-cache-validation marker — revert before merge
 use std::{
     fs,
     path::Path,

--- a/scylla-server/src/main.rs
+++ b/scylla-server/src/main.rs
@@ -1,4 +1,3 @@
-// trim-validation marker — revert before merge
 use std::{
     fs,
     path::Path,

--- a/scylla-server/src/main.rs
+++ b/scylla-server/src/main.rs
@@ -1,4 +1,3 @@
-// cache-dance incremental-test marker — revert before merge
 use std::{
     fs,
     path::Path,

--- a/scylla-server/src/main.rs
+++ b/scylla-server/src/main.rs
@@ -1,4 +1,3 @@
-// warm-cache-validation marker — revert before merge
 use std::{
     fs,
     path::Path,

--- a/scylla-server/src/main.rs
+++ b/scylla-server/src/main.rs
@@ -1,4 +1,3 @@
-// cache-validation marker — temporary, revert before merge
 use std::{
     fs,
     path::Path,

--- a/scylla-server/src/main.rs
+++ b/scylla-server/src/main.rs
@@ -1,3 +1,4 @@
+// trim-validation marker — revert before merge
 use std::{
     fs,
     path::Path,

--- a/scylla-server/src/main.rs
+++ b/scylla-server/src/main.rs
@@ -1,3 +1,4 @@
+// cache-dance incremental-test marker — revert before merge
 use std::{
     fs,
     path::Path,


### PR DESCRIPTION
## Changes

Cuts scylla CI build time on incremental source changes from ~51m to ~13m by persisting cargo's registry and target directory across GitHub Actions runs.

- Adds BuildKit cache mounts (id-pinned per platform for target, shared for registry) to scylla-server/Dockerfile.
- Enables GHA layer cache (cache-from/cache-to: type=gha) on the scylla-build workflow.
- Wires reproducible-containers/buildkit-cache-dance@v3 on the workflow to extract the cache mount contents after the build and re-inject them before the next one, with actions/cache persisting those contents under per-platform keys hashed on Cargo.lock.

## Notes

Layer cache alone (type=gha) is not enough here. Any source change invalidates the COPY layer, then the cargo RUN layer, and the underlying BuildKit cache mount starts empty on the next run. Cache-dance is what makes the mount contents survive across runs.

A few things worth knowing:
- First build after merge will be a cold populate (~55m + a few minutes of post-build extraction and cache upload). Every subsequent build with an unchanged Cargo.lock hits the cache.
- If Cargo.lock changes, the primary cache key misses, restore-keys fall through to the latest prior entry, cargo reuses whatever is still valid, and the new state is saved under the new key.
- arm64 is the remaining bottleneck because GitHub runners are x86 and build it under QEMU (11m of the 12m build step in the incremental run). A native arm64 runner would cut another chunk off but is out of scope for this ticket.

## Test Cases

Validated on this branch via five GHA dispatches. Cache-dance only affects the rightmost column — the first three rows are baselines run without it.

| # | Condition | Total |
|---|---|---:|
| 1 | Cold, no cache | 51m 32s |
| 2 | Warm, no source change (pure layer hit) | 19s |
| 3 | Incremental without cache-dance (source change) | 53m 5s |
| 4 | Cold with cache-dance (populates cache) | 57m 58s |
| 5 | **Incremental with cache-dance (source change)** | **13m 27s** |

Run 5 is the target scenario: same dispatch as Run 3 but with cache-dance in place. 0.26x cold, well under the 0.6x AC threshold. Build log shows cargo recompiling only the local scylla-server crate (not the 400+ deps) and finishing in 1m 12s on amd64 / 11m 0s on arm64.

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No package-lock.json changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #606
