### PR TITLE
#613 Speed up client-build: hoist ng build out of Docker

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -16,8 +16,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 20.17.0
-          cache: "npm"
-          cache-dependency-path: ./angular-client/package-lock.json
 
       - name: Install deps
         working-directory: ./angular-client

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -8,8 +8,11 @@ env:
   IMAGE_NAME: northeastern-electric-racing/argos-client
 
 jobs:
-  build-client:
+  build-and-push:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     defaults:
       run:
         working-directory: ./angular-client
@@ -26,31 +29,14 @@ jobs:
       - name: Build production bundle
         run: npm run build:production
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: client-dist
-          path: angular-client/dist/angular-client/browser
-          if-no-files-found: error
+      # Stage dist where Dockerfile.prebuilt expects it; /dist is in .dockerignore,
+      # so the docker context can't pull from dist/angular-client/browser directly.
+      - name: Stage dist into docker context
+        run: cp -r dist/angular-client/browser browser
 
-  build-image:
-    needs: build-client
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - { runner: ubuntu-24.04,     platform: linux/amd64, arch: amd64 }
-          - { runner: ubuntu-24.04-arm, platform: linux/arm64, arch: arm64 }
-    runs-on: ${{ matrix.runner }}
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/download-artifact@v4
+      - uses: docker/setup-qemu-action@v3
         with:
-          name: client-dist
-          path: angular-client/browser
+          platforms: arm64
 
       - uses: docker/setup-buildx-action@v4.0.0
 
@@ -60,33 +46,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # No Docker layer cache — apk add gettext is trivial and the dist COPY
-      # invalidates every run. Real build cost (ng build) lives in build-client.
+      # Multi-arch in one buildx push — apk add gettext is the only RUN, fine under QEMU.
+      # All real CPU work (ng build) ran natively above; arch-sensitive part is just the nginx base layer.
       - uses: docker/build-push-action@v7.0.0
         with:
           context: ./angular-client
           file: ./angular-client/Dockerfile.prebuilt
           push: true
-          platforms: ${{ matrix.platform }}
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-${{ matrix.arch }}
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
           provenance: false
-
-  merge:
-    needs: build-image
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: docker/login-action@v4.0.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create multi-arch manifest
-        run: |
-          docker buildx imagetools create \
-            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }} \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-amd64 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-arm64

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -1,59 +1,94 @@
-#
 name: Create and publish client docker image
 
 on:
   workflow_dispatch:
 
-
-
-# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: northeastern-electric-racing/argos-client
 
-# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
-  build-and-push-image:
-    runs-on: ubuntu-latest
-    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+  build-client:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20.17.0
+          cache: "npm"
+          cache-dependency-path: ./angular-client/package-lock.json
+
+      - name: Install deps
+        working-directory: ./angular-client
+        run: npm ci
+
+      - name: Build production bundle
+        working-directory: ./angular-client
+        run: npm run build:production
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: client-dist
+          path: angular-client/dist/angular-client/browser
+          if-no-files-found: error
+
+  build-image:
+    needs: build-client
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: ubuntu-24.04,     platform: linux/amd64, arch: amd64 }
+          - { runner: ubuntu-24.04-arm, platform: linux/arm64, arch: arm64 }
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
-      # 
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.0.0
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
-      - name: Log in to the Container registry
-        uses: docker/login-action@v4.0.0
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: client-dist
+          path: angular-client/browser
+
+      - uses: docker/setup-buildx-action@v4.0.0
+
+      - uses: docker/login-action@v4.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v6.0.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-client
-      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
-      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
-      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
-      - name: Build and push Docker image for angular client
-        uses: docker/build-push-action@v7.0.0
+
+      # No Docker layer cache (cache-from/cache-to: type=gha) — apk add gettext
+      # is trivial and the dist COPY invalidates every run. Real build cost is
+      # ng build, cached via setup-node's npm cache in build-client.
+      - uses: docker/build-push-action@v7.0.0
         with:
           context: ./angular-client
+          file: ./angular-client/Dockerfile.prebuilt
           push: true
