### PR TITLE
#622 Preserve graph topic selection across page nav

### DIFF
--- a/angular-client/src/pages/graph-page/graph-page.component.spec.ts
+++ b/angular-client/src/pages/graph-page/graph-page.component.spec.ts
@@ -1,0 +1,133 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, ParamMap, Router, convertToParamMap } from '@angular/router';
+import { MessageService } from 'primeng/api';
+import { BehaviorSubject } from 'rxjs';
+import APIService from 'src/services/api.service';
+import { FaultService } from 'src/services/fault.service';
+import Storage from 'src/services/storage.service';
+import { TopicSelectionService } from 'src/services/topic-selection.service';
+import { QueryResponse } from 'src/utils/api.utils';
+import { DataType, Run } from 'src/utils/types.utils';
+import GraphPageComponent from './graph-page.component';
+
+describe('GraphPageComponent — URL/topic-selection sync', () => {
+  let fixture: ComponentFixture<GraphPageComponent>;
+  let topicService: TopicSelectionService;
+  let routerNavigate: jasmine.Spy;
+
+  const dataTypeA: DataType = { name: 'BMS/Pack/SOC', unit: '%' };
+  const dataTypeB: DataType = { name: 'MPU/State/Speed', unit: 'mph' };
+  const dataTypeC: DataType = { name: 'BMS/Pack/Voltage', unit: 'V' };
+  const allDataTypes: DataType[] = [dataTypeA, dataTypeB, dataTypeC];
+
+  let dataTypesData: BehaviorSubject<DataType[] | null>;
+  let queryParamMap: BehaviorSubject<ParamMap>;
+
+  beforeEach(async () => {
+    dataTypesData = new BehaviorSubject<DataType[] | null>(null);
+    const runsData = new BehaviorSubject<Run[] | null>(null);
+
+    // First query() call comes from queryDataTypes; subsequent from initGeneralPage (runs).
+    let queryCalls = 0;
+    const apiServiceMock: Pick<APIService, 'query'> = {
+      query: <T>() => {
+        queryCalls += 1;
+        const response: QueryResponse<unknown> =
+          queryCalls === 1
+            ? {
+                isLoading: new BehaviorSubject<boolean>(true),
+                data: dataTypesData,
+                isError: new BehaviorSubject<boolean>(false),
+                error: new BehaviorSubject<Error | null>(null)
+              }
+            : {
+                isLoading: new BehaviorSubject<boolean>(true),
+                data: runsData,
+                isError: new BehaviorSubject<boolean>(false),
+                error: new BehaviorSubject<Error | null>(null)
+              };
+        return response as QueryResponse<T>;
+      }
+    };
+
+    queryParamMap = new BehaviorSubject<ParamMap>(convertToParamMap({}));
+    const routeMock = {
+      queryParamMap: queryParamMap.asObservable(),
+      snapshot: {
+        get queryParamMap() {
+          return queryParamMap.value;
+        }
+      }
+    };
+    routerNavigate = jasmine.createSpy('navigate').and.returnValue(Promise.resolve(true));
+    const routerMock = {
+      url: '/graph',
+      navigate: routerNavigate
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [GraphPageComponent],
+      providers: [
+        TopicSelectionService,
+        FaultService,
+        Storage,
+        MessageService,
+        { provide: APIService, useValue: apiServiceMock },
+        { provide: ActivatedRoute, useValue: routeMock },
+        { provide: Router, useValue: routerMock }
+      ]
+    }).compileComponents();
+
+    topicService = TestBed.inject(TopicSelectionService);
+  });
+
+  // dataTypesIsLoading stays true so the template keeps showing loading-page; this avoids
+  // booting child components whose deps aren't wired up in this test bed. The data-subscription
+  // path (and therefore syncUrlToService) still runs because we emit on `data` directly.
+  function mountAndLoadDataTypes() {
+    fixture = TestBed.createComponent(GraphPageComponent);
+    fixture.detectChanges();
+    dataTypesData.next(allDataTypes);
+  }
+
+  it('preserves non-empty service state when URL has no topics param (regression for #622)', () => {
+    topicService.setSelectedDataTypes([dataTypeA, dataTypeB]);
+    mountAndLoadDataTypes();
+
+    expect(topicService.getSelectedDataTypes().value).toEqual([dataTypeA, dataTypeB]);
+  });
+
+  it('hydrates service from URL deep link when service is empty', () => {
+    queryParamMap.next(convertToParamMap({ topics: `${dataTypeA.name},${dataTypeB.name}` }));
+    mountAndLoadDataTypes();
+
+    const names = topicService
+      .getSelectedDataTypes()
+      .value.map((d) => d.name)
+      .sort();
+    expect(names).toEqual([dataTypeA.name, dataTypeB.name].sort());
+  });
+
+  it('merges URL topics into service additively (no removals driven by URL)', () => {
+    topicService.setSelectedDataTypes([dataTypeA]);
+    queryParamMap.next(convertToParamMap({ topics: dataTypeC.name }));
+    mountAndLoadDataTypes();
+
+    const names = topicService
+      .getSelectedDataTypes()
+      .value.map((d) => d.name)
+      .sort();
+    expect(names).toEqual([dataTypeA.name, dataTypeC.name].sort());
+  });
+
+  it('clears service and topics URL param when selection is explicitly cleared', () => {
+    topicService.setSelectedDataTypes([dataTypeA]);
+    mountAndLoadDataTypes();
+
+    topicService.clearSelection();
+
+    expect(topicService.getSelectedDataTypes().value).toEqual([]);
+    const lastNav = routerNavigate.calls.mostRecent();
+    expect(lastNav.args[1].queryParams.topics).toBeNull();
+  });
+});

