### PR TITLE
Add log-future-addition skill for filing a single idea as one issue

### DIFF
--- a/.claude/skills/log-future-addition/SKILL.md
+++ b/.claude/skills/log-future-addition/SKILL.md
@@ -56,24 +56,24 @@ One or two sentences describing the idea, in the user's own framing.
 
 The motivation, or the scrap it came from. Omit this section entirely if there is nothing to add.
 
-> *Logged as a future addition — un-triaged.*
+> *Logged as a raw idea via log-future-addition.*
 </issue-template>
 
 Keep to at most three backtick usages in the whole body (per `issue-tracker.md`).
 
 ### 4. Choose labels
 
-- **`idea`** — always. Marks provenance and "not yet classified". If the label does not exist yet, create it first: `gh label create idea --color FBCA04 --description "A raw, un-triaged idea for a future addition"`.
+- **`needs-triage`** — always. Files the idea straight into the triage queue as intake. This is the one place a triage role is applied at creation instead of by `/triage` (see `issue-tracker.md`).
 - **Type** (`bug` / `new feature` / `feature enhancement`) — apply when the idea clearly is one; otherwise leave it for `/triage`.
-- **Area** (`angular-client` / `scylla-server` / `DevOps`) — apply only when obvious; otherwise omit. This skill relaxes the "at least one area label" rule in `issue-tracker.md` because a raw idea often is not scoped to an area yet.
+- **Area** (`angular-client` / `scylla-server` / `DevOps`) — apply only when obvious; otherwise omit. A raw idea often is not scoped to an area yet, so area is not required.
 - **Difficulty** — never. That is `/triage`'s call.
 
-The issue lands un-triaged; `/triage` fills in category, area, and difficulty later.
+`/triage` then classifies it (category, area, difficulty) like any other needs-triage issue.
 
 ### 5. Confirm, then file
 
 Show the drafted title, body, and labels. On consent, file it:
 
-`gh issue create --title "..." --body "..." --assignee @me --label idea[,<others>]`
+`gh issue create --title "..." --body "..." --assignee @me --label needs-triage[,<others>]`
 
 Report the new issue number and URL. Do not triage it, and do not run any further work on it.

