### PR TITLE
#632 - Run multiple dev compose stacks concurrently

### DIFF
--- a/angular-client/compose.client.yml
+++ b/angular-client/compose.client.yml
@@ -1,6 +1,5 @@
 services:
   client:
-    container_name: client
     restart: unless-stopped
     image: ghcr.io/northeastern-electric-racing/argos-client:develop
     build:
@@ -8,7 +7,7 @@ services:
       target: production
       dockerfile: Dockerfile
     ports:
-      - 80:80
+      - ${CLIENT_HOST_PORT:-80}:80
     cpu_shares: 512
 
     environment:

--- a/argos.sh
+++ b/argos.sh
@@ -2,5 +2,20 @@
 
 profile=$1
 shift 1
+
+# STACK_OFFSET=N shifts every published host port by N and suffixes the
+# compose project name with _oN so a second dev stack runs alongside the
+# first with zero collisions. Unset or 0 = byte-identical to today.
+project="odyssey_$profile"
+if [ -n "$STACK_OFFSET" ] && [ "$STACK_OFFSET" != "0" ]; then
+    export ODYSSEY_DB_PORT=$((5432 + STACK_OFFSET))
+    export SCYLLA_HOST_PORT=$((8000 + STACK_OFFSET))
+    export CLIENT_HOST_PORT=$((80 + STACK_OFFSET))
+    export SIREN_MQTT_PORT=$((1883 + STACK_OFFSET))
+    export SIREN_WS_PORT=$((9002 + STACK_OFFSET))
+    export GRAFANA_HOST_PORT=$((3002 + STACK_OFFSET))
+    project="${project}_o${STACK_OFFSET}"
+fi
+
 cd ./compose
-docker compose -f compose.yml -f "compose.$profile.yml" -p "odyssey_$profile" "$@"
+docker compose -f compose.yml -f "compose.$profile.yml" -p "$project" "$@"

--- a/argos.sh
+++ b/argos.sh
@@ -4,4 +4,4 @@ profile=$1
 shift 1
 cd ./compose
 docker compose -f compose.yml -f "compose.$profile.yml" \
-    -p "odyssey_$profile${STACK_OFFSET:+_o$STACK_OFFSET}" "$@"
+    -p "odyssey_$profile${STACK_OFFSET:+_$STACK_OFFSET}" "$@"

--- a/argos.sh
+++ b/argos.sh
@@ -2,20 +2,6 @@
 
 profile=$1
 shift 1
-
-# STACK_OFFSET=N shifts every published host port by N and suffixes the
-# compose project name with _oN so a second dev stack runs alongside the
-# first with zero collisions. Unset or 0 = byte-identical to today.
-project="odyssey_$profile"
-if [ -n "$STACK_OFFSET" ] && [ "$STACK_OFFSET" != "0" ]; then
-    export ODYSSEY_DB_PORT=$((5432 + STACK_OFFSET))
-    export SCYLLA_HOST_PORT=$((8000 + STACK_OFFSET))
-    export CLIENT_HOST_PORT=$((80 + STACK_OFFSET))
-    export SIREN_MQTT_PORT=$((1883 + STACK_OFFSET))
-    export SIREN_WS_PORT=$((9002 + STACK_OFFSET))
-    export GRAFANA_HOST_PORT=$((3002 + STACK_OFFSET))
-    project="${project}_o${STACK_OFFSET}"
-fi
-
 cd ./compose
-docker compose -f compose.yml -f "compose.$profile.yml" -p "$project" "$@"
+docker compose -f compose.yml -f "compose.$profile.yml" \
+    -p "odyssey_$profile${STACK_OFFSET:+_o$STACK_OFFSET}" "$@"

--- a/compose/README.md
+++ b/compose/README.md
@@ -30,6 +30,24 @@ The base docker compose (`compose.yml`) contains some important features to note
 
 *These profiles are non-exhuastive, there are plently of use cases these profiles do not cover.  In that case, you can write your own profile to cover it.*
 