--- a/angular-client/src/pages/graph-page/graph-page.component.ts
+++ b/angular-client/src/pages/graph-page/graph-page.component.ts
@@ -378,10 +378,15 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
   private syncUrlToService(params: ParamMap) {
     if (this.dataTypes.length === 0) return;
 
-    const topicNames = new Set(params.get('topics')?.split(',') ?? []);
-    const topics = this.dataTypes.filter((dt) => topicNames.has(dt.name));
+    const topicsParam = params.get('topics');
+    if (!topicsParam) return;
 
-    this.topicSelectionService.setSelectedDataTypes(topics);
+    // URL → service is additive only. The service is source of truth; the URL is a view of
+    // it (kept in sync by updateUrl). When URL and service diverge, we only add what the URL
+    // contributes (deep-link hydration) — never remove. Removals come from explicit UI actions.
+    const topicNames = new Set(topicsParam.split(','));
+    const topicsFromUrl = this.dataTypes.filter((dt) => topicNames.has(dt.name));
+    this.topicSelectionService.addDataTypes(topicsFromUrl);
   }
 
   private updateUrl(selectedDataTypes: DataType[]) {


### PR DESCRIPTION
## Changes

Make graph-page's URL → service sync additive. The TopicSelectionService is the source of truth; the URL is a view of it (kept in sync by updateUrl). syncUrlToService now uses addDataTypes instead of setSelectedDataTypes, so re-entering /graph with no topics= param can no longer wipe in-memory selection. Removals only come from explicit UI actions; deep links still hydrate the service.

## Notes

In-memory persistence only — a full page reload still resets the service unless the URL carries the topics. localStorage persistence is intentionally deferred per the ticket.

## Test Cases

- Select topics on /graph, navigate to another page, return to /graph: selection preserved
- Open /graph?topics=A,B in a fresh session: service hydrates from URL
- Service has [A], URL has ?topics=C: service merges to [A, C]
- Explicitly clear via UI: service empties and topics URL param is removed
- Existing topic-selection.service tests still pass

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No package-lock.json changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #622
