### PR TITLE
#689 - Add research skill for delegated primary-source investigation

### DIFF
--- a/.claude/skills/research/SKILL.md
+++ b/.claude/skills/research/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: research
+description: Investigate a question against high-trust primary sources and capture the findings as a Markdown file in the repo. Use when the user wants a topic researched, docs or API facts gathered, or reading legwork delegated to a background agent.
+---
+
+Spin up a **background agent** to do the research, so you keep working while it reads.
+
+Its job:
+
+1. Investigate the question against **primary sources** — official docs, source code, specs, first-party APIs — not a secondary write-up of them. Follow every claim back to the source that owns it.
+2. Write the findings to a single Markdown file, citing each claim's source.
+3. Save it where the repo already keeps such notes; match the existing convention, and if there is none, put it somewhere sensible and say where.


### PR DESCRIPTION
## Changes

Vendors Matt Pocock's research skill: a background agent investigates a question against primary sources (official docs, source code, specs, first-party APIs) and leaves a single cited markdown file where the repo keeps such notes.

## Notes

Skills-only, independent of the rename/split PRs — based directly on develop. Needed as wayfinder's research-type ticket, and fills the dangling research delegate in the journal work (#680/#681).

## Test Cases

- Skill loads and is reachable under /research

## Checklist

- [x] All commits are tagged with the ticket number
- [x] Removed non-applicable sections of this template

Closes #689

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdH2gxRtfjoqUWa5hG8SvF)_