### PR TITLE
Graph page topic selection preset

### DIFF
--- a/angular-client/src/components/select-dropdown/select-dropdown.component.css
+++ b/angular-client/src/components/select-dropdown/select-dropdown.component.css
@@ -52,3 +52,7 @@
 ::ng-deep .p-select-option {
   font-size: 0.8rem;
 }
+
+::ng-deep .p-select-empty-message {
+  font-size: 0.8rem;
+}

--- a/angular-client/src/components/select-dropdown/select-dropdown.component.css
+++ b/angular-client/src/components/select-dropdown/select-dropdown.component.css
@@ -56,3 +56,9 @@
 ::ng-deep .p-select-empty-message {
   font-size: 0.8rem;
 }
+
+::ng-deep .p-select-option-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/angular-client/src/components/select-dropdown/select-dropdown.component.ts
+++ b/angular-client/src/components/select-dropdown/select-dropdown.component.ts
@@ -45,7 +45,14 @@ export class SelectDropdownComponent {
     // callers that never unset `defaultValue` see no behavior change.
     effect(() => {
       const val = this.defaultValue();
-      this.selectedOption = val ? this.options().find((option) => option.name === val) : undefined;
+      if (val) {
+        const match = this.options().find((option) => option.name === val);
+        if (match) {
+          this.selectedOption = match;
+        }
+      } else {
+        this.selectedOption = undefined;
+      }
     });
   }
 

--- a/angular-client/src/components/select-dropdown/select-dropdown.component.ts
+++ b/angular-client/src/components/select-dropdown/select-dropdown.component.ts
@@ -39,12 +39,7 @@ export class SelectDropdownComponent {
   constructor() {
     effect(() => {
       const val = this.defaultValue();
-      if (val) {
-        const match = this.options().find((option) => option.name === val);
-        if (match) {
-          this.selectedOption = match;
-        }
-      }
+      this.selectedOption = val ? this.options().find((option) => option.name === val) : undefined;
     });
   }
 

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.css
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.css
@@ -5,6 +5,19 @@
   margin-top: 10px;
 }
 