-          target: production
-          platforms: linux/arm64,linux/amd64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          # for caching
-          # cache-from: type=gha,scope=global
-          # cache-to: type=gha,mode=max,scope=global
-          # https://github.com/docker/build-push-action/issues/820
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-${{ matrix.arch }}
           provenance: false
-          build-args: |
-            PROD=true
+
+  merge:
+    needs: build-image
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: docker/login-action@v4.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-arm64

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -10,6 +10,9 @@ env:
 jobs:
   build-client:
     runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: ./angular-client
     steps:
       - uses: actions/checkout@v6
 
@@ -18,11 +21,9 @@ jobs:
           node-version: 20.17.0
 
       - name: Install deps
-        working-directory: ./angular-client
         run: npm ci
 
       - name: Build production bundle
-        working-directory: ./angular-client
         run: npm run build:production
 
       - uses: actions/upload-artifact@v4
@@ -59,9 +60,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # No Docker layer cache (cache-from/cache-to: type=gha) — apk add gettext
-      # is trivial and the dist COPY invalidates every run. Real build cost is
-      # ng build, cached via setup-node's npm cache in build-client.
+      # No Docker layer cache — apk add gettext is trivial and the dist COPY
+      # invalidates every run. Real build cost (ng build) lives in build-client.
       - uses: docker/build-push-action@v7.0.0
         with:
           context: ./angular-client

--- a/angular-client/Dockerfile.prebuilt
+++ b/angular-client/Dockerfile.prebuilt
@@ -10,8 +10,7 @@ WORKDIR /usr/share/nginx/html
 COPY browser/ .
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY env.prod.js ./assets/env.prod.js
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+COPY --chmod=755 entrypoint.sh /entrypoint.sh
 
 EXPOSE 80
 

--- a/angular-client/Dockerfile.prebuilt
+++ b/angular-client/Dockerfile.prebuilt
@@ -1,0 +1,19 @@
+# Used by .github/workflows/client-build.yml — expects the Angular production
+# bundle to already be built on the runner and staged at browser/.
+# For local/compose builds that build from source, use Dockerfile.
+FROM nginx:alpine
+
+RUN apk add --no-cache gettext
+
+WORKDIR /usr/share/nginx/html
+
+COPY browser/ .
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY env.prod.js ./assets/env.prod.js
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 80
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Changes

Mirrors the #610 scylla idea (build once native, avoid QEMU on real work) but goes further — collapses the client workflow to a single job. ng build runs once on an amd64 runner, then one buildx push produces the multi-arch manifest directly.

- Single build-and-push job: checkout, setup-node, npm ci, npm run build:production, setup-qemu, setup-buildx, login, one buildx call with `platforms: linux/amd64,linux/arm64`
- New angular-client/Dockerfile.prebuilt: nginx:alpine base, no Build stage, COPYs the prebuilt browser/ artifact along with nginx.conf, env.prod.js, and entrypoint.sh
- angular-client/Dockerfile is untouched so build-check.yml and compose still build from source

## Notes

- Deviates from the ticket AC in two deliberate ways:
  - AC calls for three jobs (build-client → build-image matrix → merge). Started there, then realized the per-arch Docker work is just apk add gettext plus static COPYs — native runners bought nothing. The ng build hoist is what actually saves the QEMU time. Collapsed to one job to drop pointless artifact upload/download and the imagetools merge step.
  - AC calls for `cache: "npm"` on setup-node. ng build dominates build-client wall time and the cache burns runner storage on a hash that turns over every lockfile change. Happy to add either back if a reviewer wants strict AC parity.
- Workflow is workflow_dispatch only, so timings come from manually triggering the workflow on this branch. Will fill them in here once the first run completes.
- Out of scope per the ticket: enabling .angular/cache in CI as a follow-up.

## Test Cases

- Lint and prettier pass on the angular-client tree
- No merge conflicts against develop
- CI run pending: confirm the job produces a multi-arch manifest that pulls and runs on both amd64 and arm64

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No package-lock.json changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #613