+#### Running multiple dev stacks side-by-side
+
+Set `STACK_OFFSET=N` in front of `argos.sh` to shift every published host port by `N` and suffix the compose project name with `_oN`, so a second dev stack runs alongside the first with no name or port collisions. Unset (or `0`) means today's exact behavior, byte-identical to before.
+
+```
+# stack 1: today's ports (db 5432, scylla 8000, client 80, siren 1883/9002, grafana 3002)
+./argos.sh client-dev up -d
+
+# stack 2: every port shifted by 10 (db 5442, scylla 8010, client 90, siren 1893/9012, grafana 3012)
+STACK_OFFSET=10 ./argos.sh fake-data up -d
+
+# tear each down with the same offset that started it
+./argos.sh client-dev down
+STACK_OFFSET=10 ./argos.sh fake-data down
+```
+
+`STACK_OFFSET` is honored for the dev profiles (`client-dev`, `scylla-dev`, `fake-data`). Production profiles (`router`, `brick`, `tpu`) are unaffected when run with no env vars. Multiple `ng serve` clients and multiple `cargo run` scyllas are already supported via the existing port flags and are independent of this.
+
 #### Examples with and without profiles
 
 - To send some simulated data to a client you are running with `npm`: `./argos.sh client-dev up`

--- a/compose/README.md
+++ b/compose/README.md
@@ -34,7 +34,7 @@ The base docker compose (`compose.yml`) contains some important features to note
 
 Every published host port in the dev compose files reads from an env var with today's value as the default: `ODYSSEY_DB_PORT` (5432), `SCYLLA_HOST_PORT` (8000), `CLIENT_HOST_PORT` (80), `SIREN_MQTT_PORT` (1883), `SIREN_WS_PORT` (9002), `GRAFANA_HOST_PORT` (3002). With no env vars set, behavior is byte-identical to before.
 
-To run a second dev stack alongside the first, set those vars (shifted to free values) plus `STACK_OFFSET=N`, which `argos.sh` appends to the project name as `_oN` so `down`, `logs`, and `exec` target the right stack:
+To run a second dev stack alongside the first, set those vars (shifted to free values) plus `STACK_OFFSET=N`, which `argos.sh` appends to the project name as `_N` so `down`, `logs`, and `exec` target the right stack:
 
 ```
 # stack 1 at defaults

--- a/compose/README.md
+++ b/compose/README.md
@@ -32,21 +32,30 @@ The base docker compose (`compose.yml`) contains some important features to note
 
 #### Running multiple dev stacks side-by-side
 
-Set `STACK_OFFSET=N` in front of `argos.sh` to shift every published host port by `N` and suffix the compose project name with `_oN`, so a second dev stack runs alongside the first with no name or port collisions. Unset (or `0`) means today's exact behavior, byte-identical to before.
+Every published host port in the dev compose files reads from an env var with today's value as the default: `ODYSSEY_DB_PORT` (5432), `SCYLLA_HOST_PORT` (8000), `CLIENT_HOST_PORT` (80), `SIREN_MQTT_PORT` (1883), `SIREN_WS_PORT` (9002), `GRAFANA_HOST_PORT` (3002). With no env vars set, behavior is byte-identical to before.
+
+To run a second dev stack alongside the first, set those vars (shifted to free values) plus `STACK_OFFSET=N`, which `argos.sh` appends to the project name as `_oN` so `down`, `logs`, and `exec` target the right stack:
 
 ```
-# stack 1: today's ports (db 5432, scylla 8000, client 80, siren 1883/9002, grafana 3002)
+# stack 1 at defaults
 ./argos.sh client-dev up -d
 
-# stack 2: every port shifted by 10 (db 5442, scylla 8010, client 90, siren 1893/9012, grafana 3012)
-STACK_OFFSET=10 ./argos.sh fake-data up -d
+# stack 2, shifted by 10 — each profile only consumes the vars its services need.
+# Use 'env' so the vars don't leak into stack 1's teardown.
+N=10
+env STACK_OFFSET=$N \
+    ODYSSEY_DB_PORT=$((5432+N))   SCYLLA_HOST_PORT=$((8000+N)) \
+    CLIENT_HOST_PORT=$((80+N))    SIREN_MQTT_PORT=$((1883+N)) \
+    SIREN_WS_PORT=$((9002+N))     GRAFANA_HOST_PORT=$((3002+N)) \
+    ./argos.sh fake-data up -d
 
