### PR TITLE
Shutdown Closed Indicator

### DIFF
--- a/angular-client/src/pages/efuses-page/components/rtds-debug-card/rtds-debug-card.component.css
+++ b/angular-client/src/pages/efuses-page/components/rtds-debug-card/rtds-debug-card.component.css
@@ -79,12 +79,14 @@
 
 .rtds-button-subtext-2 {
   text-align: center;
-  font-size: 15px;
+  font-size: 14px;
   margin-top: 1px;
   margin-bottom: 2px;
+  font-weight: 100;
   line-height: 1.2;
   font-family: 'Highway Gothic', 'Roboto', sans-serif;
   padding-bottom: 10px;
+  padding-top: 5px;
 }
 
 .shutdown-indicator {

--- a/angular-client/src/pages/efuses-page/components/rtds-debug-card/rtds-debug-card.component.html
+++ b/angular-client/src/pages/efuses-page/components/rtds-debug-card/rtds-debug-card.component.html
@@ -86,8 +86,10 @@
           </div>
         </div>
         <div class="shutdown-indicator">
-          <indicator-light [label]="'SHUTDOWN'" [active]="shutdown" [color]="'red'" [fontSize]="14" />
-          <div class="rtds-button-subtext-2">(RTDS will not sound if shutdown is active.)</div>
+          <indicator-light [label]="'SHUTDOWN CLOSED'" [active]="shutdown" [color]="'red'" [fontSize]="14" />
+          <div class="rtds-button-subtext-2">
+            Shutdown has to be closed for RTDS to sound. This is enforced in the firmware.
+          </div>
         </div>
       </vstack>
     </div>


### PR DESCRIPTION
The firmware logic for shutdown switched, so I've updated the indicator light on the RTDS Debug card to make that clearer. Right now, the indicator will turn on if shutdown is closed, and will turn off otherwise. Shutdown has to be closed (i.e., the indicator light has to be on) for RTDS to sound.