### PR TITLE
#565 - add selected topics view to sidebar

### DIFF
--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.css
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.css
@@ -12,6 +12,12 @@
   gap: 12px;
 }
 
+.toggle-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 16px;
+}
+
 .flatten-toggle {
   display: inline-flex;
   align-items: center;

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.html
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.html
@@ -5,13 +5,27 @@
       label="Clear Topics"
       additionalStyles="background-color: #323232; border: 1.4px solid #027bd7;"
     />
-    <label class="flatten-toggle">
-      <typography content="Flat" variant="sidebar-label" additionalStyles="padding: 0px;" />
-      <p-toggleSwitch [ngModel]="flattenMode()" (ngModelChange)="toggleFlattenMode($event)" ariaLabel="Flatten topic tree" />
-    </label>
+    <div class="toggle-group">
+      <label class="flatten-toggle">
+        <typography content="Selected" variant="sidebar-label" additionalStyles="padding: 0px;" />
+        <p-toggleSwitch
+          [ngModel]="selectedOnly()"
+          (ngModelChange)="toggleSelectedOnly($event)"
+          ariaLabel="Show only selected topics"
+        />
+      </label>
+      <label class="flatten-toggle">
+        <typography content="Flat" variant="sidebar-label" additionalStyles="padding: 0px;" />
+        <p-toggleSwitch
+          [ngModel]="flattenMode()"
+          (ngModelChange)="toggleFlattenMode($event)"
+          ariaLabel="Flatten topic tree"
+        />
+      </label>
+    </div>
   </div>
   <p-tree
-    [value]="flattenMode() ? flatNodes : treeNodes"
+    [value]="activeNodes()"
     styleClass="w-full md:w-[30rem]"
     (onNodeSelect)="nodeSelect($event)"
     (onNodeUnselect)="onNodeUnselect($event)"

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.ts
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.ts
@@ -1,11 +1,18 @@
-import { Component, Injector, OnInit, inject, input, signal } from '@angular/core';
+import { Component, Injector, OnInit, computed, inject, input, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { TreeNode, PrimeTemplate } from 'primeng/api';
 import { TreeNodeSelectEvent, TreeNodeUnSelectEvent, Tree } from 'primeng/tree';
 import { ToggleSwitch } from 'primeng/toggleswitch';
 import Storage from 'src/services/storage.service';
 import { dataTypesToNodes } from 'src/utils/dataTypes.utils';
-import { mapNodesToTreeNodes, findSelectedTreeNodes, flattenTreeNodes, TreeNodeData } from 'src/utils/tree.utils';
+import {
+  mapNodesToTreeNodes,
+  findSelectedTreeNodes,
+  flattenTreeNodes,
+  filterSelectedNodes,
+  TreeNodeData
+} from 'src/utils/tree.utils';
 import { DataType } from 'src/utils/types.utils';
 import { TopicSelectionService } from 'src/services/topic-selection.service';
 import { ButtonComponent } from '../../../../components/argos-button/argos-button.component';
@@ -27,6 +34,14 @@ export default class GraphSidebarDesktopComponent implements OnInit {
   flatNodes: TreeNode<TreeNodeData>[] = [];
   selectedNodes?: TreeNode<TreeNodeData>[];
   flattenMode = signal(false);
+  selectedOnly = signal(false);
+
+  private selectedDataTypesSig = toSignal(this.topicSelectionService.getSelectedDataTypes(), { initialValue: [] });
+  private selectedFlatNodes = computed(() => filterSelectedNodes(this.flatNodes, this.selectedDataTypesSig()));
+  activeNodes = computed(() => {
+    if (this.selectedOnly()) return this.selectedFlatNodes();
+    return this.flattenMode() ? this.flatNodes : this.treeNodes;
+  });
 
   ngOnInit(): void {
     const nodes = dataTypesToNodes(this.dataTypes());
@@ -37,8 +52,14 @@ export default class GraphSidebarDesktopComponent implements OnInit {
 
   toggleFlattenMode(value: boolean) {
     this.flattenMode.set(value);
+    if (this.selectedOnly()) return;
     const active = value ? this.flatNodes : this.treeNodes;
     this.selectedNodes = findSelectedTreeNodes(active, this.topicSelectionService);
+  }
+
+  toggleSelectedOnly(value: boolean) {
+    this.selectedOnly.set(value);
+    this.selectedNodes = findSelectedTreeNodes(this.activeNodes(), this.topicSelectionService);
   }
 
   clearSelections = () => {

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.css
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.css
@@ -27,12 +27,18 @@
   height: 100%;
 }
 
+.toggle-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 16px;
+  align-self: flex-start;
+}
+
 .flatten-toggle {
   display: inline-flex;
   align-items: center;
   gap: 8px;
   cursor: pointer;
-  align-self: flex-start;
 }
 
 .tree-node-container {

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.html
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.html
@@ -11,16 +11,26 @@
         label="Clear Topics"
         additionalStyles="background-color: #323232; border: 1.4px solid #027bd7; width: 100%;"
       />
-      <label class="flatten-toggle">
-        <typography content="Flat" variant="sidebar-label" additionalStyles="padding: 0px;" />
-        <p-toggleSwitch
-          [ngModel]="flattenMode()"
-          (ngModelChange)="toggleFlattenMode($event)"
-          ariaLabel="Flatten topic tree"
-        />
-      </label>
+      <div class="toggle-group">
+        <label class="flatten-toggle">
+          <typography content="Selected" variant="sidebar-label" additionalStyles="padding: 0px;" />
+          <p-toggleSwitch
+            [ngModel]="selectedOnly()"
+            (ngModelChange)="toggleSelectedOnly($event)"
+            ariaLabel="Show only selected topics"
+          />
+        </label>
+        <label class="flatten-toggle">
+          <typography content="Flat" variant="sidebar-label" additionalStyles="padding: 0px;" />
+          <p-toggleSwitch
+            [ngModel]="flattenMode()"
+            (ngModelChange)="toggleFlattenMode($event)"
+            ariaLabel="Flatten topic tree"
+          />
+        </label>
+      </div>
       <p-tree
-        [value]="flattenMode() ? flatNodes : treeNodes"
+        [value]="activeNodes()"
         (onNodeSelect)="nodeSelect($event)"
         (onNodeUnselect)="onNodeUnselect($event)"
         [(selection)]="selectedNodes"

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.ts
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, Injector, OnInit, inject, input, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Injector, OnInit, computed, inject, input, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { TreeNode, PrimeTemplate } from 'primeng/api';
 import { TreeNodeSelectEvent, TreeNodeUnSelectEvent, Tree } from 'primeng/tree';
@@ -6,7 +7,13 @@ import { Sidebar } from 'primeng/sidebar';
 import { ToggleSwitch } from 'primeng/toggleswitch';
 import Storage from 'src/services/storage.service';
 import { dataTypesToNodes } from 'src/utils/dataTypes.utils';
-import { mapNodesToTreeNodes, findSelectedTreeNodes, flattenTreeNodes, TreeNodeData } from 'src/utils/tree.utils';
+import {
+  mapNodesToTreeNodes,
+  findSelectedTreeNodes,
+  flattenTreeNodes,
+  filterSelectedNodes,
+  TreeNodeData
+} from 'src/utils/tree.utils';
 import { DataType } from 'src/utils/types.utils';
 import { TopicSelectionService } from 'src/services/topic-selection.service';
 import { ButtonComponent } from '../../../../components/argos-button/argos-button.component';
@@ -31,6 +38,14 @@ export default class GraphSidebarMobileComponent implements OnInit {
   flatNodes: TreeNode<TreeNodeData>[] = [];
   selectedNodes?: TreeNode<TreeNodeData>[];
   flattenMode = signal(false);
+  selectedOnly = signal(false);
+
+  private selectedDataTypesSig = toSignal(this.topicSelectionService.getSelectedDataTypes(), { initialValue: [] });
+  private selectedFlatNodes = computed(() => filterSelectedNodes(this.flatNodes, this.selectedDataTypesSig()));
+  activeNodes = computed(() => {
+    if (this.selectedOnly()) return this.selectedFlatNodes();
+    return this.flattenMode() ? this.flatNodes : this.treeNodes;
+  });
 
   ngOnInit(): void {
     const nodes = dataTypesToNodes(this.dataTypes());
@@ -45,8 +60,14 @@ export default class GraphSidebarMobileComponent implements OnInit {
 
   toggleFlattenMode(value: boolean) {
     this.flattenMode.set(value);
+    if (this.selectedOnly()) return;
     const active = value ? this.flatNodes : this.treeNodes;
     this.selectedNodes = findSelectedTreeNodes(active, this.topicSelectionService);
+  }
+
+  toggleSelectedOnly(value: boolean) {
+    this.selectedOnly.set(value);
+    this.selectedNodes = findSelectedTreeNodes(this.activeNodes(), this.topicSelectionService);
   }
 
   clearSelections = () => {

--- a/angular-client/src/utils/tree.utils.spec.ts
+++ b/angular-client/src/utils/tree.utils.spec.ts
@@ -1,7 +1,7 @@
 import { signal } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { TreeNode } from 'primeng/api';
-import { compactTopicLabel, flattenTreeNodes, TreeNodeData } from './tree.utils';
+import { compactTopicLabel, filterSelectedNodes, flattenTreeNodes, TreeNodeData } from './tree.utils';
 import { DataType, Node } from './types.utils';
 
 const EMPTY_DISPLAY = signal('');
@@ -105,5 +105,32 @@ describe('flattenTreeNodes', () => {
   it('returns an empty list when the tree has no leaves', () => {
     const flat = flattenTreeNodes([branch('Empty', [])]);
     expect(flat).toEqual([]);
+  });
+});
+
+describe('filterSelectedNodes', () => {
+  const voltage = leaf('BMS/Pack/Voltage', 'V');
+  const soc = leaf('BMS/Pack/SOC', '%');
+  const speed = leaf('MPU/State/Speed', 'mph');
+  const flat = [voltage, soc, speed];
+
+  it('returns nodes whose dataType matches the selection by name', () => {
+    const result = filterSelectedNodes(flat, [voltage.data!.dataType, speed.data!.dataType]);
+    expect(result).toEqual([voltage, speed]);
+  });
+
+  it('preserves original node references so PrimeNG selection-by-ref works', () => {
+    const [match] = filterSelectedNodes(flat, [voltage.data!.dataType]);
+    expect(match).toBe(voltage);
+  });
+
+  it('returns an empty list when no data types are selected', () => {
+    expect(filterSelectedNodes(flat, [])).toEqual([]);
+  });
+
+  it('ignores selected data types that are not in the flat list', () => {
+    const ghost: DataType = { name: 'Does/Not/Exist', unit: '' };
+    const result = filterSelectedNodes(flat, [ghost, soc.data!.dataType]);
+    expect(result).toEqual([soc]);
   });
 });

--- a/angular-client/src/utils/tree.utils.ts
+++ b/angular-client/src/utils/tree.utils.ts
@@ -5,7 +5,7 @@ import { map } from 'rxjs';
 import Storage from 'src/services/storage.service';
 import { decimalPipe } from 'src/utils/pipes.utils';
 import { DataValue } from 'src/utils/socket.utils';
-import { Node } from 'src/utils/types.utils';
+import { DataType, Node } from 'src/utils/types.utils';
 import { TopicSelectionService } from 'src/services/topic-selection.service';
 
 export interface TreeNodeData extends Node {
@@ -89,6 +89,20 @@ export function flattenTreeNodes(treeNodes: TreeNode<TreeNodeData>[], maxLabelLe
 
   collect(treeNodes);
   return leaves.sort((a, b) => (a.label ?? '').localeCompare(b.label ?? ''));
+}
+
+/**
+ * Filters a flat list of leaf TreeNodes to only those whose dataType is in
+ * `selectedDataTypes`. Preserves the original node references so PrimeNG's
+ * selection-by-reference matching keeps working.
+ */
+export function filterSelectedNodes(
+  flatNodes: TreeNode<TreeNodeData>[],
+  selectedDataTypes: DataType[]
+): TreeNode<TreeNodeData>[] {
+  if (selectedDataTypes.length === 0) return [];
+  const selectedNames = new Set(selectedDataTypes.map((dt) => dt.name));
+  return flatNodes.filter((n) => n.data?.dataType && selectedNames.has(n.data.dataType.name));
 }
 
 /** Finds already-selected nodes and expands their parents. */


### PR DESCRIPTION
## Changes

Adds a Selected toggle to the graph sidebar (desktop + mobile) that filters the topic list down to only the currently-selected topics in flat layout. Implemented via a toSignal of the selection service feeding a computed filter over the existing flatNodes — deselects in this view drop the row in real time, and toggling off restores the prior tree-or-flat view with the user's flat preference and remaining selections intact. Added a small filterSelectedNodes helper in src/utils/tree.utils.ts (with tests) so the filtering preserves the original TreeNode references that PrimeNG's selection-by-ref needs.

## Notes

The Selected toggle and Flat toggle are independent: Selected always renders flat (per the ticket), but it does not mutate flattenMode, so the user's flat preference survives the round-trip. Mobile and desktop sidebars duplicate the same wiring rather than sharing a base — matches the existing pattern from #564 and avoids scope creep into a refactor.

## Test Cases

- Toggle Selected on with two leaves selected → list shows exactly those two as flat, with live values
- Deselect a row inside the selected-only view → row drops and graph updates in real time
- Toggle Selected off → previous tree view restored with prior expansions and remaining selection highlighted
- Flat on → Selected on → Selected off → list returns to flat (preference preserved)
- Mobile (414×896): same flow through the slide-over sidebar
- filterSelectedNodes unit tests cover empty selection, ref preservation, and ghost data types not in the flat list

## Screenshots

_screenshot pending_

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No package-lock.json changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #565