-# tear each down with the same offset that started it
+# Teardown: stack 1 needs nothing; stack 2 only needs STACK_OFFSET since
+# 'compose down' targets containers by project name, not by port.
 ./argos.sh client-dev down
 STACK_OFFSET=10 ./argos.sh fake-data down
 ```
 
-`STACK_OFFSET` is honored for the dev profiles (`client-dev`, `scylla-dev`, `fake-data`). Production profiles (`router`, `brick`, `tpu`) are unaffected when run with no env vars. Multiple `ng serve` clients and multiple `cargo run` scyllas are already supported via the existing port flags and are independent of this.
+Production profiles (`router`, `brick`, `tpu`) are unaffected when run with no env vars. Multiple `ng serve` clients and multiple `cargo run` scyllas are already supported via the existing port flags and are independent of this.
 
 #### Examples with and without profiles
 

--- a/compose/README.md
+++ b/compose/README.md
@@ -24,7 +24,7 @@ Profiles:
 
 
 The base docker compose (`compose.yml`) contains some important features to note.  However, it is useless standalone.  Please read the profile customization selection below before using the base compose.
-- It persists the database between `down` commands via a volume called `argos_db-data`.  Delete it with `docker volume rm argos_db-data` to start with a new database next `up`.
+- It persists the database between `down` commands via a volume named `<project>_db-data` (e.g. `odyssey_client-dev_db-data` for the default `client-dev` stack).  Wipe it with `./argos.sh <profile> down -v` or `docker volume rm <project>_db-data` to start with a new database next `up`.
 - It weighs the CPU usage of siren higher, so it is prioritized in CPU starvation scenarios.
 
 
@@ -52,10 +52,10 @@ env STACK_OFFSET=$N \
 # Teardown: stack 1 needs nothing; stack 2 only needs STACK_OFFSET since
 # 'compose down' targets containers by project name, not by port.
 ./argos.sh client-dev down
-STACK_OFFSET=10 ./argos.sh fake-data down
+STACK_OFFSET=$N ./argos.sh fake-data down
 ```
 
-Production profiles (`router`, `brick`, `tpu`) are unaffected when run with no env vars. Multiple `ng serve` clients and multiple `cargo run` scyllas are already supported via the existing port flags and are independent of this.
+`STACK_OFFSET` is purely a project-name suffix: any non-empty value (including `0`) creates a separate compose project, so don't set it when running production profiles. Production profiles (`router`, `brick`, `tpu`) are unaffected when run with no env vars. Multiple `ng serve` clients and multiple `cargo run` scyllas are already supported via the existing port flags and are independent of this.
 
 #### Examples with and without profiles
 

--- a/compose/compose.calypso.yml
+++ b/compose/compose.calypso.yml
@@ -1,6 +1,5 @@
 services:
   calypso:
-    container_name: calypso
     image: ghcr.io/northeastern-electric-racing/calypso:Develop
     restart: unless-stopped
     environment:

--- a/compose/compose.scylla-dev.yml
+++ b/compose/compose.scylla-dev.yml
@@ -10,7 +10,7 @@ services:
     build:
       context: ../angular-client
     environment:
-      BACKEND_URL: http://127.0.0.1:8000
+      BACKEND_URL: http://127.0.0.1:${SCYLLA_HOST_PORT:-8000}
 
   siren:
     extends:

--- a/compose/compose.yml
+++ b/compose/compose.yml
@@ -2,7 +2,6 @@ version: "3.8"
 
 services:
   odyssey-db:
-    container_name: odyssey-db
     image: postgres:17.2
     restart: unless-stopped
     environment:
@@ -12,7 +11,7 @@ services:
       - "-c"
       - "shared_buffers=256MB"
     ports:
-      - 5432:5432 # Exposed for external access if needed
+      - ${ODYSSEY_DB_PORT:-5432}:5432 # Exposed for external access if needed
     expose:
       - 5432 # Allow inter-container communication
     volumes:
@@ -21,18 +20,18 @@ services:
     stop_grace_period: 2m
 
   scylla-server:
-    container_name: scylla-server
     image: ghcr.io/northeastern-electric-racing/argos-scylla:develop
     build:
       context: ../scylla-server
     restart: unless-stopped
     ports:
-      - 8000:8000
+      - ${SCYLLA_HOST_PORT:-8000}:${SCYLLA_HOST_PORT:-8000}
     depends_on:
       - odyssey-db
     environment:
       - DATABASE_URL=postgresql://postgres:password@odyssey-db:5432/postgres
       - RUST_LOG=warn,scylla_server=debug
+      - SCYLLA_PORT=${SCYLLA_HOST_PORT:-8000}
     cpu_shares: 1024
     stop_grace_period: 2m
     stop_signal: SIGINT

--- a/scylla-server/integration_test.sh
+++ b/scylla-server/integration_test.sh
@@ -23,11 +23,11 @@ cd ../scylla-server || { echo "scylla-server directory not found"; exit 1; }
 
 # Run database migrations
 echo "Running database migrations..."
-DATABASE_URL=postgresql://postgres:password@127.0.0.1:5432/postgres diesel migration run || { echo "Migration failed"; exit 1; }
+DATABASE_URL=postgresql://postgres:password@127.0.0.1:${ODYSSEY_DB_PORT:-5432}/postgres diesel migration run || { echo "Migration failed"; exit 1; }
 
 # Run tests
 echo "Running tests..."
