### PR TITLE
#619 Pin siren mosquitto to 2.0.22

### DIFF
--- a/siren-base/compose.siren.yml
+++ b/siren-base/compose.siren.yml
@@ -2,7 +2,7 @@ services:
   siren:
     container_name: siren
     restart: unless-stopped
-    image: eclipse-mosquitto:latest
+    image: eclipse-mosquitto:2.0.22-openssl
     ports:
       - 1883:1883
       - 9002:9001 # win conflict on 9001

--- a/siren-base/mosquitto/mosquitto.conf
+++ b/siren-base/mosquitto/mosquitto.conf
@@ -51,10 +51,6 @@ listener 1883
 
 socket_domain ipv4
 
-max_topic_alias 0
-max_topic_alias_broker 0
-
-
 #bind_interface
 
 #http_dir
@@ -188,8 +184,6 @@ topic reserved out 2 dummy dummyremote
 #bridge_attempt_unsubscribe true
 
 bridge_protocol_version mqttv50
-
-bridge_max_topic_alias 0
 
 #cleansession false
 


### PR DESCRIPTION
## Changes

Pins the siren mosquitto image to eclipse-mosquitto:2.0.22-openssl to match the TPU (Buildroot 2025.11.1, mosquitto 2.0.22), and removes three 2.1-only options from mosquitto.conf — max_topic_alias, max_topic_alias_broker, and bridge_max_topic_alias — that fail to parse on 2.0.22. No other broker settings touched.

## Notes

Deploy still requires wiping the on-host mosquitto.db before restart so 2.0.22 doesn't try to read a 2.1.x-format persistence file, and diffing the on-host conf against this branch first to catch drift (notably the bridge address line, which has been seen pointing at 10.42.0.2 instead of 192.168.100.12). Those are deploy actions, not part of this PR.

## Test Cases

- mosquitto.conf has no remaining max_topic_alias or bridge_max_topic_alias references
- compose.siren.yml uses the pinned 2.0.22-openssl tag (no floating :latest, :2, or :2.0)
- allow_anonymous, max_qos, max_queued_messages, and bridge_protocol_version mqttv50 are unchanged

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #619