--- a/.claude/skills/log-future-addition/SKILL.md
+++ b/.claude/skills/log-future-addition/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: log-future-addition
+description: File a single out-of-scope idea, feature, or improvement as one un-triaged GitHub issue. Use whenever the user raises something that would be a good future addition to the app but is out of scope for the current work ("we could also…", "would be nice to…", "let's do that later") — offer to log it. For a fleshed-out feature use to-prd; to break an existing plan into tickets use to-issues.
+---
+
+# Log Future Addition
+
+Capture one rough, out-of-scope idea as a single un-triaged GitHub issue, so a good thought is not lost when it surfaces mid-work.
+
+This is the lightweight counterpart to `to-prd`. Use it for a **brief, quick idea** — anything already thought through belongs in `to-prd` (a spec) or a `grill-with-docs` session. It is NOT for breaking down plans; that is `to-issues`.
+
+Issue tracker conventions (title, labels, backticks, assignment) live in `docs/agents/issue-tracker.md`. The `Idea` term is defined in `docs/agents/glossary.md`. Do not duplicate those here — link and follow.
+
+## When to reach for this skill
+
+- An out-of-scope idea comes up in conversation and you want to keep it without derailing the current work.
+- You have a one-line feature/bug/improvement scrap and just want it on the tracker.
+
+If the input is really a plan or spec — multiple features, acceptance criteria, phased work, or simply long and detailed — say so and point the user to `to-prd` (one PRD issue) or `to-issues` (many tracer-bullet issues). Suggest, do not hard-refuse; the user can override.
+
+## Two-stage consent
+
+1. **Before running:** unless the user explicitly invoked this skill, first *ask* whether they want to log the idea (e.g. "Want me to log that as a future addition?"). Only proceed on a yes.
+2. **Before posting:** always show the full drafted issue and get consent before calling `gh issue create`. Never file silently.
+
+## Process
+
+### 1. Gather the idea
+
+Take the idea from, in order of preference:
+
+1. The command argument, if one was passed (this is how another skill delegates a raw idea to this one).
+2. The current conversation context.
+3. A short interactive prompt, if neither of the above yields anything.
+
+### 2. Check for duplicates
+
+Run one lightweight, non-blocking search on the idea's keywords:
+
+`gh issue list --search "<keywords>" --state open`
+
+If a strong match turns up, surface it in the confirm step ("possible duplicate of #123 — file anyway?"). Never block filing on this.
+
+### 3. Draft the issue
+
+- **Title:** concise, imperative (per `issue-tracker.md`).
+- **Body:** the minimal shape below — a raw idea, not a spec.
+- **Labels:** see below.
+
+<issue-template>
+## What
+
+One or two sentences describing the idea, in the user's own framing.
+
+## Why
+
+The motivation, or the scrap it came from. Omit this section entirely if there is nothing to add.
+
+> *Logged as a future addition — un-triaged.*
+</issue-template>
+
+Keep to at most three backtick usages in the whole body (per `issue-tracker.md`).
+
+### 4. Choose labels
+
+- **`idea`** — always. Marks provenance and "not yet classified". If the label does not exist yet, create it first: `gh label create idea --color FBCA04 --description "A raw, un-triaged idea for a future addition"`.
+- **Type** (`bug` / `new feature` / `feature enhancement`) — apply when the idea clearly is one; otherwise leave it for `/triage`.
+- **Area** (`angular-client` / `scylla-server` / `DevOps`) — apply only when obvious; otherwise omit. This skill relaxes the "at least one area label" rule in `issue-tracker.md` because a raw idea often is not scoped to an area yet.
+- **Difficulty** — never. That is `/triage`'s call.
+
+The issue lands un-triaged; `/triage` fills in category, area, and difficulty later.
+
+### 5. Confirm, then file
+
+Show the drafted title, body, and labels. On consent, file it:
+
+`gh issue create --title "..." --body "..." --assignee @me --label idea[,<others>]`
+
+Report the new issue number and URL. Do not triage it, and do not run any further work on it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,8 @@ Workflow skills (commit, open-pr, update-pr, address-pr-comments, run-local, ver
 
 Issues live in GitHub Issues on `Northeastern-Electric-Racing/Argos` via the `gh` CLI. See `docs/agents/issue-tracker.md` for title, label, and assignment conventions.
 
+When an out-of-scope but worthwhile idea for the app comes up mid-work, offer to log it as a single un-triaged issue with the `log-future-addition` skill instead of letting it slip.
+
 ### Triage labels
 
 Five-role vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`), created via `gh label create` and applied by `/triage`. See `docs/agents/triage-labels.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Workflow skills (commit, open-pr, update-pr, address-pr-comments, run-local, ver
 
 Issues live in GitHub Issues on `Northeastern-Electric-Racing/Argos` via the `gh` CLI. See `docs/agents/issue-tracker.md` for title, label, and assignment conventions.
 
-When an out-of-scope but worthwhile idea for the app comes up mid-work, offer to log it as a single un-triaged issue with the `log-future-addition` skill instead of letting it slip.
+When an out-of-scope but worthwhile idea for the app comes up mid-work, offer to log it as a needs-triage issue with the `log-future-addition` skill instead of letting it slip.
 
 ### Triage labels
 

--- a/docs/agents/glossary.md
+++ b/docs/agents/glossary.md
@@ -13,3 +13,5 @@ Plain-language definitions of the workflow and agent-tooling terms used across t
 **Tracer-bullet issue / vertical slice.** A scoping pattern where each ticket cuts a thin slice through every layer it touches (database, API, UI, tests) end-to-end, instead of completing one layer at a time. Each slice stands on its own. The `to-issues` skill breaks plans into these.
 
 **PRD (Product Requirements Document).** A feature spec. The `to-prd` skill writes one; `to-issues` then breaks it into tracer-bullet tickets.
+
+**Idea.** A raw, un-fleshed feature or bug scrap filed as a single ticket before anyone has classified it — the lightweight counterpart to a PRD. Carries the `idea` label (and an area label only when obvious), no type or difficulty, and lands un-triaged for `/triage` to classify. Filed by the single-idea skill; anything already thought through should go to `to-prd` or `grill-with-docs` instead.

--- a/docs/agents/glossary.md
+++ b/docs/agents/glossary.md
@@ -14,4 +14,4 @@ Plain-language definitions of the workflow and agent-tooling terms used across t
 
 **PRD (Product Requirements Document).** A feature spec. The `to-prd` skill writes one; `to-issues` then breaks it into tracer-bullet tickets.
 
-**Idea.** A raw, un-fleshed feature or bug scrap filed as a single ticket before anyone has classified it — the lightweight counterpart to a PRD. The `log-future-addition` skill files it directly into `needs-triage` (adding a type or area only where clear, never a difficulty), so `/triage` classifies it like any other intake. Deliberately thin — a seed to shape or park, not a deficient spec. Anything already thought through should go to `to-prd` or `grill-with-docs` instead.
+**Idea.** A raw, un-fleshed feature or bug scrap filed as a single needs-triage ticket before anyone has classified it — the lightweight counterpart to a PRD. Filed by the `log-future-addition` skill for `/triage` to classify like any other intake. Deliberately thin; anything already thought through belongs in `to-prd` or `grill-with-docs`.

--- a/docs/agents/glossary.md
+++ b/docs/agents/glossary.md
@@ -14,4 +14,4 @@ Plain-language definitions of the workflow and agent-tooling terms used across t
 
 **PRD (Product Requirements Document).** A feature spec. The `to-prd` skill writes one; `to-issues` then breaks it into tracer-bullet tickets.
 
-**Idea.** A raw, un-fleshed feature or bug scrap filed as a single ticket before anyone has classified it — the lightweight counterpart to a PRD. Carries the `idea` label (and an area label only when obvious), no type or difficulty, and lands un-triaged for `/triage` to classify. Filed by the single-idea skill; anything already thought through should go to `to-prd` or `grill-with-docs` instead.
+**Idea.** A raw, un-fleshed feature or bug scrap filed as a single ticket before anyone has classified it — the lightweight counterpart to a PRD. Always carries the `idea` label, plus an inferred type label when clear and an area label when obvious, but never a difficulty, and lands un-triaged for `/triage` to fill in the rest. Filed by the single-idea skill; anything already thought through should go to `to-prd` or `grill-with-docs` instead.

--- a/docs/agents/glossary.md
+++ b/docs/agents/glossary.md
@@ -14,4 +14,4 @@ Plain-language definitions of the workflow and agent-tooling terms used across t
 
 **PRD (Product Requirements Document).** A feature spec. The `to-prd` skill writes one; `to-issues` then breaks it into tracer-bullet tickets.
 
-**Idea.** A raw, un-fleshed feature or bug scrap filed as a single ticket before anyone has classified it — the lightweight counterpart to a PRD. Always carries the `idea` label, plus an inferred type label when clear and an area label when obvious, but never a difficulty, and lands un-triaged for `/triage` to fill in the rest. Filed by the single-idea skill; anything already thought through should go to `to-prd` or `grill-with-docs` instead.
+**Idea.** A raw, un-fleshed feature or bug scrap filed as a single ticket before anyone has classified it — the lightweight counterpart to a PRD. The `log-future-addition` skill files it directly into `needs-triage` (adding a type or area only where clear, never a difficulty), so `/triage` classifies it like any other intake. Deliberately thin — a seed to shape or park, not a deficient spec. Anything already thought through should go to `to-prd` or `grill-with-docs` instead.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -27,9 +27,7 @@ These apply when an AI skill files an issue with `gh issue create`. They govern 
 | Type | `bug`, `new feature`, `feature enhancement`, `good first issue`, `epic`, `idea` |
 | Difficulty | `straightforward`, `medium`, `difficult` |
 
-The triage roles (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) are applied by `/triage`, not at creation time. See triage-labels.md.
-
-The `idea` type marks a raw, un-triaged idea filed by the `log-future-addition` skill (see glossary.md). Issues filed that way carry `idea` plus an inferred type and area only where those are clear; they are exempt from the "at least one area label" rule above, since a raw idea is often not scoped to an area yet. `/triage` fills in the rest later.
+The triage roles (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) are applied by `/triage`, not at creation time (see triage-labels.md). The one exception to the label rules above is `idea`: the `log-future-addition` skill files a raw idea with that label — plus a type or area only where clear, area not required — for `/triage` to finish later (see glossary.md).
 
 **Backticks:** at most three backtick usages in the entire issue body. Reference files, functions, and identifiers in plain text; reserve backticks for commands worth copy-pasting or short snippets.
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -24,10 +24,12 @@ These apply when an AI skill files an issue with `gh issue create`. They govern 
 | Group | Labels |
 | --- | --- |
 | Area | `angular-client`, `scylla-server`, `DevOps` |
-| Type | `bug`, `new feature`, `feature enhancement`, `good first issue`, `epic` |
+| Type | `bug`, `new feature`, `feature enhancement`, `good first issue`, `epic`, `idea` |
 | Difficulty | `straightforward`, `medium`, `difficult` |
 
 The triage roles (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) are applied by `/triage`, not at creation time. See triage-labels.md.
+
+The `idea` type marks a raw, un-triaged idea filed by the `log-future-addition` skill (see glossary.md). Issues filed that way carry `idea` plus an inferred type and area only where those are clear; they are exempt from the "at least one area label" rule above, since a raw idea is often not scoped to an area yet. `/triage` fills in the rest later.
 
 **Backticks:** at most three backtick usages in the entire issue body. Reference files, functions, and identifiers in plain text; reserve backticks for commands worth copy-pasting or short snippets.
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -24,10 +24,10 @@ These apply when an AI skill files an issue with `gh issue create`. They govern 
 | Group | Labels |
 | --- | --- |
 | Area | `angular-client`, `scylla-server`, `DevOps` |
-| Type | `bug`, `new feature`, `feature enhancement`, `good first issue`, `epic`, `idea` |
+| Type | `bug`, `new feature`, `feature enhancement`, `good first issue`, `epic` |
 | Difficulty | `straightforward`, `medium`, `difficult` |
 
-The triage roles (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) are applied by `/triage`, not at creation time (see triage-labels.md). The one exception to the label rules above is `idea`: the `log-future-addition` skill files a raw idea with that label — plus a type or area only where clear, area not required — for `/triage` to finish later (see glossary.md).
+The triage roles (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) are applied by `/triage`, not at creation time (see triage-labels.md) — with one exception: the `log-future-addition` skill files a raw idea directly with `needs-triage`, placing it straight in the triage queue (a type or area is added only where clear, area not required; see glossary.md).
 
 **Backticks:** at most three backtick usages in the entire issue body. Reference files, functions, and identifiers in plain text; reserve backticks for commands worth copy-pasting or short snippets.
 

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -12,4 +12,4 @@ The skills speak in terms of five canonical triage roles. This file maps those r
 
 When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
 
-These labels are created on the repo via `gh label create` (see issue-tracker.md and ADR 0002); `/triage` then applies them. Existing Argos labels (`bug`, `new feature`, `epic`, `idea`, `angular-client`, `scylla-server`, `straightforward`, `medium`, `difficult`, `DevOps`, `good first issue`) are content/area labels and live alongside the triage labels above without overlap. See glossary.md for AFK, HITL, triage, and the other workflow terms.
+These labels are created on the repo via `gh label create` (see issue-tracker.md and ADR 0002); `/triage` then applies them. Existing Argos labels (`bug`, `new feature`, `epic`, `angular-client`, `scylla-server`, `straightforward`, `medium`, `difficult`, `DevOps`, `good first issue`) are content/area labels and live alongside the triage labels above without overlap. See glossary.md for AFK, HITL, triage, and the other workflow terms.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -12,4 +12,4 @@ The skills speak in terms of five canonical triage roles. This file maps those r
 
 When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
 
-These labels are created on the repo via `gh label create` (see issue-tracker.md and ADR 0002); `/triage` then applies them. Existing Argos labels (`bug`, `new feature`, `epic`, `angular-client`, `scylla-server`, `straightforward`, `medium`, `difficult`, `DevOps`, `good first issue`) are content/area labels and live alongside the triage labels above without overlap. See glossary.md for AFK, HITL, triage, and the other workflow terms.
+These labels are created on the repo via `gh label create` (see issue-tracker.md and ADR 0002); `/triage` then applies them. Existing Argos labels (`bug`, `new feature`, `epic`, `idea`, `angular-client`, `scylla-server`, `straightforward`, `medium`, `difficult`, `DevOps`, `good first issue`) are content/area labels and live alongside the triage labels above without overlap. See glossary.md for AFK, HITL, triage, and the other workflow terms.


### PR DESCRIPTION
## Changes

Adds the log-future-addition skill — a lightweight counterpart to to-prd that files one out-of-scope idea as a single needs-triage issue. It takes the idea from a command arg, else the conversation, else a short prompt; drafts a minimal What/Why body; runs one non-blocking duplicate search; and files only after two-stage consent (offers before running unless explicitly invoked, then confirms the draft before posting). No new label — an idea goes straight into the existing needs-triage queue (plus an obvious type or area when clear), and /triage classifies it like any other intake.

Also pins the Idea term in the glossary, adds a one-line carve-out in issue-tracker.md noting the skill applies needs-triage at creation, and points CLAUDE.md at the skill so an out-of-scope idea gets offered a home instead of being lost.

## Notes

- Reuses the existing needs-triage label. An earlier draft added a dedicated idea label, but it was dropped as redundant — a filed idea simply needs triage, which needs-triage already means.
- The skill applies needs-triage at creation, the one documented exception to "triage roles are applied by /triage, not at creation" — consistent with triage's own unlabeled-to-needs-triage intake.
- No ticket exists for this work, so commits are not `#NNN`-tagged and the Closes line is omitted. Wire in a ticket if one should track it.

## Test Cases

- Skill loads and is discoverable by the harness under the expected trigger (out-of-scope idea surfaces mid-work).
- Glossary, issue-tracker, and CLAUDE.md cross-references resolve to the new skill.

## Checklist

- [ ] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No package-lock.json changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)