-DATABASE_URL=postgresql://postgres:password@127.0.0.1:5432/postgres cargo test -- --test-threads=1 || { echo "Tests failed"; exit 1; }
+DATABASE_URL=postgresql://postgres:password@127.0.0.1:${ODYSSEY_DB_PORT:-5432}/postgres cargo test -- --test-threads=1 || { echo "Tests failed"; exit 1; }
 
 # Navigate back to the compose directory
 cd ../compose || { echo "Compose directory not found"; exit 1; }

--- a/scylla-server/integration_test.sh
+++ b/scylla-server/integration_test.sh
@@ -1,16 +1,18 @@
 #!/bin/sh
 
+PROJECT=odyssey_integration_test
+
 # Navigate to the compose directory
 echo "Navigating to compose directory..."
 cd ../compose || { echo "Compose directory not found"; exit 1; }
 
-# Remove any existing odyssey-timescale container
-echo "Stopping and removing any existing odyssey-timescale container..."
-docker rm -f odyssey-db 2>/dev/null || echo "No existing container to remove."
+# Tear down any leftover integration-test stack from a previous run
+echo "Stopping any existing integration-test stack..."
+docker compose -p "$PROJECT" down 2>/dev/null || true
 
-# Start a new odyssey-timescale container
-echo "Starting a new odyssey-timescale container..."
-docker compose up -d odyssey-db || { echo "Failed to start odyssey-timescale"; exit 1; }
+# Start a new odyssey-db container under our project
+echo "Starting odyssey-db..."
+docker compose -p "$PROJECT" up -d odyssey-db || { echo "Failed to start odyssey-db"; exit 1; }
 
 # Wait for the database to initialize
 echo "Waiting for the database to initialize..."
@@ -32,6 +34,6 @@ cd ../compose || { echo "Compose directory not found"; exit 1; }
 
 # Stop and clean up containers
 echo "Stopping and cleaning up containers..."
-docker compose down || { echo "Failed to clean up containers"; exit 1; }
+docker compose -p "$PROJECT" down || { echo "Failed to clean up containers"; exit 1; }
 
 echo "Script completed successfully!"

--- a/siren-base/compose.grafana.yml
+++ b/siren-base/compose.grafana.yml
@@ -1,7 +1,6 @@
 services:
   grafana:
     image: grafana/grafana-oss
-    container_name: grafana
     restart: unless-stopped
     environment:
       # increases the log level from info to debug
@@ -9,6 +8,6 @@ services:
       - GF_PLUGINS_PREINSTALL=grafana-mqtt-datasource@@https://github.com/Northeastern-Electric-Racing/mqtt-datasource/releases/download/v1.2.0/grafana-mqtt-datasource-1.2.0.zip
       - GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=grafana-mqtt-datasource
     ports:
-      - "3002:3000"
+      - "${GRAFANA_HOST_PORT:-3002}:3000"
     volumes:
       - "grafana_storage:/var/lib/grafana"

--- a/siren-base/compose.siren.yml
+++ b/siren-base/compose.siren.yml
@@ -1,11 +1,10 @@
 services:
   siren:
-    container_name: siren
     restart: unless-stopped
     image: eclipse-mosquitto:latest
     ports:
-      - 1883:1883
-      - 9002:9001 # win conflict on 9001
+      - ${SIREN_MQTT_PORT:-1883}:1883
+      - ${SIREN_WS_PORT:-9002}:9001 # win conflict on 9001
     expose:
       - 1883
     volumes:


### PR DESCRIPTION
## Changes

Dev compose profiles (client-dev, scylla-dev, fake-data) can now run side-by-side via STACK_OFFSET=N. Defaults match today exactly, so single-stack and production behavior are unchanged. 

This is mainly for making parallel development easier, specifically when using AI agents that share a computer.
 
## Notes

- container_name dropped from every dev-path service and host ports moved to ${VAR:-default}, so docker compose's project-name suffix handles uniqueness.
- argos.sh just appends _$STACK_OFFSET to the project name when set; port math is the caller's job, recipe in compose/README.md.
- integration_test.sh runs under its own compose project and reads ${ODYSSEY_DB_PORT:-5432}.
- Operator impact: docker logs scylla-server / docker logs odyssey-db no longer work; use project-aware names (e.g. odyssey_router-scylla-server-1).

## Test Cases

- Single stack boots like before.
- Two stacks run at the same time.
- Router image still builds.
- Integration tests still pass.

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No package-lock.json changes
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket

Closes #632
