### PR TITLE
#625 promote rule logs to info, drop per-message chatter

### DIFF
--- a/scylla-server/src/controllers/rule_controller.rs
+++ b/scylla-server/src/controllers/rule_controller.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use serde_with::DurationSeconds;
 use serde_with::serde_as;
 use std::time::Duration;
-use tracing::debug;
+use tracing::{debug, info};
 
 use crate::{
     error::ScyllaError,
@@ -28,7 +28,7 @@ pub async fn add_rule(
     Extension(rules_manager): Extension<Arc<RuleManager>>,
     Json(rule): Json<Rule>,
 ) -> Result<Json<String>, ScyllaError> {
-    debug!(
+    info!(
         "Incoming rules reg: {}, from {}",
         rule.topic,
         auth.username().to_string()
@@ -48,7 +48,7 @@ pub async fn delete_rule(
     Extension(rules_manager): Extension<Arc<RuleManager>>,
     Path(rule_id): Path<String>,
 ) -> Result<(), ScyllaError> {
-    debug!(
+    info!(
         "Incoming rules del: {}, from {}",
         rule_id,
         auth.username().to_string()
@@ -117,6 +117,7 @@ pub async fn edit_rule(
         debounce_time,
     }): Json<EditRulePayload>,
 ) -> Result<(), ScyllaError> {
+    info!("Incoming rules edit: {}", rule_id);
     rules_manager
         .edit_rule(RuleId(rule_id), expr, debounce_time)
         .await
@@ -128,7 +129,7 @@ pub async fn unsubscribe_rules(
     Extension(rules_manager): Extension<Arc<RuleManager>>,
     Json(request): Json<RuleSubscriptionRequest>,
 ) -> Result<Json<String>, ScyllaError> {
-    debug!(
+    info!(
         "Unsubscribing client {} from {} rules",
         request.client_id,
         request.rule_ids.len()
@@ -152,7 +153,7 @@ pub async fn subscribe_rules(
     Extension(rules_manager): Extension<Arc<RuleManager>>,
     Json(request): Json<RuleSubscriptionRequest>,
 ) -> Result<Json<String>, ScyllaError> {
-    debug!(
+    info!(
         "Subscribing client {} to {} rules",
         request.client_id,
         request.rule_ids.len()

--- a/scylla-server/src/rule_structs.rs
+++ b/scylla-server/src/rule_structs.rs
@@ -402,10 +402,7 @@ impl RuleManager {
                 .get_mut(&rule_id)
                 .map(|rule| rule.tick(&data.values))
             {
-                Some(Some(val)) => {
-                    info!("Rule {} triggered: {}", rule_id, val);
-                    val
-                }
+                Some(Some(val)) => val,
                 // Rule tick failed
                 Some(None) => return Err(RuleManagerError::RuleFailure),
                 None => {
@@ -417,6 +414,7 @@ impl RuleManager {
             if !triggered {
                 continue;
             }
+            info!("Rule {} triggered", rule_id);
 
             for client in clients {
                 notifications.push((

--- a/scylla-server/src/rule_structs.rs
+++ b/scylla-server/src/rule_structs.rs
@@ -14,7 +14,8 @@ use std::borrow::Borrow;
 use std::hash::Hash;
 use std::time::Duration;
 use tokio::sync::RwLock;
-use tracing::debug;
+use tracing::info;
+use tracing::trace;
 use tracing::warn;
 
 use crate::ClientData;
@@ -382,7 +383,7 @@ impl RuleManager {
 
         let mut notifications: Vec<(ClientId, RuleNotification)> = Vec::new();
 
-        debug!(
+        trace!(
             "Handling rule processing for {} with values: {:?}",
             data.name, data.values
         );
@@ -402,7 +403,7 @@ impl RuleManager {
                 .map(|rule| rule.tick(&data.values))
             {
                 Some(Some(val)) => {
-                    debug!("Rule {} triggered: {}", rule_id, val);
+                    info!("Rule {} triggered: {}", rule_id, val);
                     val
                 }
                 // Rule tick failed


### PR DESCRIPTION
## Changes

Drops the per-MQTT-message "Handling rule processing" log in rule_structs.rs from debug to trace so it no longer floods Docker logs at default verbosity. Promotes "Rule X triggered" plus the add/delete/edit/subscribe/unsubscribe handlers in rule_controller.rs from debug to info so rule lifecycle events surface without bumping the global log level. edit_rule had no log; added one for parity with the other CRUD handlers.

## Notes

GET handlers (get_all_rules, get_client_subscribed_rules, get_all_rules_with_client_info) stay at debug — they fire on every page load and would re-introduce chatter at info.

## Test Cases

- cargo build clean
- integration_test.sh: all 25 rule_structs tests pass, including handle_msg_rule_triggered and edit_rule_preserves_subscriptions_concurrent
- Rest of integration suite (bimultimap, run_service, data_service, etc.) passes

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No package-lock.json changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #625
