### PR TITLE
#627 Custom time range and multi-day x-axis

### DIFF
--- a/angular-client/src/components/argos-button/argos-button.component.css
+++ b/angular-client/src/components/argos-button/argos-button.component.css
@@ -18,6 +18,14 @@
   user-select: none;
 }
 
+.btn--sm {
+  border-radius: 8px;
+  padding: 4px 10px;
+  font-size: 12px;
+  height: 28px;
+  line-height: 1;
+}
+
 .btn:hover:not(:disabled) {
   transition: ease;
   transition-duration: 0.2s;
@@ -34,5 +42,12 @@
     padding: 6px 8px;
     font-size: 13px;
     min-height: 44px;
+  }
+
+  .btn--sm {
+    padding: 4px 8px;
+    font-size: 12px;
+    min-height: 32px;
+    height: auto;
   }
 }

--- a/angular-client/src/components/argos-button/argos-button.component.html
+++ b/angular-client/src/components/argos-button/argos-button.component.html
@@ -1,3 +1,5 @@
 <div id="button">
-  <button type="button" class="btn" (click)="onClick()()" [style]="style()" [disabled]="disabled()">{{ label() }}</button>
+  <button type="button" [class]="cssClass()" (click)="onClick()($event)" [style]="style()" [disabled]="disabled()">
+    {{ label() }}
+  </button>
 </div>

--- a/angular-client/src/components/argos-button/argos-button.component.spec.ts
+++ b/angular-client/src/components/argos-button/argos-button.component.spec.ts
@@ -1,0 +1,57 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ButtonComponent } from './argos-button.component';
+
+describe('ButtonComponent', () => {
+  let component: ButtonComponent;
+  let fixture: ComponentFixture<ButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ButtonComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ButtonComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('label', 'Test');
+    fixture.componentRef.setInput('onClick', () => {});
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('defaults to btn btn--default class and includes legacy width/height', () => {
+    expect(component.cssClass()).toBe('btn btn--default');
+    expect(component.style()).toContain('width: 140px');
+    expect(component.style()).toContain('height: 45px');
+  });
+
+  it('omits legacy width/height when size is sm', () => {
+    fixture.componentRef.setInput('size', 'sm');
+    fixture.detectChanges();
+    expect(component.cssClass()).toBe('btn btn--sm');
+    expect(component.style()).not.toContain('width: 140px');
+    expect(component.style()).not.toContain('height: 45px');
+  });
+
+  it('appends additionalStyles after the size-driven base', () => {
+    fixture.componentRef.setInput('size', 'sm');
+    fixture.componentRef.setInput('additionalStyles', 'background-color: red;');
+    fixture.detectChanges();
+    expect(component.style()).toContain('background-color: red;');
+  });
+
+  it('passes the click event to the onClick handler (popover triggers depend on this)', () => {
+    let received: Event | undefined;
+    fixture.componentRef.setInput('onClick', (e?: Event) => {
+      received = e;
+    });
+    fixture.detectChanges();
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    button.click();
+    expect(received).toBeDefined();
+    expect(received instanceof Event).toBeTrue();
+  });
+});

--- a/angular-client/src/components/argos-button/argos-button.component.ts
+++ b/angular-client/src/components/argos-button/argos-button.component.ts
@@ -1,5 +1,7 @@
 import { Component, computed, input } from '@angular/core';
 
