### PR TITLE
#564 add flatten mode to topic tree

### DIFF
--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.css
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.css
@@ -5,6 +5,20 @@
   margin-top: 10px;
 }
 
+.header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.flatten-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
 .tree-node-container {
   display: flex;
   align-items: center;

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.html
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.html
@@ -1,11 +1,17 @@
 <div class="background">
-  <argos-button
-    [onClick]="clearSelections"
-    label="Clear Topics"
-    additionalStyles="background-color: #323232; border: 1.4px solid #027bd7;"
-  />
+  <div class="header-row">
+    <argos-button
+      [onClick]="clearSelections"
+      label="Clear Topics"
+      additionalStyles="background-color: #323232; border: 1.4px solid #027bd7;"
+    />
+    <label class="flatten-toggle">
+      <typography content="Flat" variant="sidebar-label" additionalStyles="padding: 0px;" />
+      <p-toggleSwitch [ngModel]="flattenMode()" (ngModelChange)="toggleFlattenMode($event)" ariaLabel="Flatten topic tree" />
+    </label>
+  </div>
   <p-tree
-    [value]="treeNodes"
+    [value]="flattenMode() ? flatNodes : treeNodes"
     styleClass="w-full md:w-[30rem]"
     (onNodeSelect)="nodeSelect($event)"
     (onNodeUnselect)="onNodeUnselect($event)"

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.ts
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.ts
@@ -1,9 +1,11 @@
-import { Component, Injector, OnInit, inject, input } from '@angular/core';
+import { Component, Injector, OnInit, inject, input, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { TreeNode, PrimeTemplate } from 'primeng/api';
 import { TreeNodeSelectEvent, TreeNodeUnSelectEvent, Tree } from 'primeng/tree';
+import { ToggleSwitch } from 'primeng/toggleswitch';
 import Storage from 'src/services/storage.service';
 import { dataTypesToNodes } from 'src/utils/dataTypes.utils';
-import { mapNodesToTreeNodes, findSelectedTreeNodes, TreeNodeData } from 'src/utils/tree.utils';
+import { mapNodesToTreeNodes, findSelectedTreeNodes, flattenTreeNodes, TreeNodeData } from 'src/utils/tree.utils';
 import { DataType } from 'src/utils/types.utils';
 import { TopicSelectionService } from 'src/services/topic-selection.service';
 import { ButtonComponent } from '../../../../components/argos-button/argos-button.component';
@@ -13,7 +15,7 @@ import TypographyComponent from 'src/components/typography/typography.component'
   selector: 'graph-sidebar-desktop',
   templateUrl: './graph-sidebar-desktop.component.html',
   styleUrls: ['./graph-sidebar-desktop.component.css'],
-  imports: [ButtonComponent, Tree, PrimeTemplate, TypographyComponent]
+  imports: [ButtonComponent, Tree, PrimeTemplate, TypographyComponent, ToggleSwitch, FormsModule]
 })
 export default class GraphSidebarDesktopComponent implements OnInit {
   private topicSelectionService = inject(TopicSelectionService);
@@ -22,12 +24,21 @@ export default class GraphSidebarDesktopComponent implements OnInit {
 
   dataTypes = input<DataType[]>([]);
   treeNodes: TreeNode<TreeNodeData>[] = [];
+  flatNodes: TreeNode<TreeNodeData>[] = [];
   selectedNodes?: TreeNode<TreeNodeData>[];
+  flattenMode = signal(false);
 
   ngOnInit(): void {
     const nodes = dataTypesToNodes(this.dataTypes());
     this.treeNodes = mapNodesToTreeNodes(nodes, this.storage, this.injector);
+    this.flatNodes = flattenTreeNodes(this.treeNodes);
     this.selectedNodes = findSelectedTreeNodes(this.treeNodes, this.topicSelectionService);
+  }
+
+  toggleFlattenMode(value: boolean) {
+    this.flattenMode.set(value);
+    const active = value ? this.flatNodes : this.treeNodes;
+    this.selectedNodes = findSelectedTreeNodes(active, this.topicSelectionService);
   }
 
   clearSelections = () => {

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.css
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.css
@@ -27,6 +27,14 @@
   height: 100%;
 }
 
+.flatten-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  align-self: flex-start;
+}
+
 .tree-node-container {
   display: flex;
   align-items: center;

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.html
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.html
@@ -11,8 +11,16 @@
         label="Clear Topics"
         additionalStyles="background-color: #323232; border: 1.4px solid #027bd7; width: 100%;"
       />
+      <label class="flatten-toggle">
+        <typography content="Flat" variant="sidebar-label" additionalStyles="padding: 0px;" />
+        <p-toggleSwitch
+          [ngModel]="flattenMode()"
+          (ngModelChange)="toggleFlattenMode($event)"
+          ariaLabel="Flatten topic tree"
+        />
+      </label>
       <p-tree
-        [value]="treeNodes"
+        [value]="flattenMode() ? flatNodes : treeNodes"
         (onNodeSelect)="nodeSelect($event)"
         (onNodeUnselect)="onNodeUnselect($event)"
         [(selection)]="selectedNodes"

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.ts
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.ts
@@ -1,10 +1,12 @@
-import { ChangeDetectionStrategy, Component, Injector, OnInit, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Injector, OnInit, inject, input, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { TreeNode, PrimeTemplate } from 'primeng/api';
 import { TreeNodeSelectEvent, TreeNodeUnSelectEvent, Tree } from 'primeng/tree';
 import { Sidebar } from 'primeng/sidebar';
+import { ToggleSwitch } from 'primeng/toggleswitch';
 import Storage from 'src/services/storage.service';
 import { dataTypesToNodes } from 'src/utils/dataTypes.utils';
-import { mapNodesToTreeNodes, findSelectedTreeNodes, TreeNodeData } from 'src/utils/tree.utils';
+import { mapNodesToTreeNodes, findSelectedTreeNodes, flattenTreeNodes, TreeNodeData } from 'src/utils/tree.utils';
 import { DataType } from 'src/utils/types.utils';
 import { TopicSelectionService } from 'src/services/topic-selection.service';
 import { ButtonComponent } from '../../../../components/argos-button/argos-button.component';
@@ -15,7 +17,7 @@ import TypographyComponent from 'src/components/typography/typography.component'
   templateUrl: './graph-sidebar-mobile.component.html',
   styleUrls: ['./graph-sidebar-mobile.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [Sidebar, PrimeTemplate, Tree, ButtonComponent, TypographyComponent]
+  imports: [Sidebar, PrimeTemplate, Tree, ButtonComponent, TypographyComponent, ToggleSwitch, FormsModule]
 })
 export default class GraphSidebarMobileComponent implements OnInit {
   dataTypes = input.required<DataType[]>();
@@ -26,17 +28,26 @@ export default class GraphSidebarMobileComponent implements OnInit {
 
   sidebarVisible = false;
   treeNodes: TreeNode<TreeNodeData>[] = [];
+  flatNodes: TreeNode<TreeNodeData>[] = [];
   selectedNodes?: TreeNode<TreeNodeData>[];
+  flattenMode = signal(false);
 
   ngOnInit(): void {
     const nodes = dataTypesToNodes(this.dataTypes());
     this.treeNodes = mapNodesToTreeNodes(nodes, this.storage, this.injector);
+    this.flatNodes = flattenTreeNodes(this.treeNodes);
     this.selectedNodes = findSelectedTreeNodes(this.treeNodes, this.topicSelectionService);
   }
 
   toggleSidebar = () => {
     this.sidebarVisible = !this.sidebarVisible;
   };
+
+  toggleFlattenMode(value: boolean) {
+    this.flattenMode.set(value);
+    const active = value ? this.flatNodes : this.treeNodes;
+    this.selectedNodes = findSelectedTreeNodes(active, this.topicSelectionService);
+  }
 
   clearSelections = () => {
     this.treeNodes.forEach((n) => (n.expanded = false));

--- a/angular-client/src/utils/tree.utils.spec.ts
+++ b/angular-client/src/utils/tree.utils.spec.ts
@@ -1,0 +1,109 @@
+import { signal } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { TreeNode } from 'primeng/api';
+import { compactTopicLabel, flattenTreeNodes, TreeNodeData } from './tree.utils';
+import { DataType, Node } from './types.utils';
+
+const EMPTY_DISPLAY = signal('');
+
+const leaf = (name: string, unit = ''): TreeNode<TreeNodeData> => {
+  const dataType: DataType = { name, unit };
+  return {
+    label: name.split('/').pop(),
+    key: name + '/',
+    selectable: true,
+    children: [],
+    data: {
+      name: name.split('/').pop()!,
+      topicName: name + '/',
+      dataType,
+      nodes: new BehaviorSubject<Node[]>([]),
+      displayValue: EMPTY_DISPLAY
+    }
+  };
+};
+
+const branch = (name: string, children: TreeNode<TreeNodeData>[]): TreeNode<TreeNodeData> => ({
+  label: name,
+  key: name + '/',
+  selectable: false,
+  children,
+  data: {
+    name,
+    topicName: name + '/',
+    dataType: { name, unit: '' },
+    nodes: new BehaviorSubject<Node[]>([]),
+    displayValue: EMPTY_DISPLAY
+  }
+});
+
+describe('compactTopicLabel', () => {
+  it('returns the full path when it fits under the limit', () => {
+    expect(compactTopicLabel('BMS/Pack/Voltage', 30)).toBe('BMS/Pack/Voltage');
+    expect(compactTopicLabel('BMS/PerCell/Alpha/1/Burning/0', 30)).toBe('BMS/PerCell/Alpha/1/Burning/0');
+  });
+
+  it('drops front segments after the first to make the path fit', () => {
+    expect(compactTopicLabel('BMS/PerCell/AlphaSomething/1/Burning/0', 30)).toBe('BMS...1/Burning/0');
+  });
+
+  it('keeps the longest tail that fits', () => {
+    expect(compactTopicLabel('BMS/AAAA/B/C/D/E', 14)).toBe('BMS...B/C/D/E');
+  });
+
+  it('falls back to first...lastSegment when even that overflows', () => {
+    expect(compactTopicLabel('VeryLongSystem/Mid/AlsoVeryLongLeaf', 5)).toBe('VeryLongSystem...AlsoVeryLongLeaf');
+  });
+
+  it('returns short paths unchanged when they have <= 2 segments', () => {
+    expect(compactTopicLabel('Just/Two', 5)).toBe('Just/Two');
+    expect(compactTopicLabel('Solo', 2)).toBe('Solo');
+  });
+});
+
+describe('flattenTreeNodes', () => {
+  it('returns only leaves, excluding branches', () => {
+    const tree = [branch('BMS', [leaf('BMS/Pack/Voltage'), leaf('BMS/Pack/SOC')]), branch('MPU', [leaf('MPU/State/Speed')])];
+    const flat = flattenTreeNodes(tree);
+    expect(flat.length).toBe(3);
+    flat.forEach((n) => expect(n.children?.length).toBe(0));
+    flat.forEach((n) => expect(n.selectable).toBe(true));
+  });
+
+  it('keeps full labels when they fit under the default threshold', () => {
+    const tree = [branch('BMS', [branch('Pack', [leaf('BMS/Pack/Voltage')])])];
+    const flat = flattenTreeNodes(tree);
+    expect(flat.length).toBe(1);
+    expect(flat[0].label).toBe('BMS/Pack/Voltage');
+  });
+
+  it('compacts long paths using firstSegment...tail', () => {
+    const tree = [branch('BMS', [leaf('BMS/PerCell/AlphaSomething/1/Burning/0')])];
+    const flat = flattenTreeNodes(tree, 30);
+    expect(flat[0].label).toBe('BMS...1/Burning/0');
+  });
+
+  it('preserves the leaf data so displayValue stays wired', () => {
+    const original = leaf('BMS/Pack/Voltage', 'V');
+    const flat = flattenTreeNodes([branch('BMS', [original])]);
+    expect(flat[0].data?.dataType).toBe(original.data!.dataType);
+    expect(flat[0].data?.displayValue).toBe(original.data!.displayValue);
+    expect(flat[0].key).toBe(original.key);
+  });
+
+  it('sorts results alphabetically by label', () => {
+    const tree = [
+      branch('MPU', [leaf('MPU/State/Speed')]),
+      branch('BMS', [leaf('BMS/Pack/Voltage'), leaf('BMS/Pack/SOC')]),
+      leaf('Aux/Sensor/Zeta')
+    ];
+    const flat = flattenTreeNodes(tree);
+    const labels = flat.map((n) => n.label);
+    expect(labels).toEqual(['Aux/Sensor/Zeta', 'BMS/Pack/SOC', 'BMS/Pack/Voltage', 'MPU/State/Speed']);
+  });
+
+  it('returns an empty list when the tree has no leaves', () => {
+    const flat = flattenTreeNodes([branch('Empty', [])]);
+    expect(flat).toEqual([]);
+  });
+});

--- a/angular-client/src/utils/tree.utils.ts
+++ b/angular-client/src/utils/tree.utils.ts
@@ -44,6 +44,53 @@ export function mapNodesToTreeNodes(
   return runInInjectionContext(injector, () => nodes.map(mapToTreeNode));
 }
 
+/**
+ * Compacts a slash-separated path so it fits under `maxLength`.
+ * Returns the full path when it already fits. Otherwise keeps the first
+ * segment and as much of the tail as fits, joined by `...`. Falls back to
+ * `first...lastSegment` when even that exceeds `maxLength`.
+ */
+export function compactTopicLabel(name: string, maxLength: number): string {
+  if (name.length <= maxLength) return name;
+  const segments = name.split('/');
+  if (segments.length <= 2) return name;
+  const [first] = segments;
+  for (let tailStart = 1; tailStart < segments.length; tailStart++) {
+    const tail = segments.slice(tailStart).join('/');
+    const candidate = `${first}...${tail}`;
+    if (candidate.length <= maxLength) return candidate;
+  }
+  return `${first}...${segments[segments.length - 1]}`;
+}
+
+/**
+ * Flattens a tree of TreeNodes to a leaf-only list. Each leaf's label is the
+ * full `dataType.name` when it fits under `maxLabelLength`, otherwise compacted
+ * to `<firstSegment>...<tail>` keeping as much of the tail as fits.
+ * Preserves `data` so each leaf's `displayValue` signal stays wired to live values.
+ */
+export function flattenTreeNodes(treeNodes: TreeNode<TreeNodeData>[], maxLabelLength = 30): TreeNode<TreeNodeData>[] {
+  const leaves: TreeNode<TreeNodeData>[] = [];
+
+  const collect = (nodes: TreeNode<TreeNodeData>[]): void => {
+    for (const node of nodes) {
+      if (node.children?.length) {
+        collect(node.children as TreeNode<TreeNodeData>[]);
+      } else if (node.data?.dataType) {
+        leaves.push({
+          ...node,
+          label: compactTopicLabel(node.data.dataType.name, maxLabelLength),
+          children: [],
+          selectable: true
+        });
+      }
+    }
+  };
+
+  collect(treeNodes);
+  return leaves.sort((a, b) => (a.label ?? '').localeCompare(b.label ?? ''));
+}
+
 /** Finds already-selected nodes and expands their parents. */
 export function findSelectedTreeNodes(
   treeNodes: TreeNode<TreeNodeData>[],


### PR DESCRIPTION
## Changes

Adds a Flat toggle to the graph sidebar topic tree (desktop + mobile) that swaps the nested tree for an alphabetical flat list of leaves. Labels show the full path when it fits a 30-char budget, otherwise compact to firstSegment...tail. Selection state is preserved across toggles.

## Notes

- Selection truth lives in TopicSelectionService; toggling between tree/flat re-derives the local selectedNodes via findSelectedTreeNodes against the active list, so the same dataType is reflected correctly in either view (and parent paths auto-expand on the way back).
- The 30-char threshold is a heuristic that fits the desktop sidebar at standard widths and preserves the cell-letter segment (Alpha/Beta/etc.) so similarly-named leaves don't collapse onto the same label. Mobile uses the same default; horizontal scroll handles the few longest paths.
- Single-segment leaves are rendered as-is (no synthetic ellipsis).
- Unit tests live in src/utils/tree.utils.spec.ts; ng test is currently broken on develop for unrelated NodeJS.Timeout typing reasons, so the spec is documentation/regression-ready rather than executable in CI today.

## Test Cases

- Toggle is visible above the tree in both desktop and mobile sidebars
- Tree mode renders nested folders unchanged
- Flat mode shows leaves only, sorted alphabetically, with live values rendered next to each
- Long paths compact to firstSegment + ... + tail; short paths render in full
- PrimeNG search filter works against compacted labels in flat mode
- Selecting leaves in flat mode and toggling off re-expands the tree to those leaves with selection highlighted; the chart plots them correctly

## Screenshots

_screenshot pending_

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No package-lock.json changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #564
