### PR TITLE
#664 sync scylla Cargo.lock with Cargo.toml

### DIFF
--- a/.github/workflows/scylla-ci.yml
+++ b/.github/workflows/scylla-ci.yml
@@ -27,23 +27,23 @@ jobs:
            with:
             submodules: recursive
          - name: Clippy
-           run: cargo clippy --all-targets
+           run: cargo clippy --all-targets --locked
          - name: Fmt
            run: cargo fmt --check
          - name: Start DB
            working-directory: compose
            run: docker compose up -d odyssey-db
          - name: Build
-           run: cargo build --verbose
+           run: cargo build --verbose --locked
          - name: Run # so we can migrate the database, run for a little than bail
            env:
              DATABASE_URL: postgresql://postgres:password@127.0.0.1:5432/postgres
            run: |
-                cargo run & ID=$!; sleep 10s; kill $ID
+                cargo run --locked & ID=$!; sleep 10s; kill $ID
          - name: Test
            env:
              DATABASE_URL: postgresql://postgres:password@127.0.0.1:5432/postgres
-           run: cargo test -- --test-threads=1
+           run: cargo test --locked -- --test-threads=1
          - name: Cleanup
            working-directory: compose
            run: docker compose down

--- a/scylla-server/Cargo.lock
+++ b/scylla-server/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "form_urlencoded",
  "futures-core",
  "futures-util",
+ "headers",
  "http",
  "http-body",
  "http-body-util",
@@ -1041,6 +1042,30 @@ dependencies = [
  "flate2",
  "nom",
  "num-traits",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
 ]
 
 [[package]]


### PR DESCRIPTION
## Changes

Two changes:

Syncs scylla-server Cargo.lock with Cargo.toml by adding the headers v0.4.1 and headers-core v0.3.0 entries that axum-extra's typed-header feature requires. The committed lock was missing them, so the manual scylla docker image workflow, which builds with `cargo build --release --locked`, aborted with exit 101 (arm64 hit the lock error directly; amd64 hit a transient index-fetch reset during the same forced re-resolution). Minimal sync: 25 insertions, no version change to any existing crate.

Adds --locked to every cargo command in Scylla CI (clippy, build, run, test) so future lock drift fails on every PR rather than only on the manual docker build, which was the gap that let this drift reach develop.

## Notes

Regular Scylla CI previously built without --locked, so it silently regenerated the lock in memory and stayed green; only the --locked docker build surfaced the drift. The CI change closes that gap, and this PR's own Scylla CI run now self-verifies the lock is in sync.

## Test Cases

- Resolving the lock with the locked flag (cargo metadata --locked) now succeeds, where it previously exited 101.
- Manual "Create and publish scylla docker image" workflow run on this branch: green on amd64, arm64, and the multi-arch manifest.
- Scylla CI on this PR runs every cargo step with --locked and passes, confirming the lockfile matches the manifest.

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] No merge conflicts
- [ ] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No package-lock.json changes (unless dependencies have changed)
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #664