+.presets-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.preset-select {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 .header-row {
   display: flex;
   align-items: center;

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.css
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.css
@@ -3,26 +3,50 @@
   margin-left: 0px;
   max-height: 80vh;
   margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .presets-row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  margin-bottom: 8px;
+  justify-content: flex-start;
+  gap: 6px;
 }
 
 .preset-select {
-  flex: 1 1 auto;
-  min-width: 0;
+  flex: 0 0 auto;
+}
+
+.preset-select ::ng-deep .p-select {
+  height: 28px !important;
+  min-height: 28px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.preset-select ::ng-deep .p-select-label,
+.preset-select ::ng-deep .p-select-label.p-placeholder {
+  width: auto !important;
+  min-width: 100px;
+  padding: 0 0.5rem !important;
+  font-size: 12px;
+  line-height: 28px;
+  height: 28px;
+}
+
+.preset-select ::ng-deep .p-select-dropdown {
+  width: 1.75rem;
 }
 
 .header-row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+  justify-content: flex-start;
+  gap: 16px;
+  flex-wrap: wrap;
 }
 
 .toggle-group {

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.css
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.css
@@ -16,12 +16,23 @@
 }
 
 .preset-select {
-  flex: 0 0 auto;
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.presets-row argos-button {
+  flex-shrink: 0;
+}
+
+.presets-row argos-button ::ng-deep .btn {
+  white-space: nowrap;
 }
 
 .preset-select ::ng-deep .p-select {
   height: 28px !important;
   min-height: 28px;
+  width: 100%;
   border-radius: 8px;
   display: inline-flex;
   align-items: center;
@@ -29,12 +40,14 @@
 
 .preset-select ::ng-deep .p-select-label,
 .preset-select ::ng-deep .p-select-label.p-placeholder {
-  width: auto !important;
-  min-width: 100px;
+  width: 100% !important;
   padding: 0 0.5rem !important;
   font-size: 12px;
   line-height: 28px;
   height: 28px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .preset-select ::ng-deep .p-select-dropdown {

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.html
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.html
@@ -9,6 +9,7 @@
     <argos-button
       [onClick]="openPresetsDialog"
       label="Manage Presets"
+      size="sm"
       additionalStyles="background-color: #323232; border: 1.4px solid #027bd7;"
     />
   </div>
@@ -16,6 +17,7 @@
     <argos-button
       [onClick]="clearSelections"
       label="Clear Topics"
+      size="sm"
       additionalStyles="background-color: #323232; border: 1.4px solid #027bd7;"
     />
     <div class="toggle-group">

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.html
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.html
@@ -1,4 +1,17 @@
 <div class="background">
+  <div class="presets-row">
+    <select-dropdown
+      class="preset-select"
+      [options]="presetSelectorConfig().options"
+      [placeholder]="presetSelectorConfig().placeholder"
+      [defaultValue]="activePresetName()"
+    />
+    <argos-button
+      [onClick]="openPresetsDialog"
+      label="Manage Presets"
+      additionalStyles="background-color: #323232; border: 1.4px solid #027bd7;"
+    />
+  </div>
   <div class="header-row">
     <argos-button
       [onClick]="clearSelections"

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.ts
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.ts
@@ -1,7 +1,7 @@
 import { Component, Injector, OnInit, computed, inject, input, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
-import { MessageService, TreeNode, PrimeTemplate } from 'primeng/api';
+import { TreeNode, PrimeTemplate } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
 import { TreeNodeSelectEvent, TreeNodeUnSelectEvent, Tree } from 'primeng/tree';
 import { ToggleSwitch } from 'primeng/toggleswitch';
@@ -13,7 +13,7 @@ import {
 } from 'src/components/select-dropdown/select-dropdown.component';
 import { GraphPresetService, Preset } from 'src/services/graph-preset.service';
 import Storage from 'src/services/storage.service';
-import { dataTypesToNodes, partitionDataTypesByName } from 'src/utils/dataTypes.utils';
+import { dataTypesToNodes } from 'src/utils/dataTypes.utils';
 import {
   mapNodesToTreeNodes,
   findSelectedTreeNodes,
@@ -37,7 +37,6 @@ export default class GraphSidebarDesktopComponent implements OnInit {
   private topicSelectionService = inject(TopicSelectionService);
   private presetService = inject(GraphPresetService);
   private dialogService = inject(DialogService);
-  private messageService = inject(MessageService);
   private storage = inject(Storage);
   private injector = inject(Injector);
 
@@ -133,15 +132,7 @@ export default class GraphSidebarDesktopComponent implements OnInit {
   }
 
   private applyPreset(preset: Preset) {
-    const { matched, unknown } = partitionDataTypesByName(this.dataTypes(), preset.topicNames);
-    if (unknown.length > 0) {
-      this.messageService.add({
-        severity: 'warn',
-        summary: 'Unknown Topics Skipped',
-        detail: unknown.join(', '),
-        life: 8000
-      });
-    }
+    const matched = this.presetService.resolvePresetTopics(preset, this.dataTypes());
     this.applyMatched(matched);
   }
 

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.ts
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.ts
@@ -1,11 +1,19 @@
 import { Component, Injector, OnInit, computed, inject, input, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
-import { TreeNode, PrimeTemplate } from 'primeng/api';
+import { MessageService, TreeNode, PrimeTemplate } from 'primeng/api';
+import { DialogService } from 'primeng/dynamicdialog';
 import { TreeNodeSelectEvent, TreeNodeUnSelectEvent, Tree } from 'primeng/tree';
 import { ToggleSwitch } from 'primeng/toggleswitch';
+import { take } from 'rxjs';
+import {
+  DropdownOption,
+  SelectDropdownComponent,
+  SelectorConfig
+} from 'src/components/select-dropdown/select-dropdown.component';
+import { GraphPresetService, Preset } from 'src/services/graph-preset.service';
 import Storage from 'src/services/storage.service';
-import { dataTypesToNodes } from 'src/utils/dataTypes.utils';
+import { dataTypesToNodes, partitionDataTypesByName } from 'src/utils/dataTypes.utils';
 import {
   mapNodesToTreeNodes,
   findSelectedTreeNodes,
@@ -17,15 +25,19 @@ import { DataType } from 'src/utils/types.utils';
 import { TopicSelectionService } from 'src/services/topic-selection.service';
 import { ButtonComponent } from '../../../../components/argos-button/argos-button.component';
 import TypographyComponent from 'src/components/typography/typography.component';
+import { PresetDialogComponent } from '../../preset-dialog/preset-dialog.component';
 
 @Component({
   selector: 'graph-sidebar-desktop',
   templateUrl: './graph-sidebar-desktop.component.html',
   styleUrls: ['./graph-sidebar-desktop.component.css'],
-  imports: [ButtonComponent, Tree, PrimeTemplate, TypographyComponent, ToggleSwitch, FormsModule]
+  imports: [ButtonComponent, Tree, PrimeTemplate, TypographyComponent, ToggleSwitch, FormsModule, SelectDropdownComponent]
 })
 export default class GraphSidebarDesktopComponent implements OnInit {
   private topicSelectionService = inject(TopicSelectionService);
+  private presetService = inject(GraphPresetService);
+  private dialogService = inject(DialogService);
+  private messageService = inject(MessageService);
   private storage = inject(Storage);
   private injector = inject(Injector);
 
@@ -42,6 +54,18 @@ export default class GraphSidebarDesktopComponent implements OnInit {
     if (this.selectedOnly()) return this.selectedFlatNodes();
     return this.flattenMode() ? this.flatNodes : this.treeNodes;
   });
+
+  private presets = toSignal(this.presetService.getPresets(), { initialValue: [] as Preset[] });
+  presetSelectorConfig = computed<SelectorConfig>(() => ({
+    placeholder: 'Apply Preset…',
+    options: this.presets().map(
+      (p): DropdownOption => ({
+        name: p.name,
+        function: () => this.applyPreset(p)
+      })
+    )
+  }));
+  activePresetName = toSignal(this.presetService.getActivePresetName(), { initialValue: undefined });
 
   ngOnInit(): void {
     const nodes = dataTypesToNodes(this.dataTypes());
@@ -68,6 +92,24 @@ export default class GraphSidebarDesktopComponent implements OnInit {
     this.selectedNodes = undefined;
   };
 
+  openPresetsDialog = () => {
+    const ref = this.dialogService.open(PresetDialogComponent, {
+      header: 'Topic Presets',
+      width: '640px',
+      draggable: true,
+      closable: true,
+      closeAriaLabel: 'Close',
+      data: {
+        dataTypes: this.dataTypes()
+      }
+    });
+    ref.onClose.pipe(take(1)).subscribe((matched: DataType[] | null) => {
+      if (matched) {
+        this.applyMatched(matched);
+      }
+    });
+  };
+
   nodeSelect(event: TreeNodeSelectEvent) {
     const dt = event.node.data?.dataType;
     if (dt) {
@@ -88,5 +130,23 @@ export default class GraphSidebarDesktopComponent implements OnInit {
     if (dt) {
       this.topicSelectionService.removeDataType(dt);
     }
+  }
+
+  private applyPreset(preset: Preset) {
+    const { matched, unknown } = partitionDataTypesByName(this.dataTypes(), preset.topicNames);
+    if (unknown.length > 0) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Unknown Topics Skipped',
+        detail: unknown.join(', '),
+        life: 8000
+      });
+    }
+    this.applyMatched(matched);
+  }
+
+  private applyMatched(matched: DataType[]) {
+    this.topicSelectionService.setSelectedDataTypes(matched);
+    this.selectedNodes = findSelectedTreeNodes(this.activeNodes(), this.topicSelectionService);
   }
 }

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.ts
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.ts
@@ -1,8 +1,8 @@
-import { Component, Injector, OnInit, computed, inject, input, signal } from '@angular/core';
+import { Component, Injector, OnDestroy, OnInit, computed, inject, input, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { TreeNode, PrimeTemplate } from 'primeng/api';
-import { DialogService } from 'primeng/dynamicdialog';
+import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { TreeNodeSelectEvent, TreeNodeUnSelectEvent, Tree } from 'primeng/tree';
 import { ToggleSwitch } from 'primeng/toggleswitch';
 import { take } from 'rxjs';
@@ -33,12 +33,13 @@ import { PresetDialogComponent } from '../../preset-dialog/preset-dialog.compone
   styleUrls: ['./graph-sidebar-desktop.component.css'],
   imports: [ButtonComponent, Tree, PrimeTemplate, TypographyComponent, ToggleSwitch, FormsModule, SelectDropdownComponent]
 })
-export default class GraphSidebarDesktopComponent implements OnInit {
+export default class GraphSidebarDesktopComponent implements OnInit, OnDestroy {
   private topicSelectionService = inject(TopicSelectionService);
   private presetService = inject(GraphPresetService);
   private dialogService = inject(DialogService);
   private storage = inject(Storage);
   private injector = inject(Injector);
+  private presetDialogRef?: DynamicDialogRef;
 
   dataTypes = input<DataType[]>([]);
   treeNodes: TreeNode<TreeNodeData>[] = [];
@@ -92,7 +93,7 @@ export default class GraphSidebarDesktopComponent implements OnInit {
   };
 
   openPresetsDialog = () => {
-    const ref = this.dialogService.open(PresetDialogComponent, {
+    this.presetDialogRef = this.dialogService.open(PresetDialogComponent, {
       header: 'Topic Presets',
       width: '640px',
       draggable: true,
@@ -102,12 +103,18 @@ export default class GraphSidebarDesktopComponent implements OnInit {
         dataTypes: this.dataTypes()
       }
     });
-    ref.onClose.pipe(take(1)).subscribe((matched: DataType[] | null) => {
+    this.presetDialogRef.onClose.pipe(take(1)).subscribe((matched: DataType[] | null) => {
       if (matched) {
         this.applyMatched(matched);
       }
     });
   };
+
+  ngOnDestroy(): void {
+    if (this.presetDialogRef) {
+      this.presetDialogRef.close();
+    }
+  }
 
   nodeSelect(event: TreeNodeSelectEvent) {
     const dt = event.node.data?.dataType;

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.ts
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-desktop/graph-sidebar-desktop.component.ts
@@ -137,6 +137,7 @@ export default class GraphSidebarDesktopComponent implements OnInit {
   }
 
   private applyMatched(matched: DataType[]) {
+    if (matched.length === 0) return; // unknown topics warn toast
     this.topicSelectionService.setSelectedDataTypes(matched);
     this.selectedNodes = findSelectedTreeNodes(this.activeNodes(), this.topicSelectionService);
   }

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.css
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.css
@@ -35,13 +35,23 @@
 }
 
 .preset-select {
-  flex: 0 0 auto;
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.presets-row argos-button {
+  flex-shrink: 0;
+}
+
+.presets-row argos-button ::ng-deep .btn {
+  white-space: nowrap;
 }
 
 .preset-select ::ng-deep .p-select {
   height: 28px !important;
   min-height: 28px;
-  min-width: 130px;
+  width: 100%;
   border-radius: 8px;
   display: inline-flex;
   align-items: center;
@@ -49,12 +59,14 @@
 
 .preset-select ::ng-deep .p-select-label,
 .preset-select ::ng-deep .p-select-label.p-placeholder {
-  width: auto !important;
-  min-width: 100px;
+  width: 100% !important;
   padding: 0 0.5rem !important;
   font-size: 12px;
   line-height: 28px;
   height: 28px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .preset-select ::ng-deep .p-select-dropdown {

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.css
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.css
@@ -30,12 +30,35 @@
 .presets-row {
   display: flex;
   align-items: center;
-  gap: 8px;
+  justify-content: flex-start;
+  gap: 6px;
 }
 
 .preset-select {
-  flex: 1 1 auto;
-  min-width: 0;
+  flex: 0 0 auto;
+}
+
+.preset-select ::ng-deep .p-select {
+  height: 28px !important;
+  min-height: 28px;
+  min-width: 130px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.preset-select ::ng-deep .p-select-label,
+.preset-select ::ng-deep .p-select-label.p-placeholder {
+  width: auto !important;
+  min-width: 100px;
+  padding: 0 0.5rem !important;
+  font-size: 12px;
+  line-height: 28px;
+  height: 28px;
+}
+
+.preset-select ::ng-deep .p-select-dropdown {
+  width: 1.75rem;
 }
 
 .toggle-group {

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.css
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.css
@@ -27,6 +27,17 @@
   height: 100%;
 }
 
+.presets-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.preset-select {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 .toggle-group {
   display: inline-flex;
   align-items: center;

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.html
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.html
@@ -6,6 +6,19 @@
   </ng-template>
   <ng-template pTemplate="content">
     <div class="sidebar-content">
+      <div class="presets-row">
+        <select-dropdown
+          class="preset-select"
+          [options]="presetSelectorConfig().options"
+          [placeholder]="presetSelectorConfig().placeholder"
+          [defaultValue]="activePresetName()"
+        />
+        <argos-button
+          [onClick]="openPresetsDialog"
+          label="Manage"
+          additionalStyles="background-color: #323232; border: 1.4px solid #027bd7;"
+        />
+      </div>
       <argos-button
         [onClick]="clearSelections"
         label="Clear Topics"

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.html
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.html
@@ -16,12 +16,14 @@
         <argos-button
           [onClick]="openPresetsDialog"
           label="Manage"
+          size="sm"
           additionalStyles="background-color: #323232; border: 1.4px solid #027bd7;"
         />
       </div>
       <argos-button
         [onClick]="clearSelections"
         label="Clear Topics"
+        size="sm"
         additionalStyles="background-color: #323232; border: 1.4px solid #027bd7; width: 100%;"
       />
       <div class="toggle-group">

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.ts
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, Injector, OnInit, computed, inject, input, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
-import { MessageService, TreeNode, PrimeTemplate } from 'primeng/api';
+import { TreeNode, PrimeTemplate } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
 import { TreeNodeSelectEvent, TreeNodeUnSelectEvent, Tree } from 'primeng/tree';
 import { Sidebar } from 'primeng/sidebar';
@@ -14,7 +14,7 @@ import {
 } from 'src/components/select-dropdown/select-dropdown.component';
 import { GraphPresetService, Preset } from 'src/services/graph-preset.service';
 import Storage from 'src/services/storage.service';
-import { dataTypesToNodes, partitionDataTypesByName } from 'src/utils/dataTypes.utils';
+import { dataTypesToNodes } from 'src/utils/dataTypes.utils';
 import {
   mapNodesToTreeNodes,
   findSelectedTreeNodes,
@@ -50,7 +50,6 @@ export default class GraphSidebarMobileComponent implements OnInit {
   private topicSelectionService = inject(TopicSelectionService);
   private presetService = inject(GraphPresetService);
   private dialogService = inject(DialogService);
-  private messageService = inject(MessageService);
   private storage = inject(Storage);
   private injector = inject(Injector);
 
@@ -150,15 +149,7 @@ export default class GraphSidebarMobileComponent implements OnInit {
   }
 
   private applyPreset(preset: Preset) {
-    const { matched, unknown } = partitionDataTypesByName(this.dataTypes(), preset.topicNames);
-    if (unknown.length > 0) {
-      this.messageService.add({
-        severity: 'warn',
-        summary: 'Unknown Topics Skipped',
-        detail: unknown.join(', '),
-        life: 8000
-      });
-    }
+    const matched = this.presetService.resolvePresetTopics(preset, this.dataTypes());
     this.applyMatched(matched);
   }
 

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.ts
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.ts
@@ -1,12 +1,20 @@
 import { ChangeDetectionStrategy, Component, Injector, OnInit, computed, inject, input, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
-import { TreeNode, PrimeTemplate } from 'primeng/api';
+import { MessageService, TreeNode, PrimeTemplate } from 'primeng/api';
+import { DialogService } from 'primeng/dynamicdialog';
 import { TreeNodeSelectEvent, TreeNodeUnSelectEvent, Tree } from 'primeng/tree';
 import { Sidebar } from 'primeng/sidebar';
 import { ToggleSwitch } from 'primeng/toggleswitch';
+import { take } from 'rxjs';
+import {
+  DropdownOption,
+  SelectDropdownComponent,
+  SelectorConfig
+} from 'src/components/select-dropdown/select-dropdown.component';
+import { GraphPresetService, Preset } from 'src/services/graph-preset.service';
 import Storage from 'src/services/storage.service';
-import { dataTypesToNodes } from 'src/utils/dataTypes.utils';
+import { dataTypesToNodes, partitionDataTypesByName } from 'src/utils/dataTypes.utils';
 import {
   mapNodesToTreeNodes,
   findSelectedTreeNodes,
@@ -18,18 +26,31 @@ import { DataType } from 'src/utils/types.utils';
 import { TopicSelectionService } from 'src/services/topic-selection.service';
 import { ButtonComponent } from '../../../../components/argos-button/argos-button.component';
 import TypographyComponent from 'src/components/typography/typography.component';
+import { PresetDialogComponent } from '../../preset-dialog/preset-dialog.component';
 
 @Component({
   selector: 'graph-sidebar-mobile',
   templateUrl: './graph-sidebar-mobile.component.html',
   styleUrls: ['./graph-sidebar-mobile.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [Sidebar, PrimeTemplate, Tree, ButtonComponent, TypographyComponent, ToggleSwitch, FormsModule]
+  imports: [
+    Sidebar,
+    PrimeTemplate,
+    Tree,
+    ButtonComponent,
+    TypographyComponent,
+    ToggleSwitch,
+    FormsModule,
+    SelectDropdownComponent
+  ]
 })
 export default class GraphSidebarMobileComponent implements OnInit {
   dataTypes = input.required<DataType[]>();
 
   private topicSelectionService = inject(TopicSelectionService);
+  private presetService = inject(GraphPresetService);
+  private dialogService = inject(DialogService);
+  private messageService = inject(MessageService);
   private storage = inject(Storage);
   private injector = inject(Injector);
 
@@ -46,6 +67,18 @@ export default class GraphSidebarMobileComponent implements OnInit {
     if (this.selectedOnly()) return this.selectedFlatNodes();
     return this.flattenMode() ? this.flatNodes : this.treeNodes;
   });
+
+  private presets = toSignal(this.presetService.getPresets(), { initialValue: [] as Preset[] });
+  presetSelectorConfig = computed<SelectorConfig>(() => ({
+    placeholder: 'Apply Preset…',
+    options: this.presets().map(
+      (p): DropdownOption => ({
+        name: p.name,
+        function: () => this.applyPreset(p)
+      })
+    )
+  }));
+  activePresetName = toSignal(this.presetService.getActivePresetName(), { initialValue: undefined });
 
   ngOnInit(): void {
     const nodes = dataTypesToNodes(this.dataTypes());
@@ -76,6 +109,24 @@ export default class GraphSidebarMobileComponent implements OnInit {
     this.selectedNodes = undefined;
   };
 
+  openPresetsDialog = () => {
+    const ref = this.dialogService.open(PresetDialogComponent, {
+      header: 'Topic Presets',
+      width: '90vw',
+      draggable: true,
+      closable: true,
+      closeAriaLabel: 'Close',
+      data: {
+        dataTypes: this.dataTypes()
+      }
+    });
+    ref.onClose.pipe(take(1)).subscribe((matched: DataType[] | null) => {
+      if (matched) {
+        this.applyMatched(matched);
+      }
+    });
+  };
+
   nodeSelect(event: TreeNodeSelectEvent) {
     const dt = event.node.data?.dataType;
     if (dt) {
@@ -96,5 +147,23 @@ export default class GraphSidebarMobileComponent implements OnInit {
     if (dt) {
       this.topicSelectionService.removeDataType(dt);
     }
+  }
+
+  private applyPreset(preset: Preset) {
+    const { matched, unknown } = partitionDataTypesByName(this.dataTypes(), preset.topicNames);
+    if (unknown.length > 0) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Unknown Topics Skipped',
+        detail: unknown.join(', '),
+        life: 8000
+      });
+    }
+    this.applyMatched(matched);
+  }
+
+  private applyMatched(matched: DataType[]) {
+    this.topicSelectionService.setSelectedDataTypes(matched);
+    this.selectedNodes = findSelectedTreeNodes(this.activeNodes(), this.topicSelectionService);
   }
 }

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.ts
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.ts
@@ -1,8 +1,18 @@
-import { ChangeDetectionStrategy, Component, Injector, OnInit, computed, inject, input, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Injector,
+  OnDestroy,
+  OnInit,
+  computed,
+  inject,
+  input,
+  signal
+} from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { TreeNode, PrimeTemplate } from 'primeng/api';
-import { DialogService } from 'primeng/dynamicdialog';
+import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { TreeNodeSelectEvent, TreeNodeUnSelectEvent, Tree } from 'primeng/tree';
 import { Sidebar } from 'primeng/sidebar';
 import { ToggleSwitch } from 'primeng/toggleswitch';
@@ -44,7 +54,7 @@ import { PresetDialogComponent } from '../../preset-dialog/preset-dialog.compone
     SelectDropdownComponent
   ]
 })
-export default class GraphSidebarMobileComponent implements OnInit {
+export default class GraphSidebarMobileComponent implements OnInit, OnDestroy {
   dataTypes = input.required<DataType[]>();
 
   private topicSelectionService = inject(TopicSelectionService);
@@ -52,6 +62,7 @@ export default class GraphSidebarMobileComponent implements OnInit {
   private dialogService = inject(DialogService);
   private storage = inject(Storage);
   private injector = inject(Injector);
+  private presetDialogRef?: DynamicDialogRef;
 
   sidebarVisible = false;
   treeNodes: TreeNode<TreeNodeData>[] = [];
@@ -109,7 +120,7 @@ export default class GraphSidebarMobileComponent implements OnInit {
   };
 
   openPresetsDialog = () => {
-    const ref = this.dialogService.open(PresetDialogComponent, {
+    this.presetDialogRef = this.dialogService.open(PresetDialogComponent, {
       header: 'Topic Presets',
       width: '90vw',
       draggable: true,
@@ -119,12 +130,18 @@ export default class GraphSidebarMobileComponent implements OnInit {
         dataTypes: this.dataTypes()
       }
     });
-    ref.onClose.pipe(take(1)).subscribe((matched: DataType[] | null) => {
+    this.presetDialogRef.onClose.pipe(take(1)).subscribe((matched: DataType[] | null) => {
       if (matched) {
         this.applyMatched(matched);
       }
     });
   };
+
+  ngOnDestroy(): void {
+    if (this.presetDialogRef) {
+      this.presetDialogRef.close();
+    }
+  }
 
   nodeSelect(event: TreeNodeSelectEvent) {
     const dt = event.node.data?.dataType;

--- a/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.ts
+++ b/angular-client/src/pages/graph-page/graph-sidebar/graph-sidebar-mobile/graph-sidebar-mobile.component.ts
@@ -154,6 +154,7 @@ export default class GraphSidebarMobileComponent implements OnInit {
   }
 
   private applyMatched(matched: DataType[]) {
+    if (matched.length === 0) return; // unknown topics warn toast
     this.topicSelectionService.setSelectedDataTypes(matched);
     this.selectedNodes = findSelectedTreeNodes(this.activeNodes(), this.topicSelectionService);
   }

--- a/angular-client/src/pages/graph-page/preset-dialog/preset-dialog.component.css
+++ b/angular-client/src/pages/graph-page/preset-dialog/preset-dialog.component.css
@@ -70,6 +70,7 @@
 
 .preset-table {
   width: 100%;
+  table-layout: fixed;
   border-collapse: collapse;
   color: #eee;
 }
@@ -96,12 +97,19 @@
 .preset-table td.actions,
 .preset-table th.actions {
   text-align: right;
-  width: 1%;
+  width: 16rem;
   white-space: nowrap;
 }
 
 .preset-table td.actions button {
   margin-left: 6px;
+}
+
+.preset-table .name-text {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .footer {

--- a/angular-client/src/pages/graph-page/preset-dialog/preset-dialog.component.css
+++ b/angular-client/src/pages/graph-page/preset-dialog/preset-dialog.component.css
@@ -1,0 +1,112 @@
+.dialog-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.hidden-file-input {
+  display: none;
+}
+
+.save-section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.actions-row {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.save-form {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1 1 280px;
+}
+
+.save-form label {
+  color: #ccc;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.save-form-controls {
+  display: flex;
+  gap: 8px;
+}
+
+.save-form-controls input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.hint {
+  color: #888;
+  font-size: 0.8rem;
+}
+
+.presets-list {
+  border-top: 1px solid #2a2a2a;
+  padding-top: 12px;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 24px 12px;
+  border: 1px dashed #444;
+  border-radius: 6px;
+  color: #aaa;
+}
+
+.empty-state p {
+  margin: 0 0 4px;
+  color: #ddd;
+}
+
+.preset-table {
+  width: 100%;
+  border-collapse: collapse;
+  color: #eee;
+}
+
+.preset-table th,
+.preset-table td {
+  text-align: left;
+  padding: 8px;
+  border-bottom: 1px solid #2a2a2a;
+  font-size: 0.9rem;
+}
+
+.preset-table th {
+  color: #aaa;
+  font-weight: 600;
+}
+
+.preset-table td.topic-count,
+.preset-table th.topic-count {
+  text-align: right;
+  width: 70px;
+}
+
+.preset-table td.actions,
+.preset-table th.actions {
+  text-align: right;
+  width: 1%;
+  white-space: nowrap;
+}
+
+.preset-table td.actions button {
+  margin-left: 6px;
+}
+
+.footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 4px;
+}

--- a/angular-client/src/pages/graph-page/preset-dialog/preset-dialog.component.html
+++ b/angular-client/src/pages/graph-page/preset-dialog/preset-dialog.component.html
@@ -83,14 +83,7 @@
   </section>
 
   <div class="footer">
-    <button
-      pButton
-      type="button"
-      label="Restore defaults"
-      class="p-button-text"
-      title="Re-add any default preset whose name isn't currently in your list"
-      (click)="onRestoreDefaults()"
-    ></button>
+    <button pButton type="button" label="Add Default Presets" class="p-button-text" (click)="onAddDefaultPresets()"></button>
     <button pButton type="button" label="Close" class="p-button-text" (click)="onClose()"></button>
   </div>
 

--- a/angular-client/src/pages/graph-page/preset-dialog/preset-dialog.component.html
+++ b/angular-client/src/pages/graph-page/preset-dialog/preset-dialog.component.html
@@ -1,0 +1,98 @@
+<div class="dialog-content">
+  <input
+    #fileInput
+    type="file"
+    accept=".json,application/json"
+    class="hidden-file-input"
+    (change)="onFileSelected($event)"
+    aria-hidden="true"
+  />
+
+  <section class="save-section">
+    <div class="actions-row">
+      <div class="save-form">
+        <label for="preset-name">Save current selection</label>
+        <div class="save-form-controls">
+          <input
+            id="preset-name"
+            pInputText
+            [ngModel]="newPresetName()"
+            (ngModelChange)="newPresetName.set($event)"
+            placeholder="Preset name…"
+            (keyup.enter)="onSaveCurrent()"
+          />
+          <button
+            pButton
+            type="button"
+            label="Save"
+            (click)="onSaveCurrent()"
+            [disabled]="!hasSelection() || newPresetName().trim().length === 0"
+          ></button>
+        </div>
+      </div>
+
+      <button pButton type="button" label="Upload JSON" class="p-button-outlined" (click)="onUploadClick()"></button>
+    </div>
+    @if (!hasSelection()) {
+      <small class="hint">Select a topic to save a preset</small>
+    }
+  </section>
+
+  <section class="presets-list">
+    @if (presets().length === 0) {
+      <div class="empty-state">
+        <p>No presets yet</p>
+        <small>
+          Save your current topic selection or upload a JSON of your preset
+        </small>
+      </div>
+    } @else {
+      <table class="preset-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th class="topic-count">Topics</th>
+            <th class="actions">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (preset of presets(); track preset.id) {
+            <tr>
+              <td>{{ preset.name }}</td>
+              <td class="topic-count">{{ preset.topicNames.length }}</td>
+              <td class="actions">
+                <button pButton type="button" label="Apply" (click)="onApply(preset)"></button>
+                <button
+                  pButton
+                  type="button"
+                  label="Download"
+                  class="p-button-outlined"
+                  (click)="onDownload(preset)"
+                ></button>
+                <button
+                  pButton
+                  type="button"
+                  label="Delete"
+                  class="p-button-text p-button-danger"
+                  (click)="onDelete(preset)"
+                ></button>
+              </td>
+            </tr>
+          }
+        </tbody>
+      </table>
+    }
+  </section>
+
+  <div class="footer">
+    <button
+      pButton
+      type="button"
+      label="Restore defaults"
+      class="p-button-text"
+      title="Re-add any default preset whose name isn't currently in your list"
+      (click)="onRestoreDefaults()"
+    ></button>
+    <button pButton type="button" label="Close" class="p-button-text" (click)="onClose()"></button>
+  </div>
+</div>

--- a/angular-client/src/pages/graph-page/preset-dialog/preset-dialog.component.html
+++ b/angular-client/src/pages/graph-page/preset-dialog/preset-dialog.component.html
@@ -93,4 +93,6 @@
     ></button>
     <button pButton type="button" label="Close" class="p-button-text" (click)="onClose()"></button>
   </div>
+
+  <p-confirmDialog />
 </div>

--- a/angular-client/src/pages/graph-page/preset-dialog/preset-dialog.component.html
+++ b/angular-client/src/pages/graph-page/preset-dialog/preset-dialog.component.html
@@ -48,7 +48,7 @@
       <table class="preset-table">
         <thead>
           <tr>
-            <th>Name</th>
+            <th class="name">Name</th>
             <th class="topic-count">Topics</th>
             <th class="actions">Actions</th>
           </tr>
@@ -56,7 +56,9 @@
         <tbody>
           @for (preset of presets(); track preset.id) {
             <tr>
-              <td>{{ preset.name }}</td>
+              <td class="name" [title]="preset.name">
+                <span class="name-text">{{ preset.name }}</span>
+              </td>
               <td class="topic-count">{{ preset.topicNames.length }}</td>
               <td class="actions">
                 <button pButton type="button" label="Apply" (click)="onApply(preset)"></button>

--- a/angular-client/src/pages/graph-page/preset-dialog/preset-dialog.component.html
+++ b/angular-client/src/pages/graph-page/preset-dialog/preset-dialog.component.html
@@ -42,9 +42,7 @@
     @if (presets().length === 0) {
       <div class="empty-state">
         <p>No presets yet</p>
-        <small>
-          Save your current topic selection or upload a JSON of your preset
-        </small>
+        <small> Save your current topic selection or upload a JSON of your preset </small>
       </div>
     } @else {
       <table class="preset-table">

--- a/angular-client/src/pages/graph-page/preset-dialog/preset-dialog.component.ts
+++ b/angular-client/src/pages/graph-page/preset-dialog/preset-dialog.component.ts
@@ -1,0 +1,207 @@
+import { ChangeDetectionStrategy, Component, ElementRef, computed, inject, signal, viewChild } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { MessageService } from 'primeng/api';
+import { ButtonDirective } from 'primeng/button';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { InputText } from 'primeng/inputtext';
+import { GraphPresetService, Preset, PresetSeed } from 'src/services/graph-preset.service';
+import { TopicSelectionService } from 'src/services/topic-selection.service';
+import { partitionDataTypesByName } from 'src/utils/dataTypes.utils';
+import { DataType } from 'src/utils/types.utils';
+
+interface PresetDialogData {
+  dataTypes: DataType[];
+}
+
+@Component({
+  selector: 'preset-dialog',
+  templateUrl: './preset-dialog.component.html',
+  styleUrls: ['./preset-dialog.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule, InputText, ButtonDirective]
+})
+export class PresetDialogComponent {
+  private ref = inject(DynamicDialogRef);
+  private config = inject(DynamicDialogConfig);
+  private presetService = inject(GraphPresetService);
+  private topicSelectionService = inject(TopicSelectionService);
+  private messageService = inject(MessageService);
+
+  private data = this.config.data as PresetDialogData;
+  private dataTypes = this.data.dataTypes;
+  private currentSelection = toSignal(this.topicSelectionService.getSelectedDataTypes(), {
+    initialValue: [] as DataType[]
+  });
+
+  presets = toSignal(this.presetService.getPresets(), { initialValue: [] as Preset[] });
+  newPresetName = signal('');
+  hasSelection = computed(() => this.currentSelection().length > 0);
+  fileInput = viewChild<ElementRef<HTMLInputElement>>('fileInput');
+
+  onSaveCurrent(): void {
+    const name = this.newPresetName().trim();
+    if (name.length === 0 || !this.hasSelection()) return;
+
+    const topicNames = this.currentSelection().map((dt) => dt.name);
+    const existing = this.presetService.findByName(name);
+    if (existing) {
+      if (!confirm(`A preset named "${name}" already exists. Replace its topics?`)) return;
+      this.presetService.replacePreset(existing.id, { topicNames });
+      this.messageService.add({
+        severity: 'success',
+        summary: 'Preset Replaced',
+        detail: `"${name}" now contains ${topicNames.length} topic(s)`
+      });
+    } else {
+      this.presetService.addPreset(name, topicNames);
+      this.messageService.add({
+        severity: 'success',
+        summary: 'Preset Saved',
+        detail: `"${name}" with ${topicNames.length} topic(s)`
+      });
+    }
+    this.newPresetName.set('');
+  }
+
+  onUploadClick(): void {
+    this.fileInput()?.nativeElement.click();
+  }
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+
+    input.value = '';
+
+    if (!file.name.toLowerCase().endsWith('.json')) {
+      this.messageService.add({ severity: 'error', summary: 'Invalid File', detail: 'Please select a .json file' });
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const text = reader.result as string;
+      const parsed = this.parsePresetJson(text);
+      if (!parsed) return;
+
+      const fallbackName = file.name.replace(/\.json$/i, '').trim() || 'Untitled Preset';
+      const name = parsed.name?.trim() || fallbackName;
+
+      const existing = this.presetService.findByName(name);
+      if (existing) {
+        if (!confirm(`A preset named "${name}" already exists. Replace its topics?`)) return;
+        this.presetService.replacePreset(existing.id, { topicNames: parsed.topicNames });
+      } else {
+        this.presetService.addPreset(name, parsed.topicNames);
+      }
+      this.messageService.add({
+        severity: 'success',
+        summary: 'Preset Imported',
+        detail: `"${name}" with ${parsed.topicNames.length} topic(s)`
+      });
+    };
+    reader.onerror = () => {
+      this.messageService.add({ severity: 'error', summary: 'Read Error', detail: 'Failed to read file' });
+    };
+    reader.readAsText(file);
+  }
+
+  onApply(preset: Preset): void {
+    const { matched, unknown } = partitionDataTypesByName(this.dataTypes, preset.topicNames);
+    if (unknown.length > 0) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Unknown Topics Skipped',
+        detail: unknown.join(', '),
+        life: 8000
+      });
+    }
+    this.ref.close(matched);
+  }
+
+  onDownload(preset: Preset): void {
+    const exported: PresetSeed = { name: preset.name, topicNames: [...preset.topicNames] };
+    const blob = new Blob([JSON.stringify(exported, null, 2)], { type: 'application/json;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `${this.sanitizeFilename(preset.name)}.json`;
+    link.click();
+
+    URL.revokeObjectURL(url);
+  }
+
+  onDelete(preset: Preset): void {
+    if (!confirm(`Delete preset "${preset.name}"?`)) return;
+    this.presetService.deletePreset(preset.id);
+    this.messageService.add({ severity: 'success', summary: 'Preset Deleted', detail: preset.name });
+  }
+
+  onRestoreDefaults(): void {
+    const added = this.presetService.restoreDefaults();
+    if (added === 0) {
+      this.messageService.add({
+        severity: 'info',
+        summary: 'Defaults Already Present',
+        detail: 'All default presets are already in your list.'
+      });
+    } else {
+      this.messageService.add({
+        severity: 'success',
+        summary: 'Defaults Restored',
+        detail: `Added ${added} default preset${added === 1 ? '' : 's'}.`
+      });
+    }
+  }
+
+  onClose(): void {
+    this.ref.close(null);
+  }
+
+  private parsePresetJson(text: string): { name?: string; topicNames: string[] } | null {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      this.messageService.add({ severity: 'error', summary: 'Parse Error', detail: 'File is not valid JSON' });
+      return null;
+    }
+
+    if (Array.isArray(parsed)) {
+      const topics = parsed.filter((n): n is string => typeof n === 'string' && n.length > 0);
+      if (topics.length === 0) {
+        this.messageService.add({ severity: 'error', summary: 'Parse Error', detail: 'No topic names found' });
+        return null;
+      }
+      return { topicNames: Array.from(new Set(topics)) };
+    }
+
+    if (typeof parsed === 'object' && parsed !== null) {
+      const { name, topicNames } = parsed as Record<string, unknown>;
+      if (
+        Array.isArray(topicNames) &&
+        topicNames.every((n): n is string => typeof n === 'string') &&
+        topicNames.length > 0
+      ) {
+        return {
+          name: typeof name === 'string' ? name : undefined,
+          topicNames: Array.from(new Set(topicNames.filter((n) => n.length > 0)))
+        };
+      }
+    }
+
+    this.messageService.add({
+      severity: 'error',
+      summary: 'Parse Error',
+      detail: 'Expected an object with a "topicNames" string array, or a bare array of topic names'
+    });
+    return null;
+  }
+
+  private sanitizeFilename(name: string): string {
+    return name.replace(/[\\/:*?"<>|]/g, '_').trim() || 'preset';
+  }
+}

--- a/angular-client/src/pages/graph-page/preset-dialog/preset-dialog.component.ts
+++ b/angular-client/src/pages/graph-page/preset-dialog/preset-dialog.component.ts
@@ -1,13 +1,14 @@
 import { ChangeDetectionStrategy, Component, ElementRef, computed, inject, signal, viewChild } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
-import { MessageService } from 'primeng/api';
+import { ConfirmationService, MessageService } from 'primeng/api';
 import { ButtonDirective } from 'primeng/button';
+import { ConfirmDialog } from 'primeng/confirmdialog';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { InputText } from 'primeng/inputtext';
 import { GraphPresetService, Preset, PresetSeed } from 'src/services/graph-preset.service';
 import { TopicSelectionService } from 'src/services/topic-selection.service';
-import { partitionDataTypesByName } from 'src/utils/dataTypes.utils';
+import { downloadAsFile, FileReadError, readTextFile } from 'src/utils/file.utils';
 import { DataType } from 'src/utils/types.utils';
 
 interface PresetDialogData {
@@ -19,7 +20,8 @@ interface PresetDialogData {
   templateUrl: './preset-dialog.component.html',
   styleUrls: ['./preset-dialog.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [FormsModule, InputText, ButtonDirective]
+  providers: [ConfirmationService],
+  imports: [FormsModule, InputText, ButtonDirective, ConfirmDialog]
 })
 export class PresetDialogComponent {
   private ref = inject(DynamicDialogRef);
@@ -27,6 +29,7 @@ export class PresetDialogComponent {
   private presetService = inject(GraphPresetService);
   private topicSelectionService = inject(TopicSelectionService);
   private messageService = inject(MessageService);
+  private confirmationService = inject(ConfirmationService);
 
   private data = this.config.data as PresetDialogData;
   private dataTypes = this.data.dataTypes;
@@ -46,12 +49,14 @@ export class PresetDialogComponent {
     const topicNames = this.currentSelection().map((dt) => dt.name);
     const existing = this.presetService.findByName(name);
     if (existing) {
-      if (!confirm(`A preset named "${name}" already exists. Replace its topics?`)) return;
-      this.presetService.replacePreset(existing.id, { topicNames });
-      this.messageService.add({
-        severity: 'success',
-        summary: 'Preset Replaced',
-        detail: `"${name}" now contains ${topicNames.length} topic(s)`
+      this.confirmReplace(name, () => {
+        this.presetService.replacePreset(existing.id, { topicNames });
+        this.messageService.add({
+          severity: 'success',
+          summary: 'Preset Replaced',
+          detail: `"${name}" now contains ${topicNames.length} topic(s)`
+        });
+        this.newPresetName.set('');
       });
     } else {
       this.presetService.addPreset(name, topicNames);
@@ -60,84 +65,94 @@ export class PresetDialogComponent {
         summary: 'Preset Saved',
         detail: `"${name}" with ${topicNames.length} topic(s)`
       });
+      this.newPresetName.set('');
     }
-    this.newPresetName.set('');
   }
 
   onUploadClick(): void {
     this.fileInput()?.nativeElement.click();
   }
 
-  onFileSelected(event: Event): void {
+  async onFileSelected(event: Event): Promise<void> {
     const input = event.target as HTMLInputElement;
     const file = input.files?.[0];
     if (!file) return;
 
     input.value = '';
 
-    if (!file.name.toLowerCase().endsWith('.json')) {
-      this.messageService.add({ severity: 'error', summary: 'Invalid File', detail: 'Please select a .json file' });
+    let text: string;
+    try {
+      text = await readTextFile(file, '.json');
+    } catch (err) {
+      if (err instanceof FileReadError && err.kind === 'invalid-extension') {
+        this.messageService.add({ severity: 'error', summary: 'Invalid File', detail: 'Please select a .json file' });
+      } else {
+        this.messageService.add({ severity: 'error', summary: 'Read Error', detail: 'Failed to read file' });
+      }
       return;
     }
 
-    const reader = new FileReader();
-    reader.onload = () => {
-      const text = reader.result as string;
-      const parsed = this.parsePresetJson(text);
-      if (!parsed) return;
+    const parsed = this.parsePresetJson(text);
+    if (!parsed) return;
 
-      const fallbackName = file.name.replace(/\.json$/i, '').trim() || 'Untitled Preset';
-      const name = parsed.name?.trim() || fallbackName;
+    const fallbackName = file.name.replace(/\.json$/i, '').trim() || 'Untitled Preset';
+    const name = parsed.name?.trim() || fallbackName;
 
-      const existing = this.presetService.findByName(name);
-      if (existing) {
-        if (!confirm(`A preset named "${name}" already exists. Replace its topics?`)) return;
+    const existing = this.presetService.findByName(name);
+    if (existing) {
+      this.confirmReplace(name, () => {
         this.presetService.replacePreset(existing.id, { topicNames: parsed.topicNames });
-      } else {
-        this.presetService.addPreset(name, parsed.topicNames);
-      }
-      this.messageService.add({
-        severity: 'success',
-        summary: 'Preset Imported',
-        detail: `"${name}" with ${parsed.topicNames.length} topic(s)`
+        this.toastImported(name, parsed.topicNames.length);
       });
-    };
-    reader.onerror = () => {
-      this.messageService.add({ severity: 'error', summary: 'Read Error', detail: 'Failed to read file' });
-    };
-    reader.readAsText(file);
+    } else {
+      this.presetService.addPreset(name, parsed.topicNames);
+      this.toastImported(name, parsed.topicNames.length);
+    }
   }
 
   onApply(preset: Preset): void {
-    const { matched, unknown } = partitionDataTypesByName(this.dataTypes, preset.topicNames);
-    if (unknown.length > 0) {
-      this.messageService.add({
-        severity: 'warn',
-        summary: 'Unknown Topics Skipped',
-        detail: unknown.join(', '),
-        life: 8000
-      });
-    }
+    const matched = this.presetService.resolvePresetTopics(preset, this.dataTypes);
     this.ref.close(matched);
   }
 
   onDownload(preset: Preset): void {
     const exported: PresetSeed = { name: preset.name, topicNames: [...preset.topicNames] };
-    const blob = new Blob([JSON.stringify(exported, null, 2)], { type: 'application/json;charset=utf-8;' });
-    const url = URL.createObjectURL(blob);
-
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `${this.sanitizeFilename(preset.name)}.json`;
-    link.click();
-
-    URL.revokeObjectURL(url);
+    downloadAsFile(
+      `${this.sanitizeFilename(preset.name)}.json`,
+      JSON.stringify(exported, null, 2),
+      'application/json;charset=utf-8;'
+    );
   }
 
   onDelete(preset: Preset): void {
-    if (!confirm(`Delete preset "${preset.name}"?`)) return;
-    this.presetService.deletePreset(preset.id);
-    this.messageService.add({ severity: 'success', summary: 'Preset Deleted', detail: preset.name });
+    this.confirmationService.confirm({
+      message: `Delete preset "${preset.name}"?`,
+      header: 'Delete Preset',
+      acceptLabel: 'Delete',
+      rejectLabel: 'Cancel',
+      accept: () => {
+        this.presetService.deletePreset(preset.id);
+        this.messageService.add({ severity: 'success', summary: 'Preset Deleted', detail: preset.name });
+      }
+    });
+  }
+
+  private confirmReplace(name: string, onAccept: () => void): void {
+    this.confirmationService.confirm({
+      message: `A preset named "${name}" already exists. Replace its topics?`,
+      header: 'Replace Preset',
+      acceptLabel: 'Replace',
+      rejectLabel: 'Cancel',
+      accept: onAccept
+    });
+  }
+
+  private toastImported(name: string, count: number): void {
+    this.messageService.add({
+      severity: 'success',
+      summary: 'Preset Imported',
+      detail: `"${name}" with ${count} topic(s)`
+    });
   }
 
   onRestoreDefaults(): void {

--- a/angular-client/src/pages/graph-page/preset-dialog/preset-dialog.component.ts
+++ b/angular-client/src/pages/graph-page/preset-dialog/preset-dialog.component.ts
@@ -155,8 +155,8 @@ export class PresetDialogComponent {
     });
   }
 
-  onRestoreDefaults(): void {
-    const added = this.presetService.restoreDefaults();
+  onAddDefaultPresets(): void {
+    const added = this.presetService.addDefaultPresets();
     if (added === 0) {
       this.messageService.add({
         severity: 'info',
@@ -166,7 +166,7 @@ export class PresetDialogComponent {
     } else {
       this.messageService.add({
         severity: 'success',
-        summary: 'Defaults Restored',
+        summary: 'Defaults Added',
         detail: `Added ${added} default preset${added === 1 ? '' : 's'}.`
       });
     }

--- a/angular-client/src/pages/notification-rules-page/notification-rules-page.component.ts
+++ b/angular-client/src/pages/notification-rules-page/notification-rules-page.component.ts
@@ -21,6 +21,7 @@ import { UploadConfirmDialogComponent } from './upload-confirm-dialog/upload-con
 import { AddRuleDialogComponent } from './add-rule-dialog/add-rule-dialog.component';
 import { RulesTableComponent } from './rules-table/rules-table.component';
 import { NotificationListComponent } from 'src/components/notification-list/notification-list.component';
+import { downloadAsFile, FileReadError, readTextFile } from 'src/utils/file.utils';
 
 const CLIENT_ID_KEY = 'notification_rules_client_id';
 
@@ -179,7 +180,7 @@ export default class NotificationRulesPageComponent implements OnInit {
     this.streamRailOpen.update((open) => !open);
   };
 
-  onFileSelected(event: Event): void {
+  async onFileSelected(event: Event): Promise<void> {
     const input = event.target as HTMLInputElement;
     const file = input.files?.[0];
     if (!file) return;
@@ -187,20 +188,16 @@ export default class NotificationRulesPageComponent implements OnInit {
     // Reset input so same file can be re-selected
     input.value = '';
 
-    if (!file.name.endsWith('.csv')) {
-      this.messageService.add({ severity: 'error', summary: 'Invalid File', detail: 'Please select a .csv file' });
-      return;
-    }
-
-    const reader = new FileReader();
-    reader.onload = () => {
-      const text = reader.result as string;
+    try {
+      const text = await readTextFile(file, '.csv');
       this.parseCsvAndConfirm(text);
-    };
-    reader.onerror = () => {
-      this.messageService.add({ severity: 'error', summary: 'Read Error', detail: 'Failed to read file' });
-    };
-    reader.readAsText(file);
+    } catch (err) {
+      if (err instanceof FileReadError && err.kind === 'invalid-extension') {
+        this.messageService.add({ severity: 'error', summary: 'Invalid File', detail: 'Please select a .csv file' });
+      } else {
+        this.messageService.add({ severity: 'error', summary: 'Read Error', detail: 'Failed to read file' });
+      }
+    }
   }
 
   private parseCsvAndConfirm(csv: string): void {
@@ -397,15 +394,11 @@ export default class NotificationRulesPageComponent implements OnInit {
       );
 
       const csvContent = [header, ...rows].join('\n');
-      const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-      const url = URL.createObjectURL(blob);
-
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = `notification-rules-${new Date().toISOString().slice(0, 10)}.csv`;
-      link.click();
-
-      URL.revokeObjectURL(url);
+      downloadAsFile(
+        `notification-rules-${new Date().toISOString().slice(0, 10)}.csv`,
+        csvContent,
+        'text/csv;charset=utf-8;'
+      );
       this.messageService.add({ severity: 'success', summary: 'Downloaded', detail: `Exported ${rules.length} rule(s)` });
     } catch {
       this.messageService.add({ severity: 'error', summary: 'Download Error', detail: 'Failed to download rules' });

--- a/angular-client/src/services/graph-preset.service.spec.ts
+++ b/angular-client/src/services/graph-preset.service.spec.ts
@@ -132,13 +132,13 @@ describe('GraphPresetService', () => {
     expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual([]);
   });
 
-  it('restoreDefaults adds only seed entries whose names are missing', () => {
+  it('addDefaultPresets adds only seed entries whose names are missing', () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
     const service = build();
     const [firstSeed] = PRESET_SEEDS;
     service.addPreset(firstSeed.name, ['existing-topic']);
 
-    const added = service.restoreDefaults();
+    const added = service.addDefaultPresets();
 
     expect(added).toBe(PRESET_SEEDS.length - 1);
     const namesNow = service.getPresets().value.map((p) => p.name);
@@ -147,12 +147,12 @@ describe('GraphPresetService', () => {
     expect(kept!.topicNames).toEqual(['existing-topic']);
   });
 
-  it('restoreDefaults assigns fresh ids and createdAt to new seeded entries', () => {
+  it('addDefaultPresets assigns fresh ids and createdAt to new seeded entries', () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
     const service = build();
 
     const before = Date.now();
-    service.restoreDefaults();
+    service.addDefaultPresets();
     const after = Date.now();
 
     const presets = service.getPresets().value;
@@ -164,12 +164,12 @@ describe('GraphPresetService', () => {
     });
   });
 
-  it('restoreDefaults returns 0 when all defaults are already present', () => {
+  it('addDefaultPresets returns 0 when all defaults are already present', () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
     const service = build();
-    service.restoreDefaults();
+    service.addDefaultPresets();
 
-    const added = service.restoreDefaults();
+    const added = service.addDefaultPresets();
 
     expect(added).toBe(0);
   });

--- a/angular-client/src/services/graph-preset.service.spec.ts
+++ b/angular-client/src/services/graph-preset.service.spec.ts
@@ -23,38 +23,44 @@ describe('GraphPresetService', () => {
     return TestBed.inject(GraphPresetService);
   }
 
-  it('seeds defaults when localStorage has never been written', () => {
+  it('seeds defaults when localStorage has never been written', (done) => {
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
 
     const service = build();
 
-    const presets = service.getPresets().value;
-    expect(presets.map((p) => p.name)).toEqual(PRESET_SEEDS.map((s) => s.name));
-    expect(presets.every((p) => p.id.length > 0)).toBe(true);
-    expect(presets.every((p) => p.createdAt > 0)).toBe(true);
-
-    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
-    expect(stored).toEqual(presets);
+    service.getPresets().subscribe((presets) => {
+      expect(presets.map((p) => p.name)).toEqual(PRESET_SEEDS.map((s) => s.name));
+      expect(presets.every((p) => p.id.length > 0)).toBe(true);
+      expect(presets.every((p) => p.createdAt > 0)).toBe(true);
+      expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual(presets);
+      done();
+    });
   });
 
-  it('does not seed when localStorage holds an empty array', () => {
+  it('does not seed when localStorage holds an empty array', (done) => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
 
     const service = build();
 
-    expect(service.getPresets().value).toEqual([]);
+    service.getPresets().subscribe((presets) => {
+      expect(presets).toEqual([]);
+      done();
+    });
   });
 
-  it('does not seed when localStorage already has user presets', () => {
+  it('does not seed when localStorage already has user presets', (done) => {
     const stored = makeStoredPreset({ id: 'user-1', name: 'My Preset' });
     localStorage.setItem(STORAGE_KEY, JSON.stringify([stored]));
 
     const service = build();
 
-    expect(service.getPresets().value).toEqual([stored]);
+    service.getPresets().subscribe((presets) => {
+      expect(presets).toEqual([stored]);
+      done();
+    });
   });
 
-  it('addPreset appends a preset and persists it', () => {
+  it('addPreset appends a preset and persists it', (done) => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
     const service = build();
 
@@ -63,10 +69,12 @@ describe('GraphPresetService', () => {
     expect(preset.name).toBe('Vitals');
     expect(preset.topicNames).toEqual(['BMS/Pack/SOC', 'MPU/State/Speed']);
     expect(preset.id).toBeTruthy();
-    expect(service.getPresets().value).toEqual([preset]);
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual([preset]);
 
-    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
-    expect(stored).toEqual([preset]);
+    service.getPresets().subscribe((presets) => {
+      expect(presets).toEqual([preset]);
+      done();
+    });
   });
 
   it('addPreset trims whitespace from the name', () => {
@@ -85,21 +93,23 @@ describe('GraphPresetService', () => {
     expect(() => service.addPreset('   ', ['A'])).toThrowError(/empty/i);
   });
 
-  it('replacePreset updates fields without changing id or createdAt', () => {
+  it('replacePreset updates fields without changing id or createdAt', (done) => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
     const service = build();
     const original = service.addPreset('Vitals', ['A']);
 
     service.replacePreset(original.id, { name: 'Vitals v2', topicNames: ['A', 'B'] });
 
-    const [updated] = service.getPresets().value;
-    expect(updated.id).toBe(original.id);
-    expect(updated.createdAt).toBe(original.createdAt);
-    expect(updated.name).toBe('Vitals v2');
-    expect(updated.topicNames).toEqual(['A', 'B']);
+    service.getPresets().subscribe(([updated]) => {
+      expect(updated.id).toBe(original.id);
+      expect(updated.createdAt).toBe(original.createdAt);
+      expect(updated.name).toBe('Vitals v2');
+      expect(updated.topicNames).toEqual(['A', 'B']);
+      done();
+    });
   });
 
-  it('deletePreset removes the entry by id', () => {
+  it('deletePreset removes the entry by id', (done) => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
     const service = build();
     const a = service.addPreset('A', ['x']);
@@ -107,8 +117,11 @@ describe('GraphPresetService', () => {
 
     service.deletePreset(a.id);
 
-    expect(service.getPresets().value).toEqual([b]);
     expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual([b]);
+    service.getPresets().subscribe((presets) => {
+      expect(presets).toEqual([b]);
+      done();
+    });
   });
 
   it('findByName matches case-sensitively', () => {
@@ -120,7 +133,7 @@ describe('GraphPresetService', () => {
     expect(service.findByName('vitals')).toBeUndefined();
   });
 
-  it('clearAll empties the list and writes [] to localStorage', () => {
+  it('clearAll empties the list and writes [] to localStorage', (done) => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
     const service = build();
     service.addPreset('A', ['x']);
@@ -128,39 +141,62 @@ describe('GraphPresetService', () => {
 
     service.clearAll();
 
-    expect(service.getPresets().value).toEqual([]);
     expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual([]);
+    service.getPresets().subscribe((presets) => {
+      expect(presets).toEqual([]);
+      done();
+    });
   });
 
-  it('addDefaultPresets adds only seed entries whose names are missing', () => {
+  it('addDefaultPresets adds only seed entries whose names are missing', (done) => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
     const service = build();
+
+    // No defaults shipped yet — addDefaultPresets is a no-op.
+    if (PRESET_SEEDS.length === 0) {
+      expect(service.addDefaultPresets()).toBe(0);
+      done();
+      return;
+    }
+
     const [firstSeed] = PRESET_SEEDS;
     service.addPreset(firstSeed.name, ['existing-topic']);
 
     const added = service.addDefaultPresets();
-
     expect(added).toBe(PRESET_SEEDS.length - 1);
-    const namesNow = service.getPresets().value.map((p) => p.name);
-    expect(namesNow).toEqual(jasmine.arrayWithExactContents(PRESET_SEEDS.map((s) => s.name)));
+
     const kept = service.findByName(firstSeed.name);
     expect(kept!.topicNames).toEqual(['existing-topic']);
+
+    service.getPresets().subscribe((presets) => {
+      expect(presets.map((p) => p.name)).toEqual(jasmine.arrayWithExactContents(PRESET_SEEDS.map((s) => s.name)));
+      done();
+    });
   });
 
-  it('addDefaultPresets assigns fresh ids and createdAt to new seeded entries', () => {
+  it('addDefaultPresets assigns fresh ids and createdAt to new seeded entries', (done) => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
     const service = build();
+
+    // No defaults shipped yet — addDefaultPresets is a no-op.
+    if (PRESET_SEEDS.length === 0) {
+      expect(service.addDefaultPresets()).toBe(0);
+      done();
+      return;
+    }
 
     const before = Date.now();
     service.addDefaultPresets();
     const after = Date.now();
 
-    const presets = service.getPresets().value;
-    expect(presets.length).toBe(PRESET_SEEDS.length);
-    presets.forEach((p) => {
-      expect(p.id).toBeTruthy();
-      expect(p.createdAt).toBeGreaterThanOrEqual(before);
-      expect(p.createdAt).toBeLessThanOrEqual(after);
+    service.getPresets().subscribe((presets) => {
+      expect(presets.length).toBe(PRESET_SEEDS.length);
+      presets.forEach((p) => {
+        expect(p.id).toBeTruthy();
+        expect(p.createdAt).toBeGreaterThanOrEqual(before);
+        expect(p.createdAt).toBeLessThanOrEqual(after);
+      });
+      done();
     });
   });
 
@@ -174,15 +210,18 @@ describe('GraphPresetService', () => {
     expect(added).toBe(0);
   });
 
-  it('falls back to an empty list on corrupt JSON (no auto-seed)', () => {
+  it('falls back to an empty list on corrupt JSON (no auto-seed)', (done) => {
     localStorage.setItem(STORAGE_KEY, 'not json');
 
     const service = build();
 
-    expect(service.getPresets().value).toEqual([]);
+    service.getPresets().subscribe((presets) => {
+      expect(presets).toEqual([]);
+      done();
+    });
   });
 
-  it('drops malformed entries but keeps valid ones', () => {
+  it('drops malformed entries but keeps valid ones', (done) => {
     const valid = makeStoredPreset({ id: 'valid' });
     const malformed = [
       { id: 1, name: 'wrong-id-type', topicNames: ['x'], createdAt: 1 },
@@ -195,14 +234,20 @@ describe('GraphPresetService', () => {
 
     const service = build();
 
-    expect(service.getPresets().value).toEqual([valid]);
+    service.getPresets().subscribe((presets) => {
+      expect(presets).toEqual([valid]);
+      done();
+    });
   });
 
-  it('falls back to an empty list when stored value is not an array', () => {
+  it('falls back to an empty list when stored value is not an array', (done) => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ not: 'an array' }));
 
     const service = build();
 
-    expect(service.getPresets().value).toEqual([]);
+    service.getPresets().subscribe((presets) => {
+      expect(presets).toEqual([]);
+      done();
+    });
   });
 });

--- a/angular-client/src/services/graph-preset.service.spec.ts
+++ b/angular-client/src/services/graph-preset.service.spec.ts
@@ -1,0 +1,208 @@
+import { TestBed } from '@angular/core/testing';
+import { GraphPresetService, PRESET_SEEDS, Preset } from './graph-preset.service';
+
+const STORAGE_KEY = 'argos.graphPresets';
+
+function makeStoredPreset(overrides: Partial<Preset> = {}): Preset {
+  return {
+    id: 'fixture-id',
+    name: 'Fixture',
+    topicNames: ['BMS/Pack/SOC'],
+    createdAt: 1700000000000,
+    ...overrides
+  };
+}
+
+describe('GraphPresetService', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  function build(): GraphPresetService {
+    TestBed.configureTestingModule({ providers: [GraphPresetService] });
+    return TestBed.inject(GraphPresetService);
+  }
+
+  it('seeds defaults when localStorage has never been written', () => {
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    const service = build();
+
+    const presets = service.getPresets().value;
+    expect(presets.map((p) => p.name)).toEqual(PRESET_SEEDS.map((s) => s.name));
+    expect(presets.every((p) => p.id.length > 0)).toBe(true);
+    expect(presets.every((p) => p.createdAt > 0)).toBe(true);
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored).toEqual(presets);
+  });
+
+  it('does not seed when localStorage holds an empty array', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
+
+    const service = build();
+
+    expect(service.getPresets().value).toEqual([]);
+  });
+
+  it('does not seed when localStorage already has user presets', () => {
+    const stored = makeStoredPreset({ id: 'user-1', name: 'My Preset' });
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([stored]));
+
+    const service = build();
+
+    expect(service.getPresets().value).toEqual([stored]);
+  });
+
+  it('addPreset appends a preset and persists it', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
+    const service = build();
+
+    const preset = service.addPreset('Vitals', ['BMS/Pack/SOC', 'MPU/State/Speed']);
+
+    expect(preset.name).toBe('Vitals');
+    expect(preset.topicNames).toEqual(['BMS/Pack/SOC', 'MPU/State/Speed']);
+    expect(preset.id).toBeTruthy();
+    expect(service.getPresets().value).toEqual([preset]);
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored).toEqual([preset]);
+  });
+
+  it('addPreset trims whitespace from the name', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
+    const service = build();
+
+    const preset = service.addPreset('  Race-day  ', ['A']);
+    expect(preset.name).toBe('Race-day');
+  });
+
+  it('addPreset throws on empty/whitespace-only names', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
+    const service = build();
+
+    expect(() => service.addPreset('', ['A'])).toThrowError(/empty/i);
+    expect(() => service.addPreset('   ', ['A'])).toThrowError(/empty/i);
+  });
+
+  it('replacePreset updates fields without changing id or createdAt', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
+    const service = build();
+    const original = service.addPreset('Vitals', ['A']);
+
+    service.replacePreset(original.id, { name: 'Vitals v2', topicNames: ['A', 'B'] });
+
+    const [updated] = service.getPresets().value;
+    expect(updated.id).toBe(original.id);
+    expect(updated.createdAt).toBe(original.createdAt);
+    expect(updated.name).toBe('Vitals v2');
+    expect(updated.topicNames).toEqual(['A', 'B']);
+  });
+
+  it('deletePreset removes the entry by id', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
+    const service = build();
+    const a = service.addPreset('A', ['x']);
+    const b = service.addPreset('B', ['y']);
+
+    service.deletePreset(a.id);
+
+    expect(service.getPresets().value).toEqual([b]);
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual([b]);
+  });
+
+  it('findByName matches case-sensitively', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
+    const service = build();
+    service.addPreset('Vitals', ['x']);
+
+    expect(service.findByName('Vitals')).toBeDefined();
+    expect(service.findByName('vitals')).toBeUndefined();
+  });
+
+  it('clearAll empties the list and writes [] to localStorage', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
+    const service = build();
+    service.addPreset('A', ['x']);
+    service.addPreset('B', ['y']);
+
+    service.clearAll();
+
+    expect(service.getPresets().value).toEqual([]);
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual([]);
+  });
+
+  it('restoreDefaults adds only seed entries whose names are missing', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
+    const service = build();
+    const [firstSeed] = PRESET_SEEDS;
+    service.addPreset(firstSeed.name, ['existing-topic']);
+
+    const added = service.restoreDefaults();
+
+    expect(added).toBe(PRESET_SEEDS.length - 1);
+    const namesNow = service.getPresets().value.map((p) => p.name);
+    expect(namesNow).toEqual(jasmine.arrayWithExactContents(PRESET_SEEDS.map((s) => s.name)));
+    const kept = service.findByName(firstSeed.name);
+    expect(kept!.topicNames).toEqual(['existing-topic']);
+  });
+
+  it('restoreDefaults assigns fresh ids and createdAt to new seeded entries', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
+    const service = build();
+
+    const before = Date.now();
+    service.restoreDefaults();
+    const after = Date.now();
+
+    const presets = service.getPresets().value;
+    expect(presets.length).toBe(PRESET_SEEDS.length);
+    presets.forEach((p) => {
+      expect(p.id).toBeTruthy();
+      expect(p.createdAt).toBeGreaterThanOrEqual(before);
+      expect(p.createdAt).toBeLessThanOrEqual(after);
+    });
+  });
+
+  it('restoreDefaults returns 0 when all defaults are already present', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
+    const service = build();
+    service.restoreDefaults();
+
+    const added = service.restoreDefaults();
+
+    expect(added).toBe(0);
+  });
+
+  it('falls back to an empty list on corrupt JSON (no auto-seed)', () => {
+    localStorage.setItem(STORAGE_KEY, 'not json');
+
+    const service = build();
+
+    expect(service.getPresets().value).toEqual([]);
+  });
+
+  it('drops malformed entries but keeps valid ones', () => {
+    const valid = makeStoredPreset({ id: 'valid' });
+    const malformed = [
+      { id: 1, name: 'wrong-id-type', topicNames: ['x'], createdAt: 1 },
+      { id: 'no-name', topicNames: ['x'], createdAt: 1 },
+      { id: 'bad-topics', name: 'x', topicNames: ['ok', 7], createdAt: 1 },
+      { id: 'bad-time', name: 'x', topicNames: ['x'], createdAt: 'not-a-number' },
+      valid
+    ];
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(malformed));
+
+    const service = build();
+
+    expect(service.getPresets().value).toEqual([valid]);
+  });
+
+  it('falls back to an empty list when stored value is not an array', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ not: 'an array' }));
+
+    const service = build();
+
+    expect(service.getPresets().value).toEqual([]);
+  });
+});

--- a/angular-client/src/services/graph-preset.service.ts
+++ b/angular-client/src/services/graph-preset.service.ts
@@ -77,15 +77,10 @@ export class GraphPresetService {
   };
 
   replacePreset = (id: string, patch: Partial<Pick<Preset, 'name' | 'topicNames'>>): void => {
-    const next = this.presets.value.map((p) => {
-      if (p.id !== id) return p;
-      return {
-        ...p,
-        ...(patch.name !== undefined ? { name: patch.name.trim() } : {}),
-        ...(patch.topicNames !== undefined ? { topicNames: [...patch.topicNames] } : {})
-      };
-    });
-    this.presets.next(next);
+    const updates: Partial<Preset> = {};
+    if (patch.name !== undefined) updates.name = patch.name.trim();
+    if (patch.topicNames !== undefined) updates.topicNames = [...patch.topicNames];
+    this.presets.next(this.presets.value.map((p) => (p.id === id ? { ...p, ...updates } : p)));
     this.save();
   };
 

--- a/angular-client/src/services/graph-preset.service.ts
+++ b/angular-client/src/services/graph-preset.service.ts
@@ -103,7 +103,7 @@ export class GraphPresetService {
     this.save();
   };
 
-  restoreDefaults = (): number => {
+  addDefaultPresets = (): number => {
     const existingNames = new Set(this.subject.value.map((p) => p.name));
     const toAdd = PRESET_SEEDS.filter((s) => !existingNames.has(s.name)).map(seedToPreset);
     if (toAdd.length === 0) return 0;

--- a/angular-client/src/services/graph-preset.service.ts
+++ b/angular-client/src/services/graph-preset.service.ts
@@ -1,0 +1,150 @@
+import { Injectable, inject } from '@angular/core';
+import { BehaviorSubject, Observable, combineLatest, map } from 'rxjs';
+import { v4 as uuidv4 } from 'uuid';
+import { TopicSelectionService } from './topic-selection.service';
+
+export interface Preset {
+  id: string;
+  name: string;
+  topicNames: string[];
+  createdAt: number;
+}
+
+export interface PresetSeed {
+  name: string;
+  topicNames: string[];
+}
+
+const STORAGE_KEY = 'argos.graphPresets';
+
+// Names that don't match the live schema in src/utils/topic.utils.ts get
+// silently skipped on Apply (with a warn toast), not hard-errored.
+export const PRESET_SEEDS: PresetSeed[] = [
+  {
+    name: 'test preset',
+    topicNames: ['BMS/Pack/SOC']
+  }
+];
+
+@Injectable({ providedIn: 'root' })
+export class GraphPresetService {
+  private topicSelectionService = inject(TopicSelectionService);
+  private subject = new BehaviorSubject<Preset[]>([]);
+  private activePresetName$: Observable<string | undefined> = combineLatest([
+    this.subject,
+    this.topicSelectionService.getSelectedDataTypes()
+  ]).pipe(
+    map(([presets, selectedDataTypes]) => {
+      const selected = new Set(selectedDataTypes.map((dt) => dt.name));
+      if (selected.size === 0) return undefined;
+      return presets.find(
+        (p) => p.topicNames.length === selected.size && p.topicNames.every((n) => selected.has(n))
+      )?.name;
+    })
+  );
+
+  constructor() {
+    this.subject.next(this.loadOrSeed());
+  }
+
+  getPresets = (): BehaviorSubject<Preset[]> => this.subject;
+
+  getActivePresetName = (): Observable<string | undefined> => this.activePresetName$;
+
+  addPreset = (name: string, topicNames: string[]): Preset => {
+    const trimmed = name.trim();
+    if (trimmed.length === 0) {
+      throw new Error('Preset name cannot be empty');
+    }
+    const preset: Preset = {
+      id: uuidv4(),
+      name: trimmed,
+      topicNames: [...topicNames],
+      createdAt: Date.now()
+    };
+    this.subject.next([...this.subject.value, preset]);
+    this.save();
+    return preset;
+  };
+
+  replacePreset = (id: string, patch: Partial<Pick<Preset, 'name' | 'topicNames'>>): void => {
+    const next = this.subject.value.map((p) => {
+      if (p.id !== id) return p;
+      return {
+        ...p,
+        ...(patch.name !== undefined ? { name: patch.name.trim() } : {}),
+        ...(patch.topicNames !== undefined ? { topicNames: [...patch.topicNames] } : {})
+      };
+    });
+    this.subject.next(next);
+    this.save();
+  };
+
+  deletePreset = (id: string): void => {
+    this.subject.next(this.subject.value.filter((p) => p.id !== id));
+    this.save();
+  };
+
+  findByName = (name: string): Preset | undefined => {
+    return this.subject.value.find((p) => p.name === name);
+  };
+
+  clearAll = (): void => {
+    this.subject.next([]);
+    this.save();
+  };
+
+  restoreDefaults = (): number => {
+    const existingNames = new Set(this.subject.value.map((p) => p.name));
+    const toAdd = PRESET_SEEDS.filter((s) => !existingNames.has(s.name)).map(seedToPreset);
+    if (toAdd.length === 0) return 0;
+    this.subject.next([...this.subject.value, ...toAdd]);
+    this.save();
+    return toAdd.length;
+  };
+
+  private loadOrSeed(): Preset[] {
+    const raw = localStorage.getItem(STORAGE_KEY);
+
+    // null = first visit (seed); '[]' = user cleared all (don't re-seed).
+    if (raw === null) {
+      const seeded = PRESET_SEEDS.map(seedToPreset);
+      this.save(seeded);
+      return seeded;
+    }
+
+    try {
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return [];
+      return parsed.filter(isValidPreset);
+    } catch {
+      return [];
+    }
+  }
+
+  private save(list: Preset[] = this.subject.value): void {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+  }
+}
+
+function seedToPreset(seed: PresetSeed): Preset {
+  return {
+    id: uuidv4(),
+    name: seed.name,
+    topicNames: [...seed.topicNames],
+    createdAt: Date.now()
+  };
+}
+
+function isValidPreset(value: unknown): value is Preset {
+  if (typeof value !== 'object' || value === null) return false;
+  const { id, name, topicNames, createdAt } = value as Record<string, unknown>;
+  return (
+    typeof id === 'string' &&
+    typeof name === 'string' &&
+    Array.isArray(topicNames) &&
+    topicNames.every((n) => typeof n === 'string') &&
+    typeof createdAt === 'number' &&
+    Number.isFinite(createdAt)
+  );
+}

--- a/angular-client/src/services/graph-preset.service.ts
+++ b/angular-client/src/services/graph-preset.service.ts
@@ -26,10 +26,10 @@ export const PRESET_SEEDS: PresetSeed[] = [];
 export class GraphPresetService {
   private topicSelectionService = inject(TopicSelectionService);
   private messageService = inject(MessageService);
-  private subject = new BehaviorSubject<Preset[]>([]);
-  private presets$ = this.subject.asObservable();
+  private presets = new BehaviorSubject<Preset[]>([]);
+  private presets$ = this.presets.asObservable();
   private activePresetName$: Observable<string | undefined> = combineLatest([
-    this.subject,
+    this.presets,
     this.topicSelectionService.getSelectedDataTypes()
   ]).pipe(
     map(([presets, selectedDataTypes]) => {
@@ -40,7 +40,7 @@ export class GraphPresetService {
   );
 
   constructor() {
-    this.subject.next(this.loadOrSeed());
+    this.presets.next(this.loadOrSeed());
   }
 
   getPresets = (): Observable<Preset[]> => this.presets$;
@@ -71,13 +71,13 @@ export class GraphPresetService {
       topicNames: [...topicNames],
       createdAt: Date.now()
     };
-    this.subject.next([...this.subject.value, preset]);
+    this.presets.next([...this.presets.value, preset]);
     this.save();
     return preset;
   };
 
   replacePreset = (id: string, patch: Partial<Pick<Preset, 'name' | 'topicNames'>>): void => {
-    const next = this.subject.value.map((p) => {
+    const next = this.presets.value.map((p) => {
       if (p.id !== id) return p;
       return {
         ...p,
@@ -85,29 +85,29 @@ export class GraphPresetService {
         ...(patch.topicNames !== undefined ? { topicNames: [...patch.topicNames] } : {})
       };
     });
-    this.subject.next(next);
+    this.presets.next(next);
     this.save();
   };
 
   deletePreset = (id: string): void => {
-    this.subject.next(this.subject.value.filter((p) => p.id !== id));
+    this.presets.next(this.presets.value.filter((p) => p.id !== id));
     this.save();
   };
 
   findByName = (name: string): Preset | undefined => {
-    return this.subject.value.find((p) => p.name === name);
+    return this.presets.value.find((p) => p.name === name);
   };
 
   clearAll = (): void => {
-    this.subject.next([]);
+    this.presets.next([]);
     this.save();
   };
 
   addDefaultPresets = (): number => {
-    const existingNames = new Set(this.subject.value.map((p) => p.name));
+    const existingNames = new Set(this.presets.value.map((p) => p.name));
     const toAdd = PRESET_SEEDS.filter((s) => !existingNames.has(s.name)).map(seedToPreset);
     if (toAdd.length === 0) return 0;
-    this.subject.next([...this.subject.value, ...toAdd]);
+    this.presets.next([...this.presets.value, ...toAdd]);
     this.save();
     return toAdd.length;
   };
@@ -131,7 +131,7 @@ export class GraphPresetService {
     }
   }
 
-  private save(list: Preset[] = this.subject.value): void {
+  private save(list: Preset[] = this.presets.value): void {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
   }
 }

--- a/angular-client/src/services/graph-preset.service.ts
+++ b/angular-client/src/services/graph-preset.service.ts
@@ -20,22 +20,28 @@ export interface PresetSeed {
 
 const STORAGE_KEY = 'argos.graphPresets';
 
+// Empty until we ship default presets
 export const PRESET_SEEDS: PresetSeed[] = [];
 
+/**
+ * Service for managing graph topic-selection presets, persisted to localStorage.
+ */
 @Injectable({ providedIn: 'root' })
 export class GraphPresetService {
   private topicSelectionService = inject(TopicSelectionService);
   private messageService = inject(MessageService);
   private presets = new BehaviorSubject<Preset[]>([]);
   private presets$ = this.presets.asObservable();
+
+  // Preset whose topics exactly match the current selection
   private activePresetName$: Observable<string | undefined> = combineLatest([
     this.presets,
     this.topicSelectionService.getSelectedDataTypes()
   ]).pipe(
     map(([presets, selectedDataTypes]) => {
-      const selected = new Set(selectedDataTypes.map((dt) => dt.name));
-      if (selected.size === 0) return undefined;
-      return presets.find((p) => p.topicNames.length === selected.size && p.topicNames.every((n) => selected.has(n)))?.name;
+      const selectedNames = new Set(selectedDataTypes.map((dt) => dt.name));
+      if (selectedNames.size === 0) return undefined;
+      return presets.find((preset) => presetMatchesSelection(preset, selectedNames))?.name;
     })
   );
 
@@ -98,6 +104,7 @@ export class GraphPresetService {
     this.save();
   };
 
+  // Skip seeds already present by name
   addDefaultPresets = (): number => {
     const existingNames = new Set(this.presets.value.map((p) => p.name));
     const toAdd = PRESET_SEEDS.filter((s) => !existingNames.has(s.name)).map(seedToPreset);
@@ -131,6 +138,10 @@ export class GraphPresetService {
   }
 }
 
+function presetMatchesSelection(preset: Preset, selectedNames: Set<string>): boolean {
+  return preset.topicNames.length === selectedNames.size && preset.topicNames.every((name) => selectedNames.has(name));
+}
+
 function seedToPreset(seed: PresetSeed): Preset {
   return {
     id: uuidv4(),
@@ -140,6 +151,7 @@ function seedToPreset(seed: PresetSeed): Preset {
   };
 }
 
+// Guards against malformed localStorage data
 function isValidPreset(value: unknown): value is Preset {
   if (typeof value !== 'object' || value === null) return false;
   const { id, name, topicNames, createdAt } = value as Record<string, unknown>;

--- a/angular-client/src/services/graph-preset.service.ts
+++ b/angular-client/src/services/graph-preset.service.ts
@@ -37,9 +37,7 @@ export class GraphPresetService {
     map(([presets, selectedDataTypes]) => {
       const selected = new Set(selectedDataTypes.map((dt) => dt.name));
       if (selected.size === 0) return undefined;
-      return presets.find(
-        (p) => p.topicNames.length === selected.size && p.topicNames.every((n) => selected.has(n))
-      )?.name;
+      return presets.find((p) => p.topicNames.length === selected.size && p.topicNames.every((n) => selected.has(n)))?.name;
     })
   );
 

--- a/angular-client/src/services/graph-preset.service.ts
+++ b/angular-client/src/services/graph-preset.service.ts
@@ -1,6 +1,9 @@
 import { Injectable, inject } from '@angular/core';
+import { MessageService } from 'primeng/api';
 import { BehaviorSubject, Observable, combineLatest, map } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
+import { partitionDataTypesByName } from 'src/utils/dataTypes.utils';
+import { DataType } from 'src/utils/types.utils';
 import { TopicSelectionService } from './topic-selection.service';
 
 export interface Preset {
@@ -17,19 +20,14 @@ export interface PresetSeed {
 
 const STORAGE_KEY = 'argos.graphPresets';
 
-// Names that don't match the live schema in src/utils/topic.utils.ts get
-// silently skipped on Apply (with a warn toast), not hard-errored.
-export const PRESET_SEEDS: PresetSeed[] = [
-  {
-    name: 'test preset',
-    topicNames: ['BMS/Pack/SOC']
-  }
-];
+export const PRESET_SEEDS: PresetSeed[] = [];
 
 @Injectable({ providedIn: 'root' })
 export class GraphPresetService {
   private topicSelectionService = inject(TopicSelectionService);
+  private messageService = inject(MessageService);
   private subject = new BehaviorSubject<Preset[]>([]);
+  private presets$ = this.subject.asObservable();
   private activePresetName$: Observable<string | undefined> = combineLatest([
     this.subject,
     this.topicSelectionService.getSelectedDataTypes()
@@ -45,9 +43,22 @@ export class GraphPresetService {
     this.subject.next(this.loadOrSeed());
   }
 
-  getPresets = (): BehaviorSubject<Preset[]> => this.subject;
+  getPresets = (): Observable<Preset[]> => this.presets$;
 
   getActivePresetName = (): Observable<string | undefined> => this.activePresetName$;
+
+  resolvePresetTopics = (preset: Preset, dataTypes: DataType[]): DataType[] => {
+    const { matched, unknown } = partitionDataTypesByName(dataTypes, preset.topicNames);
+    if (unknown.length > 0) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Unknown Topics Skipped',
+        detail: unknown.join(', '),
+        life: 8000
+      });
+    }
+    return matched;
+  };
 
   addPreset = (name: string, topicNames: string[]): Preset => {
     const trimmed = name.trim();
@@ -104,7 +115,7 @@ export class GraphPresetService {
   private loadOrSeed(): Preset[] {
     const raw = localStorage.getItem(STORAGE_KEY);
 
-    // null = first visit (seed); '[]' = user cleared all (don't re-seed).
+    // null = first visit, seed; '[]' = user cleared, don't re-seed.
     if (raw === null) {
       const seeded = PRESET_SEEDS.map(seedToPreset);
       this.save(seeded);

--- a/angular-client/src/utils/dataTypes.utils.ts
+++ b/angular-client/src/utils/dataTypes.utils.ts
@@ -64,3 +64,18 @@ export const dataTypeNamePipe = (dataTypeName: string) => {
   const updatedName = updatedNameArray.join('-');
   return updatedName;
 };
+
+export const partitionDataTypesByName = (
+  dataTypes: DataType[],
+  names: string[]
+): { matched: DataType[]; unknown: string[] } => {
+  const known = new Map(dataTypes.map((dt) => [dt.name, dt]));
+  const matched: DataType[] = [];
+  const unknown: string[] = [];
+  for (const name of names) {
+    const dt = known.get(name);
+    if (dt) matched.push(dt);
+    else unknown.push(name);
+  }
+  return { matched, unknown };
+};

--- a/angular-client/src/utils/file.utils.ts
+++ b/angular-client/src/utils/file.utils.ts
@@ -1,0 +1,38 @@
+export function downloadAsFile(filename: string, content: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.click();
+
+  URL.revokeObjectURL(url);
+}
+
+export type FileReadErrorKind = 'invalid-extension' | 'read-error';
+
+export class FileReadError extends Error {
+  constructor(
+    public readonly kind: FileReadErrorKind,
+    message: string
+  ) {
+    super(message);
+    this.name = 'FileReadError';
+  }
+}
+
+export function readTextFile(file: File, allowedExt: string | string[]): Promise<string> {
+  const exts = (Array.isArray(allowedExt) ? allowedExt : [allowedExt]).map((e) => e.toLowerCase());
+  const lower = file.name.toLowerCase();
+  if (!exts.some((ext) => lower.endsWith(ext))) {
+    return Promise.reject(new FileReadError('invalid-extension', `Expected ${exts.join(' or ')}`));
+  }
+
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new FileReadError('read-error', 'Failed to read file'));
+    reader.readAsText(file);
+  });
+}


### PR DESCRIPTION
## Changes

Adds a client-side topic-selection preset system to the graph page so engineers can save and reapply named topic groupings without having to reselect each session. New GraphPresetService persists presets in localStorage. New PresetDialogComponent provides save selection, apply, upload, download, delete, and restore defaults actions. It opens from both graph sidebars via DialogService. The graph sidebar gets a presets row above the topic tree containing a select dropdown for fast applying and a manage button, with the dropdown's defaultValue bound to activePresetName so it tracks the live selection. 

## Notes
- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)


Closes #566 