+export type ButtonSize = 'default' | 'sm';
+
 /**
  * Simple custom button component that does something on click
  * Takes label and onClick function as inputs
@@ -13,11 +15,17 @@ import { Component, computed, input } from '@angular/core';
 })
 export class ButtonComponent {
   label = input.required<string>();
-  onClick = input.required<() => void>();
+  // Event is optional so callers can pass either `() => void` or `(event: Event) => void`;
+  // popover/menu triggers need the event for anchoring.
+  onClick = input.required<(event?: Event) => void>();
   additionalStyles = input<string>();
   disabled = input<boolean>(false);
+  size = input<ButtonSize>('default');
+  cssClass = computed(() => `btn btn--${this.size()}`);
   style = computed(() => {
-    const base = 'width: 140px; height: 45px; ';
+    // The default size keeps the legacy fixed footprint; sm lets CSS drive sizing
+    // so callers don't need to override width/height per-button.
+    const base = this.size() === 'sm' ? '' : 'width: 140px; height: 45px; ';
     const extra = this.additionalStyles();
     return extra ? base + extra : base;
   });

--- a/angular-client/src/components/select-dropdown/select-dropdown.component.ts
+++ b/angular-client/src/components/select-dropdown/select-dropdown.component.ts
@@ -37,6 +37,12 @@ export class SelectDropdownComponent {
   @ViewChild('dropdownRef') dropdownRef: any;
 
   constructor() {
+    // The dropdown's selected display tracks `defaultValue`:
+    //  - when `defaultValue` matches an option name, that option is shown
+    //  - when `defaultValue` is undefined, the placeholder is restored
+    // The clear-on-undefined branch matters for parents that toggle the prop dynamically
+    // (e.g. graph-page deselects the active preset when a Custom range is applied). Static
+    // callers that never unset `defaultValue` see no behavior change.
     effect(() => {
       const val = this.defaultValue();
       if (val) {
@@ -44,6 +50,8 @@ export class SelectDropdownComponent {
         if (match) {
           this.selectedOption = match;
         }
+      } else {
+        this.selectedOption = undefined;
       }
     });
   }

--- a/angular-client/src/pages/graph-page/graph-caption/general-buttons/general-buttons.component.css
+++ b/angular-client/src/pages/graph-page/graph-caption/general-buttons/general-buttons.component.css
@@ -16,6 +16,116 @@
   flex-wrap: wrap;
 }
 
+.historical-section {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
+  padding-left: 10px;
+  border-left: 1px solid #2a3a44;
+}
+
+.historical-label {
+  color: #8fcadd;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* Compress the Quick Select dropdown so it lines up with the sm "Custom" button (28px).
+   The select-dropdown component sets padding-bottom: 10px and width: 10vw with !important
+   on .p-select-label globally, so we have to override with !important to win.
+
+   TODO: select-dropdown.component.css uses !important for sizing rules that should be
+   per-call-site, not global. Cleaning that up would let consumers (us) drop !important here
+   and let any other future caller pick its own dimensions without a CSS arms race. */
+.historical-section ::ng-deep select-dropdown .p-select {
+  height: 28px !important;
+  min-height: 28px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.historical-section ::ng-deep select-dropdown .p-select-label,
+.historical-section ::ng-deep select-dropdown .p-select-label.p-placeholder {
+  width: auto !important;
+  min-width: 100px;
+  padding: 0 0.5rem !important;
+  font-size: 12px;
+  line-height: 28px;
+  height: 28px;
+}
+
+.historical-section ::ng-deep select-dropdown .p-select-dropdown {
+  width: 1.75rem;
+}
+
+.custom-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+}
+
+.custom-caption {
+  color: #8fcadd;
+  font-size: 10px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.custom-popover-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 260px;
+  padding: 4px;
+}
+
+.mode-toggle {
+  display: flex;
+  flex-direction: row;
+  border: 1px solid #2a3a44;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.mode-btn {
+  flex: 1;
+  background-color: transparent;
+  color: #c9d6dc;
+  border: none;
+  padding: 6px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.mode-btn--active {
+  background-color: #027bd7;
+  color: #fff;
+}
+
+.mode-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.field-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.popover-label {
+  color: #c9d6dc;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
 @media (max-width: 768px) {
   :host {
     margin: 0;
@@ -25,6 +135,13 @@
   .general-buttons-row {
     gap: 6px;
     width: 100%;
+  }
+
+  .historical-section {
+    padding-left: 0;
+    border-left: none;
+    flex-wrap: wrap;
+    gap: 6px;
   }
 
   :host ::ng-deep select-dropdown {

--- a/angular-client/src/pages/graph-page/graph-caption/general-buttons/general-buttons.component.html
+++ b/angular-client/src/pages/graph-page/graph-caption/general-buttons/general-buttons.component.html
@@ -1,16 +1,133 @@
 <div class="general-buttons-row">
   <run-selector [selectRun]="onRunSelected()" />
   @if (historicalOn()) {
-    <argos-button [onClick]="onSetRealTime()" label="Realtime" additionalStyles="border: 1.4px solid #000" />
+    <argos-button [onClick]="onSetRealTime()" label="Realtime" size="sm" additionalStyles="border: 1.4px solid #000" />
   }
   <argos-button
     [onClick]="onClearDataType()"
     label="Clear Graph"
+    size="sm"
     additionalStyles="background-color: #323232; border: 1.4px solid #027bd7;"
   />
-  <select-dropdown
-    [options]="this.selectorConfig().options"
-    [placeholder]="selectorConfig().placeholder"
-    [defaultValue]="selectorConfig().defaultValue"
-  />
+
+  <div class="historical-section">
+    <span class="historical-label">Historical:</span>
+    <select-dropdown
+      [options]="quickSelectConfig().options"
+      [placeholder]="quickSelectConfig().placeholder"
+      [defaultValue]="selectedPresetLabel()"
+    />
+    <div class="custom-stack">
+      <argos-button
+        [onClick]="toggleCustomPopover"
+        label="Custom"
+        size="sm"
+        [additionalStyles]="
+          customActive()
+            ? 'background-color: #027bd7; border: 1.4px solid #8fcadd;'
+            : 'background-color: #0c2026; border: 1.4px solid #8fcadd;'
+        "
+      />
+      @if (customActive() && customCaption()) {
+        <span class="custom-caption">{{ customCaption() }}</span>
+      }
+    </div>
+  </div>
+
+  <p-popover #customPopover styleClass="custom-range-popover" (onShow)="onCustomPopoverShow()">
+    <ng-template #content>
+      <div class="custom-popover-body">
+        <div class="mode-toggle">
+          <button
+            type="button"
+            class="mode-btn"
+            [class.mode-btn--active]="customMode() === 'last-x'"
+            (click)="setCustomMode('last-x')"
+          >
+            Last X
+          </button>
+          <button
+            type="button"
+            class="mode-btn"
+            [class.mode-btn--active]="customMode() === 'date-range'"
+            (click)="setCustomMode('date-range')"
+          >
+            Date Range
+          </button>
+        </div>
+
+        @if (customMode() === 'last-x') {
+          <div class="mode-body">
+            <div class="field-row">
+              <label class="popover-label">Hours</label>
+              <p-inputNumber
+                [ngModel]="customHours()"
+                (ngModelChange)="customHours.set($event)"
+                mode="decimal"
+                [min]="0"
+                [step]="1"
+                inputStyleClass="text-xs p-1"
+                placeholder="0"
+              />
+            </div>
+            <div class="field-row">
+              <label class="popover-label">Minutes</label>
+              <p-inputNumber
+                [ngModel]="customMinutes()"
+                (ngModelChange)="customMinutes.set($event)"
+                mode="decimal"
+                [min]="0"
+                [step]="1"
+                inputStyleClass="text-xs p-1"
+                placeholder="30"
+              />
+            </div>
+            <argos-button
+              [onClick]="applyCustomLastX"
+              label="Apply"
+              size="sm"
+              additionalStyles="background-color: #027bd7; border: 1.4px solid #8fcadd;"
+            />
+          </div>
+        } @else {
+          <div class="mode-body">
+            <div class="field-row">
+              <label class="popover-label">From</label>
+              <p-datepicker
+                [ngModel]="customFromDate()"
+                (ngModelChange)="customFromDate.set($event)"
+                [showTime]="true"
+                [showSeconds]="true"
+                [showIcon]="true"
+                [maxDate]="maxDate()"
+                appendTo="body"
+                hourFormat="24"
+                dateFormat="yy-mm-dd"
+              />
+            </div>
+            <div class="field-row">
+              <label class="popover-label">To</label>
+              <p-datepicker
+                [ngModel]="customToDate()"
+                (ngModelChange)="customToDate.set($event)"
+                [showTime]="true"
+                [showSeconds]="true"
+                [showIcon]="true"
+                [maxDate]="maxDate()"
+                appendTo="body"
+                hourFormat="24"
+                dateFormat="yy-mm-dd"
+              />
+            </div>
+            <argos-button
+              [onClick]="applyCustomDateRange"
+              label="Apply"
+              size="sm"
+              additionalStyles="background-color: #027bd7; border: 1.4px solid #8fcadd;"
+            />
+          </div>
+        }
+      </div>
+    </ng-template>
+  </p-popover>
 </div>

--- a/angular-client/src/pages/graph-page/graph-caption/general-buttons/general-buttons.component.spec.ts
+++ b/angular-client/src/pages/graph-page/graph-caption/general-buttons/general-buttons.component.spec.ts
@@ -1,0 +1,158 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MessageService } from 'primeng/api';
+import { GeneralButtonsComponent, MAX_RANGE_MINUTES, RangePreset } from './general-buttons.component';
+
+describe('GeneralButtonsComponent — custom range validation', () => {
+  let fixture: ComponentFixture<GeneralButtonsComponent>;
+  let component: GeneralButtonsComponent;
+  let toastSpy: jasmine.SpyObj<MessageService>;
+  let onSelectPresetSpy: jasmine.Spy;
+  let onApplyCustomLastXSpy: jasmine.Spy;
+  let onApplyCustomDateRangeSpy: jasmine.Spy;
+  let onRunSelectedSpy: jasmine.Spy;
+  let onClearDataTypeSpy: jasmine.Spy;
+  let onSetRealTimeSpy: jasmine.Spy;
+
+  const presets: RangePreset[] = [
+    { label: '1 minute', minutes: 1 },
+    { label: '5 minutes', minutes: 5 }
+  ];
+
+  beforeEach(async () => {
+    toastSpy = jasmine.createSpyObj<MessageService>('MessageService', ['add']);
+    onSelectPresetSpy = jasmine.createSpy('onSelectPreset');
+    onApplyCustomLastXSpy = jasmine.createSpy('onApplyCustomLastX');
+    onApplyCustomDateRangeSpy = jasmine.createSpy('onApplyCustomDateRange');
+    onRunSelectedSpy = jasmine.createSpy('onRunSelected');
+    onClearDataTypeSpy = jasmine.createSpy('onClearDataType');
+    onSetRealTimeSpy = jasmine.createSpy('onSetRealTime');
+
+    await TestBed.configureTestingModule({
+      imports: [GeneralButtonsComponent],
+      providers: [{ provide: MessageService, useValue: toastSpy }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(GeneralButtonsComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('presets', presets);
+    fixture.componentRef.setInput('onSelectPreset', onSelectPresetSpy);
+    fixture.componentRef.setInput('onApplyCustomLastX', onApplyCustomLastXSpy);
+    fixture.componentRef.setInput('onApplyCustomDateRange', onApplyCustomDateRangeSpy);
+    fixture.componentRef.setInput('onRunSelected', onRunSelectedSpy);
+    fixture.componentRef.setInput('onClearDataType', onClearDataTypeSpy);
+    fixture.componentRef.setInput('onSetRealTime', onSetRealTimeSpy);
+    fixture.detectChanges();
+  });
+
+  describe('applyCustomLastX', () => {
+    it('rejects 0 hours / 0 minutes with a toast and no callback', () => {
+      component.customHours.set(0);
+      component.customMinutes.set(0);
+      component.applyCustomLastX();
+      expect(onApplyCustomLastXSpy).not.toHaveBeenCalled();
+      expect(toastSpy.add).toHaveBeenCalledOnceWith(
+        jasmine.objectContaining({ severity: 'warn', summary: 'Invalid Range' })
+      );
+    });
+
+    it('rejects total exceeding MAX_RANGE_MINUTES with a toast', () => {
+      component.customHours.set(MAX_RANGE_MINUTES / 60 + 1); // 8 days in hours
+      component.customMinutes.set(0);
+      component.applyCustomLastX();
+      expect(onApplyCustomLastXSpy).not.toHaveBeenCalled();
+      expect(toastSpy.add).toHaveBeenCalledOnceWith(jasmine.objectContaining({ summary: 'Range Too Large' }));
+    });
+
+    it('emits the total minutes when valid', () => {
+      component.customHours.set(2);
+      component.customMinutes.set(15);
+      component.applyCustomLastX();
+      expect(onApplyCustomLastXSpy).toHaveBeenCalledOnceWith(135);
+      expect(toastSpy.add).not.toHaveBeenCalled();
+    });
+
+    it('treats null inputs as zero', () => {
+      component.customHours.set(null);
+      component.customMinutes.set(null);
+      component.applyCustomLastX();
+      expect(onApplyCustomLastXSpy).not.toHaveBeenCalled();
+      expect(toastSpy.add).toHaveBeenCalledOnceWith(jasmine.objectContaining({ summary: 'Invalid Range' }));
+    });
+  });
+
+  describe('applyCustomDateRange', () => {
+    const now = Date.now();
+
+    it('rejects from >= to with a toast', () => {
+      component.customFromDate.set(new Date(now - 60 * 1000));
+      component.customToDate.set(new Date(now - 60 * 1000));
+      component.applyCustomDateRange();
+      expect(onApplyCustomDateRangeSpy).not.toHaveBeenCalled();
+      expect(toastSpy.add).toHaveBeenCalledOnceWith(jasmine.objectContaining({ summary: 'Invalid Range' }));
+    });
+
+    it('rejects an end time more than 1 minute in the future', () => {
+      component.customFromDate.set(new Date(now - 60 * 60 * 1000));
+      component.customToDate.set(new Date(now + 5 * 60 * 1000));
+      component.applyCustomDateRange();
+      expect(onApplyCustomDateRangeSpy).not.toHaveBeenCalled();
+      expect(toastSpy.add).toHaveBeenCalledOnceWith(jasmine.objectContaining({ summary: 'Invalid Range' }));
+    });
+
+    it('rejects a span exceeding MAX_RANGE_MINUTES', () => {
+      const oneMinuteMs = 60 * 1000;
+      component.customFromDate.set(new Date(now - (MAX_RANGE_MINUTES + 5) * oneMinuteMs));
+      component.customToDate.set(new Date(now - oneMinuteMs));
+      component.applyCustomDateRange();
+      expect(onApplyCustomDateRangeSpy).not.toHaveBeenCalled();
+      expect(toastSpy.add).toHaveBeenCalledOnceWith(jasmine.objectContaining({ summary: 'Range Too Large' }));
+    });
+
+    it('emits start and end ms when valid', () => {
+      const start = new Date(now - 30 * 60 * 1000);
+      const end = new Date(now - 60 * 1000);
+      component.customFromDate.set(start);
+      component.customToDate.set(end);
+      component.applyCustomDateRange();
+      expect(onApplyCustomDateRangeSpy).toHaveBeenCalledOnceWith(start.getTime(), end.getTime());
+      expect(toastSpy.add).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onCustomPopoverShow', () => {
+    it('seeds Last X mode + hours/minutes when activeLastXMinutes is set', () => {
+      fixture.componentRef.setInput('activeLastXMinutes', 135);
+      fixture.detectChanges();
+      component.onCustomPopoverShow();
+      expect(component.customMode()).toBe('last-x');
+      expect(component.customHours()).toBe(2);
+      expect(component.customMinutes()).toBe(15);
+    });
+
+    it('seeds Date Range mode + From/To when activeDateRange is set', () => {
+      const range = { startMs: 1_700_000_000_000, endMs: 1_700_000_900_000 };
+      fixture.componentRef.setInput('activeDateRange', range);
+      fixture.detectChanges();
+      component.onCustomPopoverShow();
+      expect(component.customMode()).toBe('date-range');
+      expect(component.customFromDate().getTime()).toBe(range.startMs);
+      expect(component.customToDate().getTime()).toBe(range.endMs);
+    });
+
+    it('resets to fresh defaults when nothing active', () => {
+      const before = Date.now();
+      component.onCustomPopoverShow();
+      const after = Date.now();
+      expect(component.customHours()).toBe(0);
+      expect(component.customMinutes()).toBe(30);
+      // From defaults to ~now − 30m, To to ~now (allow a small jitter for execution time)
+      const toMs = component.customToDate().getTime();
+      const fromMs = component.customFromDate().getTime();
+      expect(toMs).toBeGreaterThanOrEqual(before);
+      expect(toMs).toBeLessThanOrEqual(after + 50);
+      expect(toMs - fromMs).toBe(30 * 60 * 1000);
+      // maxDate also refreshed
+      expect(component.maxDate().getTime()).toBeGreaterThanOrEqual(before);
+    });
+  });
+});

--- a/angular-client/src/pages/graph-page/graph-caption/general-buttons/general-buttons.component.ts
+++ b/angular-client/src/pages/graph-page/graph-caption/general-buttons/general-buttons.component.ts
@@ -1,4 +1,9 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, signal, ViewChild } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MessageService } from 'primeng/api';
+import { DatePicker } from 'primeng/datepicker';
+import { InputNumberModule } from 'primeng/inputnumber';
+import { Popover } from 'primeng/popover';
 import { SelectorConfig } from 'src/components/select-dropdown/select-dropdown.component';
 import { Run } from 'src/utils/types.utils';
 
@@ -6,17 +11,183 @@ import { RunSelectorComponent } from '../run-selector/run-selector.component';
 import { ButtonComponent } from '../../../../components/argos-button/argos-button.component';
 import { SelectDropdownComponent } from '../../../../components/select-dropdown/select-dropdown.component';
 
+export interface RangePreset {
+  label: string;
+  minutes: number;
+}
+
+/**
+ * Cap custom ranges at 7 days.
+ *
+ * The backend has no server-side limit on time-range queries — a multi-week query at
+ * 1k Hz telemetry would download tens of millions of rows and tank both the API and the
+ * browser. 7 days covers race-day debugging windows and any reasonable post-race review;
+ * anything longer should be a run-based query, not a time-based one.
+ */
+export const MAX_RANGE_MINUTES = 7 * 24 * 60;
+
+type CustomMode = 'last-x' | 'date-range';
+
 @Component({
   selector: 'general-buttons',
   templateUrl: './general-buttons.component.html',
   styleUrl: './general-buttons.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RunSelectorComponent, ButtonComponent, SelectDropdownComponent]
+  imports: [
+    RunSelectorComponent,
+    ButtonComponent,
+    SelectDropdownComponent,
+    Popover,
+    DatePicker,
+    InputNumberModule,
+    FormsModule
+  ]
 })
 export class GeneralButtonsComponent {
+  private toastService = inject(MessageService);
+
   historicalOn = input<boolean>(false);
   onRunSelected = input.required<(run: Run) => void>();
   onClearDataType = input.required<() => void>();
   onSetRealTime = input.required<() => void>();
-  selectorConfig = input.required<SelectorConfig>();
+
+  presets = input.required<RangePreset[]>();
+  selectedPresetMinutes = input<number | undefined>(undefined);
+  // Whether a custom range is currently applied (drives the Custom button highlight + caption).
+  customActive = input<boolean>(false);
+  // Caption shown beneath the Custom button when a custom range is applied (e.g. "Last 1h 30m").
+  // Owned by the parent so the formatting/source-of-truth lives next to the state itself.
+  customCaption = input<string | null>(null);
+  // Active custom range — used by the popover to seed itself on open so users can adjust
+  // the applied values rather than re-entering them.
+  activeLastXMinutes = input<number | undefined>(undefined);
+  activeDateRange = input<{ startMs: number; endMs: number } | undefined>(undefined);
+  onSelectPreset = input.required<(minutes: number) => void>();
+  onApplyCustomLastX = input.required<(totalMinutes: number) => void>();
+  onApplyCustomDateRange = input.required<(startMs: number, endMs: number) => void>();
+
+  @ViewChild('customPopover') customPopover?: Popover;
+
+  customMode = signal<CustomMode>('last-x');
+  customHours = signal<number | null>(0);
+  customMinutes = signal<number | null>(30);
+  customFromDate = signal<Date>(new Date(Date.now() - 30 * 60 * 1000));
+  customToDate = signal<Date>(new Date());
+  maxDate = signal<Date>(new Date());
+
+  // Build the dropdown config from the preset list each time it changes; preserves the
+  // existing select-dropdown contract without leaking it back to the parent.
+  quickSelectConfig = computed<SelectorConfig>(() => ({
+    options: this.presets().map((p) => ({
+      name: p.label,
+      function: () => this.onSelectPreset()(p.minutes)
+    })),
+    placeholder: 'Quick Select'
+  }));
+
+  // The dropdown's defaultValue input matches an option by name, so we look up the label
+  // for the active preset (or undefined when a custom range is active / nothing is picked).
+  selectedPresetLabel = computed<string | undefined>(() => {
+    const minutes = this.selectedPresetMinutes();
+    if (minutes === undefined) return undefined;
+    return this.presets().find((p) => p.minutes === minutes)?.label;
+  });
+
+  toggleCustomPopover = (event?: Event) => {
+    if (event) this.customPopover?.toggle(event);
+  };
+
+  // Refresh the popover contents every time it opens. Without this, the From/To pickers
+  // and `maxDate` go stale (component-init values) once the page has been open a while,
+  // and re-applying the same range fetches data anchored at the wrong "now".
+  onCustomPopoverShow = () => {
+    this.maxDate.set(new Date());
+
+    const lastX = this.activeLastXMinutes();
+    const range = this.activeDateRange();
+    if (lastX !== undefined) {
+      this.customMode.set('last-x');
+      this.customHours.set(Math.floor(lastX / 60));
+      this.customMinutes.set(lastX % 60);
+    } else if (range !== undefined) {
+      this.customMode.set('date-range');
+      this.customFromDate.set(new Date(range.startMs));
+      this.customToDate.set(new Date(range.endMs));
+    } else {
+      // Nothing applied — restore the initial defaults for both modes so prior typing
+      // doesn't linger. Uses fresh "now" for Date Range to avoid wall-clock from page load.
+      this.customHours.set(0);
+      this.customMinutes.set(30);
+      this.customFromDate.set(new Date(Date.now() - 30 * 60 * 1000));
+      this.customToDate.set(new Date());
+    }
+  };
+
+  setCustomMode = (mode: CustomMode) => {
+    this.customMode.set(mode);
+  };
+
+  applyCustomLastX = () => {
+    const hours = this.customHours() ?? 0;
+    const minutes = this.customMinutes() ?? 0;
+    const totalMinutes = Math.floor(hours * 60 + minutes);
+    if (totalMinutes <= 0) {
+      this.toastService.add({
+        severity: 'warn',
+        summary: 'Invalid Range',
+        detail: 'Custom range must be greater than 0 minutes.'
+      });
+      return;
+    }
+    if (totalMinutes > MAX_RANGE_MINUTES) {
+      this.toastService.add({
+        severity: 'warn',
+        summary: 'Range Too Large',
+        detail: `Custom range capped at ${MAX_RANGE_MINUTES / (24 * 60)} days.`
+      });
+      return;
+    }
+    this.onApplyCustomLastX()(totalMinutes);
+  };
+
+  applyCustomDateRange = () => {
+    const from = this.customFromDate();
+    const to = this.customToDate();
+    const now = Date.now();
+    if (!from || !to) {
+      this.toastService.add({
+        severity: 'warn',
+        summary: 'Invalid Range',
+        detail: 'Pick both a start and end time.'
+      });
+      return;
+    }
+    const startMs = from.getTime();
+    const endMs = to.getTime();
+    if (startMs >= endMs) {
+      this.toastService.add({
+        severity: 'warn',
+        summary: 'Invalid Range',
+        detail: 'Start must be before end.'
+      });
+      return;
+    }
+    if (endMs > now + 60 * 1000) {
+      this.toastService.add({
+        severity: 'warn',
+        summary: 'Invalid Range',
+        detail: 'End time cannot be in the future.'
+      });
+      return;
+    }
+    if (endMs - startMs > MAX_RANGE_MINUTES * 60 * 1000) {
+      this.toastService.add({
+        severity: 'warn',
+        summary: 'Range Too Large',
+        detail: `Custom range capped at ${MAX_RANGE_MINUTES / (24 * 60)} days.`
+      });
+      return;
+    }
+    this.onApplyCustomDateRange()(startMs, endMs);
+  };
 }

--- a/angular-client/src/pages/graph-page/graph-caption/run-selector/run-selector.component.html
+++ b/angular-client/src/pages/graph-page/graph-caption/run-selector/run-selector.component.html
@@ -1,1 +1,1 @@
-<argos-button [onClick]="openDialog" [label]="label" additionalStyles="background-color: #027bd7" />
+<argos-button [onClick]="openDialog" [label]="label" size="sm" additionalStyles="background-color: #027bd7" />

--- a/angular-client/src/pages/graph-page/graph-page.component.html
+++ b/angular-client/src/pages/graph-page/graph-page.component.html
@@ -15,18 +15,21 @@
             <argos-button
               [onClick]="this.toggleSideBar"
               label="Tog Sidebar"
-              additionalStyles="background-color: #0c2026; border: 1.4px solid #8fcadd; width: 80px;"
+              size="sm"
+              additionalStyles="background-color: #0c2026; border: 1.4px solid #8fcadd;"
             />
             <argos-button
               [onClick]="this.toggleMultiYaxis"
               label="Tog Mult Yaxis"
-              additionalStyles="background-color: #0c2026; border: 1.4px solid #8fcadd; width: 80px;"
+              size="sm"
+              additionalStyles="background-color: #0c2026; border: 1.4px solid #8fcadd;"
             />
             @if (realTime === true) {
               <argos-button
                 [onClick]="this.togglePause"
                 [label]="isPaused ? 'Play' : 'Pause'"
-                additionalStyles="background-color: #0c2026; border: 1.4px solid #8fcadd; width: 50px;"
+                size="sm"
+                additionalStyles="background-color: #0c2026; border: 1.4px solid #8fcadd;"
               />
             }
           </div>
@@ -37,7 +40,8 @@
               <argos-button
                 [onClick]="this.toggleRangeMode"
                 [label]="rangeMode === 'time' ? 'Time Range' : 'Point Range'"
-                additionalStyles="background-color: #0c2026; border: 1.4px solid #8fcadd; width: 90px; font-size: 11px;"
+                size="sm"
+                additionalStyles="background-color: #0c2026; border: 1.4px solid #8fcadd;"
               />
               <label class="input-label">{{ rangeMode === 'time' ? 'X (sec):' : 'X (points):' }}</label>
               <p-inputNumber
@@ -57,6 +61,9 @@
             <label class="input-label">Y Min:</label>
             <p-inputNumber
               [(ngModel)]="yAxisMin"
+              mode="decimal"
+              [minFractionDigits]="0"
+              [maxFractionDigits]="4"
               styleClass="y-axis-input"
               inputStyleClass="text-xs p-1"
               placeholder="Auto"
@@ -66,6 +73,9 @@
             <label class="input-label">Y Max:</label>
             <p-inputNumber
               [(ngModel)]="yAxisMax"
+              mode="decimal"
+              [minFractionDigits]="0"
+              [maxFractionDigits]="4"
               styleClass="y-axis-input"
               inputStyleClass="text-xs p-1"
               placeholder="Auto"
@@ -81,8 +91,16 @@
                 [onRunSelected]="onRunSelected"
                 [onClearDataType]="clearDataType"
                 [onSetRealTime]="onSetRealtime"
-                [historicalOn]="this.run !== undefined || this.minutesToQuery !== undefined"
-                [selectorConfig]="this.queryMinutesConfig"
+                [historicalOn]="this.run !== undefined || this.historicalRangeActive()"
+                [presets]="rangePresets"
+                [selectedPresetMinutes]="selectedPresetMinutes()"
+                [customActive]="customRangeActive()"
+                [customCaption]="customRangeCaption()"
+                [activeLastXMinutes]="customLastXMinutes()"
+                [activeDateRange]="customDateRange()"
+                [onSelectPreset]="onSelectPreset"
+                [onApplyCustomLastX]="onApplyCustomLastX"
+                [onApplyCustomDateRange]="onApplyCustomDateRange"
               />
             }
           </div>

--- a/angular-client/src/pages/graph-page/graph-page.component.ts
+++ b/angular-client/src/pages/graph-page/graph-page.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { ChangeDetectorRef, Component, computed, OnDestroy, OnInit, signal, inject } from '@angular/core';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { MessageService } from 'primeng/api';
 import { BehaviorSubject, Subscription } from 'rxjs';
@@ -6,7 +6,6 @@ import { getDataByDatatTypeNameAndTiming, getDataByDataTypeNameAndRunId } from '
 import { getAllDatatypes } from 'src/api/datatype.api';
 import { getAllRuns } from 'src/api/run.api';
 import { appRoutes } from 'src/app/app-routing.module';
-import { SelectorConfig } from 'src/components/select-dropdown/select-dropdown.component';
 import APIService from 'src/services/api.service';
 import { FaultService } from 'src/services/fault.service';
 import Storage from 'src/services/storage.service';
@@ -15,7 +14,7 @@ import { DataValue } from 'src/utils/socket.utils';
 import { DataType, FaultData, GraphData, ObservableGraphInfo, Run } from 'src/utils/types.utils';
 import { ButtonComponent } from '../../components/argos-button/argos-button.component';
 import { FaultButtonsComponent } from './graph-caption/fault-buttons/fault-buttons.component';
-import { GeneralButtonsComponent } from './graph-caption/general-buttons/general-buttons.component';
+import { GeneralButtonsComponent, RangePreset } from './graph-caption/general-buttons/general-buttons.component';
 import GraphSidebarComponent from './graph-sidebar/graph-sidebar.component';
 import CustomGraphComponent from './graph/graph.component';
 import LiveValueStripComponent from './live-value-strip/live-value-strip.component';
@@ -86,7 +85,12 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
   // GRAPH State variables
   realTime: boolean = true;
   run?: Run;
-  minutesToQuery: number | undefined = undefined;
+  // Historical-range state. Exactly one of these is set when the user is in historical mode.
+  // Signals so derived computeds and downstream OnPush children update reliably even if
+  // graph-page itself is later switched to OnPush change detection.
+  selectedPresetMinutes = signal<number | undefined>(undefined);
+  customLastXMinutes = signal<number | undefined>(undefined);
+  customDateRange = signal<{ startMs: number; endMs: number } | undefined>(undefined);
   showMultiYaxis = false;
   toggleMultiYaxis = () => {
     this.showMultiYaxis = !this.showMultiYaxis;
@@ -96,54 +100,38 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
     this.isPaused = !this.isPaused;
   };
 
-  // Selector config for querying time ranges form now.
-  queryMinutesConfig: SelectorConfig = {
-    options: [
-      {
-        name: '1 minute',
-        function: () => {
-          this.onQueryTimeSelected(1);
-        }
-      },
-      {
-        name: '2 minutes',
-        function: () => {
-          this.onQueryTimeSelected(2);
-        }
-      },
-      {
-        name: '5 minutes',
-        function: () => {
-          this.onQueryTimeSelected(5);
-        }
-      },
-      {
-        name: '10 minutes',
-        function: () => {
-          this.onQueryTimeSelected(10);
-        }
-      },
-      {
-        name: '15 minutes',
-        function: () => {
-          this.onQueryTimeSelected(15);
-        }
-      },
-      {
-        name: '30 minutes',
-        function: () => {
-          this.onQueryTimeSelected(30);
-        }
-      },
-      {
-        name: '1 hour',
-        function: () => {
-          this.onQueryTimeSelected(60);
-        }
-      }
-    ],
-    placeholder: 'Select Range'
-  };
+  rangePresets: RangePreset[] = [
+    { label: '1 minute', minutes: 1 },
+    { label: '2 minutes', minutes: 2 },
+    { label: '5 minutes', minutes: 5 },
+    { label: '10 minutes', minutes: 10 },
+    { label: '15 minutes', minutes: 15 },
+    { label: '30 minutes', minutes: 30 },
+    { label: '1 hour', minutes: 60 },
+    { label: '2 hours', minutes: 120 },
+    { label: '4 hours', minutes: 240 },
+    { label: '8 hours', minutes: 480 },
+    { label: '24 hours', minutes: 1440 }
+  ];
+
+  historicalRangeActive = computed<boolean>(
+    () =>
+      this.selectedPresetMinutes() !== undefined ||
+      this.customLastXMinutes() !== undefined ||
+      this.customDateRange() !== undefined
+  );
+
+  customRangeActive = computed<boolean>(
+    () => this.customLastXMinutes() !== undefined || this.customDateRange() !== undefined
+  );
+
+  customRangeCaption = computed<string | null>(() => {
+    const lastX = this.customLastXMinutes();
+    if (lastX !== undefined) return `Last ${this.formatMinutes(lastX)}`;
+    const range = this.customDateRange();
+    if (range !== undefined) return this.formatDateRange(range.startMs, range.endMs);
+    return null;
+  });
 
   // store the values for each selected data type.
   // When we are in live mode the data  is constantly udpated.
@@ -249,7 +237,7 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
     this.realTime = true;
     this.selectedFault = undefined;
     this.renderFaultPage = false;
-    this.minutesToQuery = undefined;
+    this.clearHistoricalRangeState();
     this.rightHeader = `Real Time`;
 
     const runsQueryResponse = this.serverService.query<Run[]>(() => getAllRuns(), { queryKey: ['runs'] });
@@ -275,7 +263,7 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
   };
   private initFaultPage = () => {
     this.renderFaultPage = true;
-    this.minutesToQuery = undefined;
+    this.clearHistoricalRangeState();
 
     const selectedFaultSubscription = this.faultService.getSelectedFault();
     this.selectedFault = selectedFaultSubscription.value;
@@ -286,7 +274,13 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
     this.rightHeader = `Fault: ${this.selectedFault?.name}`;
   };
 
-  // reset shit when a run is selected.
+  private clearHistoricalRangeState() {
+    this.selectedPresetMinutes.set(undefined);
+    this.customLastXMinutes.set(undefined);
+    this.customDateRange.set(undefined);
+  }
+
+  // Reset graph state and switch into Run mode when a run is selected.
   onRunSelected = (run: Run) => {
     this.isPaused = false;
 
@@ -295,7 +289,7 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
 
     this.run = run;
     this.realTime = false;
-    this.minutesToQuery = undefined;
+    this.clearHistoricalRangeState();
     this.selectedDataTypeValuesSubject = [];
     this.selectedDataTypeValuesIsLoading = false;
     this.selectedDataTypeValuesIsError = false;
@@ -307,23 +301,61 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
     this.processDataTypeSelection(currentSelection);
   };
 
-  onQueryTimeSelected = (queryTime: number) => {
-    // Clear existing state first
-    this.clearDataType();
-
+  private startHistoricalQuery() {
     this.isPaused = false;
     this.run = undefined;
-    this.minutesToQuery = queryTime;
     this.realTime = false;
     this.selectedDataTypeValuesIsLoading = false;
     this.selectedDataTypeValuesIsError = false;
     this.selectedDataTypeValuesError = undefined;
-    this.rightHeader = 'Hist Range';
+    this.rightHeader = 'Historical';
 
     // Re-apply current selection from service to trigger data load for this time range
     const currentSelection = this.topicSelectionService.getSelectedDataTypes().value;
     this.processDataTypeSelection(currentSelection);
+  }
+
+  onSelectPreset = (minutes: number) => {
+    this.clearDataType();
+    this.clearHistoricalRangeState();
+    this.selectedPresetMinutes.set(minutes);
+    this.startHistoricalQuery();
   };
+
+  onApplyCustomLastX = (totalMinutes: number) => {
+    this.clearDataType();
+    this.clearHistoricalRangeState();
+    this.customLastXMinutes.set(totalMinutes);
+    this.startHistoricalQuery();
+  };
+
+  onApplyCustomDateRange = (startMs: number, endMs: number) => {
+    this.clearDataType();
+    this.clearHistoricalRangeState();
+    this.customDateRange.set({ startMs, endMs });
+    this.startHistoricalQuery();
+  };
+
+  private formatMinutes(mins: number): string {
+    if (mins < 60) return `${mins}m`;
+    const h = Math.floor(mins / 60);
+    const m = mins % 60;
+    return m === 0 ? `${h}h` : `${h}h ${m}m`;
+  }
+
+  private formatDateRange(startMs: number, endMs: number): string {
+    const start = new Date(startMs);
+    const end = new Date(endMs);
+    const sameDay =
+      start.getFullYear() === end.getFullYear() && start.getMonth() === end.getMonth() && start.getDate() === end.getDate();
+    const dateOpts: Intl.DateTimeFormatOptions = { month: 'numeric', day: 'numeric' };
+    const timeOpts: Intl.DateTimeFormatOptions = { hour: '2-digit', minute: '2-digit', hour12: false };
+    const startStr = `${start.toLocaleDateString('en-US', dateOpts)} ${start.toLocaleTimeString('en-US', timeOpts)}`;
+    const endStr = sameDay
+      ? end.toLocaleTimeString('en-US', timeOpts)
+      : `${end.toLocaleDateString('en-US', dateOpts)} ${end.toLocaleTimeString('en-US', timeOpts)}`;
+    return `${startStr} → ${endStr}`;
+  }
 
   // get real time ready
   onSetRealtime = () => {
@@ -332,7 +364,11 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
 
     this.run = undefined;
     this.realTime = true;
-    this.minutesToQuery = undefined;
+    // Clear pause explicitly: today the only path back to RT is via the historical-mode
+    // Realtime button (which goes through startHistoricalQuery — also clears pause), but
+    // making the reset explicit here keeps the invariant local to the transition itself.
+    this.isPaused = false;
+    this.clearHistoricalRangeState();
     this.selectedDataTypeValuesSubject = [];
     this.selectedDataTypeValuesIsLoading = false;
     this.selectedDataTypeValuesIsError = false;
@@ -435,12 +471,25 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
       let queryFn: () => Promise<Response>;
       if (this.run !== undefined) {
         queryFn = () => getDataByDataTypeNameAndRunId(dataType.name, this.run!.id);
-      } else if (this.minutesToQuery !== undefined) {
-        const realMinutes = this.minutesToQuery;
+      } else if (this.customDateRange() !== undefined) {
+        // Anchor the lookback at endMs and treat the span as `before` minutes. The backend's
+        // Timing payload is minute-granularity, so we ceil; this can return up to ~60s of
+        // extra data on the start side relative to the picker (which exposes seconds), which
+        // is preferable to losing data — a "5:00:30 → 5:05:15" pick fetches "5:00:15 → 5:05:15".
+        const { startMs, endMs } = this.customDateRange()!;
+        const beforeMinutes = Math.max(1, Math.ceil((endMs - startMs) / 60000));
+        queryFn = () =>
+          getDataByDatatTypeNameAndTiming(dataType.name, {
+            time: endMs,
+            before: beforeMinutes,
+            after: 0
+          });
+      } else if (this.selectedPresetMinutes() !== undefined || this.customLastXMinutes() !== undefined) {
+        const minutes = (this.selectedPresetMinutes() ?? this.customLastXMinutes())!;
         queryFn = () =>
           getDataByDatatTypeNameAndTiming(dataType.name, {
             time: new Date().getTime(),
-            before: realMinutes,
+            before: minutes,
             after: 0
           });
       } else {
@@ -516,7 +565,7 @@ export default class GraphPageComponent implements OnInit, OnDestroy {
 
     if (this.realTime) {
       this.processRealTimeDataTypeSelection(dataTypes);
-    } else if (this.run !== undefined || this.selectedFault !== undefined || this.minutesToQuery !== undefined) {
+    } else if (this.run !== undefined || this.selectedFault !== undefined || this.historicalRangeActive()) {
       this.processHistoricalDataTypeSelection(dataTypes); // ← pass whole array
     } else {
       this.toastService.add({

--- a/angular-client/src/pages/graph-page/graph/graph.component.ts
+++ b/angular-client/src/pages/graph-page/graph/graph.component.ts
@@ -9,7 +9,8 @@ import {
   ApexTooltip,
   ApexFill,
   ApexLegend,
-  ApexYAxis
+  ApexYAxis,
+  ApexAnnotations
 } from 'ng-apexcharts';
 import { Subscription } from 'rxjs';
 import { binarySearchInsertIndex } from 'src/utils/array.utils';
@@ -26,7 +27,10 @@ type ChartOptions = {
   fill: ApexFill;
   stroke: ApexStroke;
   legend?: ApexLegend; // Add legend property to match the options object
+  annotations?: ApexAnnotations;
 };
+
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 @Component({
   selector: 'graph',
@@ -185,6 +189,11 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
       effectiveRange = this.graphConfig().rangeMode === 'time' ? this.graphConfig().timeRangeMs : this.timeRangeMs;
     }
 
+    // Multi-day historical ranges get date-aware labels and per-day boundary annotations.
+    // Skip the O(N) span scan in real-time mode — realtime ranges are bounded and never multi-day.
+    const span = this.realTime() ? null : this.computeDataSpan();
+    const isMultiDay = !!span && span.spanMs > DAY_MS;
+
     // Single updateOptions call with series included — avoids two separate re-renders
     // Pass false, false to skip animation bookkeeping (getPreviousPaths) and animate flag
     this.chart.updateOptions(
@@ -193,13 +202,65 @@ export default class CustomGraphComponent implements OnInit, OnDestroy {
         series,
         xaxis: {
           ...this.options.xaxis,
-          range: effectiveRange
-        }
+          range: effectiveRange,
+          labels: {
+            ...this.options.xaxis.labels,
+            formatter: isMultiDay ? this.multiDayLabelFormatter : this.singleDayLabelFormatter
+          }
+        },
+        annotations: { xaxis: isMultiDay ? this.buildDayBoundaryAnnotations(span!) : [] }
       },
       false, // redraw (default is false)
       false // animate (default is true)
     );
   };
+
+  private computeDataSpan(): { minX: number; maxX: number; spanMs: number } | null {
+    let minX = Infinity;
+    let maxX = -Infinity;
+    for (const points of this.data.values()) {
+      if (points.length === 0) continue;
+      // Series data is kept sorted by x (see graphInfoCallback), so endpoints are the extrema.
+      if (points[0].x < minX) minX = points[0].x;
+      if (points[points.length - 1].x > maxX) maxX = points[points.length - 1].x;
+    }
+    if (!isFinite(minX) || !isFinite(maxX)) return null;
+    return { minX, maxX, spanMs: maxX - minX };
+  }
+
+  private singleDayLabelFormatter = (val: string | number): string =>
+    new Date(+val).toLocaleTimeString('en-US', { hour12: false });
+
+  private multiDayLabelFormatter = (val: string | number): string => {
+    const d = new Date(+val);
+    const date = d.toLocaleDateString('en-US', { month: 'numeric', day: 'numeric' });
+    const time = d.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit' });
+    return `${date} ${time}`;
+  };
+
+  private buildDayBoundaryAnnotations(span: { minX: number; maxX: number }) {
+    const annotations: { x: number; strokeDashArray: number; borderColor: string; label: object }[] = [];
+    // First local-midnight strictly after minX.
+    const cursor = new Date(span.minX);
+    cursor.setHours(24, 0, 0, 0);
+    for (let t = cursor.getTime(); t < span.maxX; t += DAY_MS) {
+      const date = new Date(t);
+      annotations.push({
+        x: t,
+        strokeDashArray: 4,
+        borderColor: '#8fcadd',
+        label: {
+          borderColor: '#8fcadd',
+          style: { color: '#fff', background: '#0c2026', fontSize: '11px' },
+          orientation: 'horizontal',
+          position: 'top',
+          offsetY: -4,
+          text: date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })
+        }
+      });
+    }
+    return annotations;
+  }
 
   graphInfoCallback = (info: GraphInfo) => {
     // Skip processing if paused


### PR DESCRIPTION
## Changes

Adds custom historical-range UI to the graph page: a popover-driven Custom button (Last X hours+minutes, or absolute From/To Date Range with seconds) sitting next to a Quick Select dropdown of presets (1m–24h). Multi-day historical spans get date-aware x-axis labels and a dashed midnight annotation per day boundary. Y Min / Y Max accept up to 4 fractional digits.

Compact toolbar treatment: argos-button gains a size: 'default' | 'sm' input (class-driven, no per-call width hacks) applied across the toolbar. Historical-range state on graph-page migrated to signals/computeds so derived values flow correctly into the OnPush general-buttons child.

## Notes

- Backend Timing payload is minute-granularity, so Date Range queries ceil the span and anchor at endMs. Picker exposes seconds; this can return up to ~60s of extra data on the start side, preferred to losing data.
- Ranges capped at 7 days (MAX_RANGE_MINUTES). Past that the API + browser bog down on multi-million-row payloads; longer windows belong on a run-based query.
- Custom popover refreshes its From/To, hours/minutes, and maxDate every time it opens — without that the values go stale relative to wall-clock once the page has been open a while, and re-applying the same range fetches the wrong "now."
- select-dropdown now clears its selected option when defaultValue becomes undefined (graph-page deselects the active preset when Custom is applied). All current callers pass static values, so no behavior change for them. Comment in select-dropdown.component.ts explains the contract.
- TODO left in general-buttons.component.css: select-dropdown.component.css uses !important for sizing rules that should be per-call-site, not global. Cleaning that up would let consumers drop the local !important overrides.

## Test Cases

- Real Time → preset → Real Time round-trip; chart resets to the configured 30s window, no leakage from the 5min historical span
- paused Real Time → historical → Real Time clears pause state and resumes data flow
- Each preset (1m–24h) and Custom Last X queries the right window; observed spans within ~6s of requested for fully-covered windows, with shorter spans correctly explained by data sparsity (run started mid-window)
- Custom Date Range with same-day vs cross-day formatting renders the matching caption (Last 4h 30m vs 4/25 14:30 → 16:45 vs 4/25 14:30 → 4/26 02:10)
- Re-opening Custom seeds the popover from the active range (Last X or Date Range), or resets to fresh defaults when nothing is applied; verified defaults shift over time
- Validation rejects 0/0, from ≥ to, end > now+1m, and span > 7d with toasts and no callback emission
- Multi-day historical span (>24h) switches x-axis to date+time labels with dashed midnight annotations
- Other select-dropdown call sites (BMS page, charging, landing) render unchanged

## Screenshots

_screenshot pending_

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No package-lock.json changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #627
