### PR TITLE
#617 - tighten Argos/Message_Rate cadence to 500ms

### DIFF
--- a/scylla-server/src/socket_handler.rs
+++ b/scylla-server/src/socket_handler.rs
@@ -90,6 +90,9 @@ impl<A: Adapter> FromConnectParts<A> for SocketClientId {
     }
 }
 
+/// Cadence at which Argos/Message_Rate is recomputed and emitted.
+const MESSAGE_RATE_INTERVAL: Duration = Duration::from_millis(500);
+
 pub async fn socket_handler_with_metadata(
     cancel_token: CancellationToken,
     mut data_channel: broadcast::Receiver<ClientData>,
@@ -105,7 +108,7 @@ pub async fn socket_handler_with_metadata(
     let mut view_interval = tokio::time::interval(Duration::from_millis(500));
     let mut timers_interval = tokio::time::interval(Duration::from_secs(1));
     let mut recent_faults_interval = tokio::time::interval(Duration::from_secs(1));
-    let mut message_rate_interval = tokio::time::interval(Duration::from_secs(2));
+    let mut message_rate_interval = tokio::time::interval(MESSAGE_RATE_INTERVAL);
 
     // init timers
     let mut timer_map: FxHashMap<String, TimerData> = FxHashMap::default();
@@ -229,23 +232,28 @@ pub async fn socket_handler_with_metadata(
                     ).await;
             },
             _ = message_rate_interval.tick() => {
-                let rate = (msg_cnt as f32 / (tokio::time::Instant::now() - last_instant).as_millis() as f32) * 1000f32;
-                debug!("Updating message rate to be {} msg/sec", rate);
-                let item = ClientData {
-                    name: "Argos/Message_Rate".to_string(),
-                    unit: "".to_string(),
-                    run_id: crate::RUN_ID.load(Ordering::Relaxed),
-                    timestamp: chrono::offset::Utc::now(),
-                    values: vec![rate]
-                };
-                send_socket_msg(
-                        &item,
-                        &mut upload_counter,
-                        &io,
-                        METADATA_SOCKET_KEY,
-                    ).await;
-                msg_cnt = 0;
-                last_instant = tokio::time::Instant::now();
+                let elapsed_secs = (tokio::time::Instant::now() - last_instant).as_secs_f32();
+                // Skip the tick if elapsed somehow rounds to 0 — leaves msg_cnt/last_instant
+                // intact so the next tick produces a valid msg/sec value.
+                if elapsed_secs > 0.0 {
+                    let rate = msg_cnt as f32 / elapsed_secs;
+                    debug!("Updating message rate to be {} msg/sec", rate);
+                    let item = ClientData {
+                        name: "Argos/Message_Rate".to_string(),
+                        unit: "".to_string(),
+                        run_id: crate::RUN_ID.load(Ordering::Relaxed),
+                        timestamp: chrono::offset::Utc::now(),
+                        values: vec![rate]
+                    };
+                    send_socket_msg(
+                            &item,
+                            &mut upload_counter,
+                            &io,
+                            METADATA_SOCKET_KEY,
+                        ).await;
+                    msg_cnt = 0;
+                    last_instant = tokio::time::Instant::now();
+                }
             }
         }
     }

--- a/scylla-server/src/socket_handler.rs
+++ b/scylla-server/src/socket_handler.rs
@@ -232,28 +232,23 @@ pub async fn socket_handler_with_metadata(
                     ).await;
             },
             _ = message_rate_interval.tick() => {
-                let elapsed_secs = (tokio::time::Instant::now() - last_instant).as_secs_f32();
-                // Skip the tick if elapsed somehow rounds to 0 — leaves msg_cnt/last_instant
-                // intact so the next tick produces a valid msg/sec value.
-                if elapsed_secs > 0.0 {
-                    let rate = msg_cnt as f32 / elapsed_secs;
-                    debug!("Updating message rate to be {} msg/sec", rate);
-                    let item = ClientData {
-                        name: "Argos/Message_Rate".to_string(),
-                        unit: "".to_string(),
-                        run_id: crate::RUN_ID.load(Ordering::Relaxed),
-                        timestamp: chrono::offset::Utc::now(),
-                        values: vec![rate]
-                    };
-                    send_socket_msg(
-                            &item,
-                            &mut upload_counter,
-                            &io,
-                            METADATA_SOCKET_KEY,
-                        ).await;
-                    msg_cnt = 0;
-                    last_instant = tokio::time::Instant::now();
-                }
+                let rate = (msg_cnt as f32 / (tokio::time::Instant::now() - last_instant).as_millis() as f32) * 1000f32;
+                debug!("Updating message rate to be {} msg/sec", rate);
+                let item = ClientData {
+                    name: "Argos/Message_Rate".to_string(),
+                    unit: "".to_string(),
+                    run_id: crate::RUN_ID.load(Ordering::Relaxed),
+                    timestamp: chrono::offset::Utc::now(),
+                    values: vec![rate]
+                };
+                send_socket_msg(
+                        &item,
+                        &mut upload_counter,
+                        &io,
+                        METADATA_SOCKET_KEY,
+                    ).await;
+                msg_cnt = 0;
+                last_instant = tokio::time::Instant::now();
             }
         }
     }


### PR DESCRIPTION
## Changes

Drops the Argos/Message_Rate emission interval in scylla-server from 2 s to 500 ms so the client header msgs/sec readout updates near-realtime. Cadence is promoted to a MESSAGE_RATE_INTERVAL constant. Rate calculation is unchanged — the math already produces msgs/sec at any interval.

## Test Cases

- cargo build clean, integration_test.sh suite green.
- Under simulator load (~2.7–2.9k msg/sec): broadcast channel length stays at 0, heartbeat msgs_in_window matches observed rate, no new backpressure warnings.
- Client header readout visibly updates every ~500 ms.

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No package-lock.json changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #617
