### PR TITLE
Standardize rule endpoint client identification

### DIFF
--- a/angular-client/src/api/rules.api.ts
+++ b/angular-client/src/api/rules.api.ts
@@ -21,21 +21,24 @@ export interface RulesResponse {
   client_rules: ClientRule[];
 }
 
+const clientIdHeader = (clientId: string): Record<string, string> => ({ 'X-Client-Id': clientId });
+
 export const getRulesByClientId = (clientId: string): Promise<Response> => {
-  return fetch(urls.getRulesByClientId(clientId));
+  return fetch(urls.getRulesWithSubscriptionStatus(), { headers: clientIdHeader(clientId) });
 };
 
 export const addRule = (clientId: string, rule: RulePayload): Promise<Response> => {
-  return fetch(urls.addRule(clientId), {
+  return fetch(urls.addRule(), {
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...clientIdHeader(clientId) },
     body: JSON.stringify(rule)
   });
 };
 
 export const deleteRule = (clientId: string, ruleId: string): Promise<Response> => {
-  return fetch(urls.deleteRule(clientId, ruleId), {
-    method: 'POST'
+  return fetch(urls.deleteRule(ruleId), {
+    method: 'POST',
+    headers: clientIdHeader(clientId)
   });
 };
 
@@ -48,17 +51,17 @@ export const editRule = (ruleId: string, rule: object): Promise<Response> => {
 };
 
 export const subscribeToRules = (clientId: string, ruleIds: string[]): Promise<Response> => {
-  return fetch(urls.subscribeToRule(clientId), {
+  return fetch(urls.subscribeToRule(), {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...clientIdHeader(clientId) },
     body: JSON.stringify(ruleIds)
   });
 };
 
 export const unsubscribeFromRules = (clientId: string, ruleIds: string[]): Promise<Response> => {
-  return fetch(urls.unsubscribeFromRule(clientId), {
+  return fetch(urls.unsubscribeFromRule(), {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...clientIdHeader(clientId) },
     body: JSON.stringify(ruleIds)
   });
 };

--- a/angular-client/src/api/rules.api.ts
+++ b/angular-client/src/api/rules.api.ts
@@ -21,27 +21,21 @@ export interface RulesResponse {
   client_rules: ClientRule[];
 }
 
-const basicAuthHeader = (clientId: string): string => 'Basic ' + btoa(`${clientId}:`);
-
 export const getRulesByClientId = (clientId: string): Promise<Response> => {
   return fetch(urls.getRulesByClientId(clientId));
 };
 
 export const addRule = (clientId: string, rule: RulePayload): Promise<Response> => {
-  return fetch(urls.addRule(), {
+  return fetch(urls.addRule(clientId), {
     method: 'PUT',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: basicAuthHeader(clientId)
-    },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(rule)
   });
 };
 
 export const deleteRule = (clientId: string, ruleId: string): Promise<Response> => {
-  return fetch(urls.deleteRule(ruleId), {
-    method: 'POST',
-    headers: { Authorization: basicAuthHeader(clientId) }
+  return fetch(urls.deleteRule(clientId, ruleId), {
+    method: 'POST'
   });
 };
 
@@ -53,23 +47,18 @@ export const editRule = (ruleId: string, rule: object): Promise<Response> => {
   });
 };
 
-export interface RuleSubscriptionRequest {
-  rule_ids: string[];
-  client_id: string;
-}
-
-export const subscribeToRules = (request: RuleSubscriptionRequest): Promise<Response> => {
-  return fetch(urls.subscribeToRule(), {
+export const subscribeToRules = (clientId: string, ruleIds: string[]): Promise<Response> => {
+  return fetch(urls.subscribeToRule(clientId), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(request)
+    body: JSON.stringify(ruleIds)
   });
 };
 
-export const unsubscribeFromRules = (request: RuleSubscriptionRequest): Promise<Response> => {
-  return fetch(urls.unsubscribeFromRule(), {
+export const unsubscribeFromRules = (clientId: string, ruleIds: string[]): Promise<Response> => {
+  return fetch(urls.unsubscribeFromRule(clientId), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(request)
+    body: JSON.stringify(ruleIds)
   });
 };

--- a/angular-client/src/api/urls.ts
+++ b/angular-client/src/api/urls.ts
@@ -37,11 +37,11 @@ const carCommandConfig = (key: string, values: number[]) =>
 
 /* Rules */
 const getRulesByClientId = (clientId: string) => `${baseURL}/rules/${clientId}`;
-const addRule = () => `${baseURL}/rules/add`;
-const deleteRule = (ruleId: string) => `${baseURL}/rules/delete/${ruleId}`;
+const addRule = (clientId: string) => `${baseURL}/rules/${clientId}/add`;
+const deleteRule = (clientId: string, ruleId: string) => `${baseURL}/rules/${clientId}/delete/${ruleId}`;
 const editRule = (ruleId: string) => `${baseURL}/rules/edit/${ruleId}`;
-const subscribeToRule = () => `${baseURL}/rules/subscribe`;
-const unsubscribeFromRule = () => `${baseURL}/rules/unsubscribe`;
+const subscribeToRule = (clientId: string) => `${baseURL}/rules/${clientId}/subscribe`;
+const unsubscribeFromRule = (clientId: string) => `${baseURL}/rules/${clientId}/unsubscribe`;
 
 /* Authentication */
 const authenticate = () => `${baseURL}/authenticate`;

--- a/angular-client/src/api/urls.ts
+++ b/angular-client/src/api/urls.ts
@@ -35,13 +35,13 @@ const updateVideos = () => `${getAllVideos()}/update`;
 const carCommandConfig = (key: string, values: number[]) =>
   `${baseURL}/config/set/${key}?${values.map((value) => `data=${value}`).join('&')}`;
 
-/* Rules */
-const getRulesByClientId = (clientId: string) => `${baseURL}/rules/${clientId}`;
-const addRule = (clientId: string) => `${baseURL}/rules/${clientId}/add`;
-const deleteRule = (clientId: string, ruleId: string) => `${baseURL}/rules/${clientId}/delete/${ruleId}`;
+/* Rules — client id travels in the X-Client-Id header, not the path */
+const getRulesWithSubscriptionStatus = () => `${baseURL}/rules/subscription-status`;
+const addRule = () => `${baseURL}/rules/add`;
+const deleteRule = (ruleId: string) => `${baseURL}/rules/delete/${ruleId}`;
 const editRule = (ruleId: string) => `${baseURL}/rules/edit/${ruleId}`;
-const subscribeToRule = (clientId: string) => `${baseURL}/rules/${clientId}/subscribe`;
-const unsubscribeFromRule = (clientId: string) => `${baseURL}/rules/${clientId}/unsubscribe`;
+const subscribeToRule = () => `${baseURL}/rules/subscribe`;
+const unsubscribeFromRule = () => `${baseURL}/rules/unsubscribe`;
 
 /* Authentication */
 const authenticate = () => `${baseURL}/authenticate`;
@@ -76,7 +76,7 @@ export const urls = {
 
   carCommandConfig,
 
-  getRulesByClientId,
+  getRulesWithSubscriptionStatus,
   addRule,
   deleteRule,
   editRule,

--- a/angular-client/src/pages/notification-rules-page/notification-rules-page.component.ts
+++ b/angular-client/src/pages/notification-rules-page/notification-rules-page.component.ts
@@ -142,10 +142,10 @@ export default class NotificationRulesPageComponent implements OnInit {
     try {
       const promises: Promise<Response>[] = [];
       if (toSubscribe.length > 0) {
-        promises.push(subscribeToRules({ rule_ids: toSubscribe, client_id: this.clientId }));
+        promises.push(subscribeToRules(this.clientId, toSubscribe));
       }
       if (toUnsubscribe.length > 0) {
-        promises.push(unsubscribeFromRules({ rule_ids: toUnsubscribe, client_id: this.clientId }));
+        promises.push(unsubscribeFromRules(this.clientId, toUnsubscribe));
       }
 
       const results = await Promise.all(promises);

--- a/angular-client/src/pages/notification-rules-page/rules-table/rules-table.component.ts
+++ b/angular-client/src/pages/notification-rules-page/rules-table/rules-table.component.ts
@@ -73,9 +73,11 @@ export class RulesTableComponent implements OnInit {
   }
 
   async onToggleSubscription(rule: ClientRule, subscribed: boolean): Promise<void> {
-    const request = { rule_ids: [rule.id], client_id: this.clientId() };
+    const ruleIds = [rule.id];
     try {
-      const response = subscribed ? await subscribeToRules(request) : await unsubscribeFromRules(request);
+      const response = subscribed
+        ? await subscribeToRules(this.clientId(), ruleIds)
+        : await unsubscribeFromRules(this.clientId(), ruleIds);
       if (response.ok) {
         this.rules.update((rules) => rules.map((r) => (r.id === rule.id ? { ...r, is_subscribed: subscribed } : r)));
       } else {

--- a/scylla-server/Cargo.lock
+++ b/scylla-server/Cargo.lock
@@ -202,7 +202,6 @@ dependencies = [
  "form_urlencoded",
  "futures-core",
  "futures-util",
- "headers",
  "http",
  "http-body",
  "http-body-util",
@@ -1033,30 +1032,6 @@ dependencies = [
  "flate2",
  "nom",
  "num-traits",
-]
-
-[[package]]
-name = "headers"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "headers-core",
- "http",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
-dependencies = [
- "http",
 ]
 
 [[package]]

--- a/scylla-server/Cargo.toml
+++ b/scylla-server/Cargo.toml
@@ -22,7 +22,7 @@ tracing = "0.1.43"
 tracing-subscriber = { version = "0.3.23", features = ["ansi", "env-filter"] }
 console-subscriber = { version = "0.5.0", optional = true }
 ringbuffer = "0.16.0"
-axum-extra = { version = "0.12.5", features = ["query", "typed-header"] }
+axum-extra = { version = "0.12.5", features = ["query"] }
 clap = { version = "4.6.0", features = ["derive", "env"] }
 chrono = { version = "0.4.43", features = ["serde"] }
 serde_json = "1.0.149"

--- a/scylla-server/src/controllers/rule_controller.rs
+++ b/scylla-server/src/controllers/rule_controller.rs
@@ -19,6 +19,7 @@ use crate::{
 const CLIENT_ID_HEADER: &str = "x-client-id";
 
 /// client id comes from the x-client-id header, keeping it out of conflict-prone route paths
+/// extractor pattern: <https://docs.rs/axum/latest/axum/extract/index.html#defining-custom-extractors>
 impl<S> FromRequestParts<S> for ClientId
 where
     S: Send + Sync,

--- a/scylla-server/src/controllers/rule_controller.rs
+++ b/scylla-server/src/controllers/rule_controller.rs
@@ -1,6 +1,10 @@
 use std::sync::Arc;
 
-use axum::{Extension, Json, debug_handler, extract::Path};
+use axum::{
+    Extension, Json, debug_handler,
+    extract::{FromRequestParts, Path},
+    http::{StatusCode, request::Parts},
+};
 use serde::Deserialize;
 use serde_with::DurationSeconds;
 use serde_with::serde_as;
@@ -12,14 +16,39 @@ use crate::{
     rule_structs::{ClientId, Rule, RuleId, RuleManager, RulesResponse},
 };
 
+const CLIENT_ID_HEADER: &str = "x-client-id";
+
+/// client id comes from the x-client-id header, keeping it out of conflict-prone route paths
+impl<S> FromRequestParts<S> for ClientId
+where
+    S: Send + Sync,
+{
+    type Rejection = ScyllaError;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        parts
+            .headers
+            .get(CLIENT_ID_HEADER)
+            .and_then(|value| value.to_str().ok())
+            .filter(|value| !value.is_empty())
+            .map(|value| ClientId(value.to_owned()))
+            .ok_or_else(|| {
+                ScyllaError::HttpError(
+                    StatusCode::BAD_REQUEST,
+                    format!("Missing or empty {CLIENT_ID_HEADER} header"),
+                )
+            })
+    }
+}
+
 #[debug_handler]
 pub async fn add_rule(
-    Path(client_id): Path<String>,
+    client_id: ClientId,
     Extension(rules_manager): Extension<Arc<RuleManager>>,
     Json(rule): Json<Rule>,
 ) -> Result<Json<String>, ScyllaError> {
     info!("Incoming rules reg: {}, from {}", rule.topic, client_id);
-    match rules_manager.add_rule(ClientId(client_id), rule).await {
+    match rules_manager.add_rule(client_id, rule).await {
         Ok(_) => Ok(Json::from("Rule added!".to_owned())),
         Err(err) => Err(ScyllaError::RuleError(err)),
     }
@@ -27,14 +56,12 @@ pub async fn add_rule(
 
 #[debug_handler]
 pub async fn delete_rule(
-    Path((client_id, rule_id)): Path<(String, String)>,
+    client_id: ClientId,
+    Path(rule_id): Path<String>,
     Extension(rules_manager): Extension<Arc<RuleManager>>,
 ) -> Result<(), ScyllaError> {
     info!("Incoming rules del: {}, from {}", rule_id, client_id);
-    match rules_manager
-        .delete_rule(ClientId(client_id), RuleId(rule_id))
-        .await
-    {
+    match rules_manager.delete_rule(client_id, RuleId(rule_id)).await {
         Ok(_) => Ok(()),
         Err(err) => Err(ScyllaError::RuleError(err)),
     }
@@ -50,22 +77,22 @@ pub async fn get_all_rules(
 
 #[debug_handler]
 pub async fn get_client_subscribed_rules(
-    Path(client_id): Path<String>,
+    client_id: ClientId,
     Extension(rules_manager): Extension<Arc<RuleManager>>,
 ) -> Json<Vec<Rule>> {
     debug!("Fetching subscribed rules for client {}", client_id);
-    Json(rules_manager.get_client_rules(ClientId(client_id)).await)
+    Json(rules_manager.get_client_rules(client_id).await)
 }
 
 #[debug_handler]
 pub async fn get_all_rules_with_client_info(
-    Path(client_id): Path<String>,
+    client_id: ClientId,
     Extension(rules_manager): Extension<Arc<RuleManager>>,
 ) -> Result<Json<RulesResponse>, ScyllaError> {
     debug!("Fetching all rules");
     Ok(Json(
         rules_manager
-            .get_all_rules_with_subscription_status(ClientId(client_id))
+            .get_all_rules_with_subscription_status(client_id)
             .await,
     ))
 }
@@ -104,7 +131,7 @@ pub async fn edit_rule(
 
 #[debug_handler]
 pub async fn unsubscribe_rules(
-    Path(client_id): Path<String>,
+    client_id: ClientId,
     Extension(rules_manager): Extension<Arc<RuleManager>>,
     Json(rule_ids): Json<Vec<String>>,
 ) -> Result<Json<String>, ScyllaError> {
@@ -116,10 +143,7 @@ pub async fn unsubscribe_rules(
 
     let rule_ids: Vec<RuleId> = rule_ids.into_iter().map(RuleId).collect();
 
-    match rules_manager
-        .unsubscribe_rules(ClientId(client_id), rule_ids)
-        .await
-    {
+    match rules_manager.unsubscribe_rules(client_id, rule_ids).await {
         Ok(_) => Ok(Json::from(
             "Successfully unsubscribed from rules".to_owned(),
         )),
@@ -129,7 +153,7 @@ pub async fn unsubscribe_rules(
 
 #[debug_handler]
 pub async fn subscribe_rules(
-    Path(client_id): Path<String>,
+    client_id: ClientId,
     Extension(rules_manager): Extension<Arc<RuleManager>>,
     Json(rule_ids): Json<Vec<String>>,
 ) -> Result<Json<String>, ScyllaError> {
@@ -141,10 +165,7 @@ pub async fn subscribe_rules(
 
     let rule_ids: Vec<RuleId> = rule_ids.into_iter().map(RuleId).collect();
 
-    match rules_manager
-        .subscribe_rules(ClientId(client_id), rule_ids)
-        .await
-    {
+    match rules_manager.subscribe_rules(client_id, rule_ids).await {
         Ok(_) => Ok(Json::from("Successfully subscribed to rules".to_owned())),
         Err(err) => Err(ScyllaError::RuleError(err)),
     }

--- a/scylla-server/src/controllers/rule_controller.rs
+++ b/scylla-server/src/controllers/rule_controller.rs
@@ -1,10 +1,6 @@
 use std::sync::Arc;
 
 use axum::{Extension, Json, debug_handler, extract::Path};
-use axum_extra::{
-    TypedHeader,
-    headers::{Authorization, authorization::Basic},
-};
 use serde::Deserialize;
 use serde_with::DurationSeconds;
 use serde_with::serde_as;
@@ -16,27 +12,14 @@ use crate::{
     rule_structs::{ClientId, Rule, RuleId, RuleManager, RulesResponse},
 };
 
-#[derive(Deserialize)]
-pub struct RuleSubscriptionRequest {
-    rule_ids: Vec<String>,
-    client_id: String,
-}
-
 #[debug_handler]
 pub async fn add_rule(
-    TypedHeader(auth): TypedHeader<Authorization<Basic>>,
+    Path(client_id): Path<String>,
     Extension(rules_manager): Extension<Arc<RuleManager>>,
     Json(rule): Json<Rule>,
 ) -> Result<Json<String>, ScyllaError> {
-    info!(
-        "Incoming rules reg: {}, from {}",
-        rule.topic,
-        auth.username().to_string()
-    );
-    match rules_manager
-        .add_rule(ClientId(auth.username().to_string()), rule)
-        .await
-    {
+    info!("Incoming rules reg: {}, from {}", rule.topic, client_id);
+    match rules_manager.add_rule(ClientId(client_id), rule).await {
         Ok(_) => Ok(Json::from("Rule added!".to_owned())),
         Err(err) => Err(ScyllaError::RuleError(err)),
     }
@@ -44,17 +27,12 @@ pub async fn add_rule(
 
 #[debug_handler]
 pub async fn delete_rule(
-    TypedHeader(auth): TypedHeader<Authorization<Basic>>,
+    Path((client_id, rule_id)): Path<(String, String)>,
     Extension(rules_manager): Extension<Arc<RuleManager>>,
-    Path(rule_id): Path<String>,
 ) -> Result<(), ScyllaError> {
-    info!(
-        "Incoming rules del: {}, from {}",
-        rule_id,
-        auth.username().to_string()
-    );
+    info!("Incoming rules del: {}, from {}", rule_id, client_id);
     match rules_manager
-        .delete_rule(ClientId(auth.username().to_string()), RuleId(rule_id))
+        .delete_rule(ClientId(client_id), RuleId(rule_id))
         .await
     {
         Ok(_) => Ok(()),
@@ -126,19 +104,20 @@ pub async fn edit_rule(
 
 #[debug_handler]
 pub async fn unsubscribe_rules(
+    Path(client_id): Path<String>,
     Extension(rules_manager): Extension<Arc<RuleManager>>,
-    Json(request): Json<RuleSubscriptionRequest>,
+    Json(rule_ids): Json<Vec<String>>,
 ) -> Result<Json<String>, ScyllaError> {
     info!(
         "Unsubscribing client {} from {} rules",
-        request.client_id,
-        request.rule_ids.len()
+        client_id,
+        rule_ids.len()
     );
 
-    let rule_ids: Vec<RuleId> = request.rule_ids.into_iter().map(RuleId).collect();
+    let rule_ids: Vec<RuleId> = rule_ids.into_iter().map(RuleId).collect();
 
     match rules_manager
-        .unsubscribe_rules(ClientId(request.client_id), rule_ids)
+        .unsubscribe_rules(ClientId(client_id), rule_ids)
         .await
     {
         Ok(_) => Ok(Json::from(
@@ -150,19 +129,20 @@ pub async fn unsubscribe_rules(
 
 #[debug_handler]
 pub async fn subscribe_rules(
+    Path(client_id): Path<String>,
     Extension(rules_manager): Extension<Arc<RuleManager>>,
-    Json(request): Json<RuleSubscriptionRequest>,
+    Json(rule_ids): Json<Vec<String>>,
 ) -> Result<Json<String>, ScyllaError> {
     info!(
         "Subscribing client {} to {} rules",
-        request.client_id,
-        request.rule_ids.len()
+        client_id,
+        rule_ids.len()
     );
 
-    let rule_ids: Vec<RuleId> = request.rule_ids.into_iter().map(RuleId).collect();
+    let rule_ids: Vec<RuleId> = rule_ids.into_iter().map(RuleId).collect();
 
     match rules_manager
-        .subscribe_rules(ClientId(request.client_id), rule_ids)
+        .subscribe_rules(ClientId(client_id), rule_ids)
         .await
     {
         Ok(_) => Ok(Json::from("Successfully subscribed to rules".to_owned())),

--- a/scylla-server/src/main.rs
+++ b/scylla-server/src/main.rs
@@ -440,17 +440,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .merge(
             Router::new()
+                // client id arrives in the x-client-id header, never the path
                 .route("/rules", get(get_all_rules))
-                .route("/rules/{client_id}", get(get_all_rules_with_client_info))
-                .route("/rules/{client_id}/add", put(add_rule))
-                .route("/rules/{client_id}/delete/{rule_id}", post(delete_rule))
                 .route(
-                    "/rules/{client_id}/subscribed",
-                    get(get_client_subscribed_rules),
+                    "/rules/subscription-status",
+                    get(get_all_rules_with_client_info),
                 )
-                .route("/rules/{client_id}/subscribe", post(subscribe_rules))
-                .route("/rules/{client_id}/unsubscribe", post(unsubscribe_rules))
+                .route("/rules/subscribed", get(get_client_subscribed_rules))
+                .route("/rules/add", put(add_rule))
+                .route("/rules/delete/{rule_id}", post(delete_rule))
                 .route("/rules/edit/{rule_id}", put(edit_rule))
+                .route("/rules/subscribe", post(subscribe_rules))
+                .route("/rules/unsubscribe", post(unsubscribe_rules))
                 .layer(Extension(rules_manager)),
         )
         // for CORS handling

--- a/scylla-server/src/main.rs
+++ b/scylla-server/src/main.rs
@@ -440,18 +440,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .merge(
             Router::new()
-                .route("/rules/add", put(add_rule))
-                .route("/rules/delete/{rule_id}", post(delete_rule))
                 .route("/rules", get(get_all_rules))
                 .route("/rules/{client_id}", get(get_all_rules_with_client_info))
+                .route("/rules/{client_id}/add", put(add_rule))
+                .route("/rules/{client_id}/delete/{rule_id}", post(delete_rule))
                 .route(
-                    "/rules/subscribed/{client_id}",
+                    "/rules/{client_id}/subscribed",
                     get(get_client_subscribed_rules),
                 )
-                .route("/rules/unsubscribe", post(unsubscribe_rules))
+                .route("/rules/{client_id}/subscribe", post(subscribe_rules))
+                .route("/rules/{client_id}/unsubscribe", post(unsubscribe_rules))
                 .route("/rules/edit/{rule_id}", put(edit_rule))
-                .route("/rules/subscribe", post(subscribe_rules))
-                //.route("/rules/delete/{rule_id}", post()).route("/rules/poll")
                 .layer(Extension(rules_manager)),
         )
         // for CORS handling


### PR DESCRIPTION
## Changes

Standardized client identification across all rule endpoints by moving `client_id` into the URL path. Previously `add_rule` and `delete_rule` pulled it from a Basic Auth header while `subscribe_rules` and `unsubscribe_rules` pulled it from the JSON body. Instead, all rule endpoint reads `client_id` now. The frontend API layer was updated to match this.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #561 
