### PR TITLE
Let to-tickets mint an epic parent when entered directly

### DIFF
--- a/.claude/skills/to-tickets/SKILL.md
+++ b/.claude/skills/to-tickets/SKILL.md
@@ -14,17 +14,21 @@ A ticket set is a **review artifact** — it is drafted as files and reviewed as
 
 ## Process
 
-### 1. Gather context
+### 1. Ensure a parent issue exists
+
+The tickets are parented to an issue, and the review branch is named for it (`{issue-number}-{slug}`). Most paths here already have one — `to-spec` published a spec issue, `wayfinder` has its map, `triage` has the incoming issue — so use it and skip creation. Reaching `to-tickets` directly from `grill-with-docs` — a well-understood feature that needs several tickets but no spec prose — does not, so mint an **epic** issue now (`docs/agents/issue-tracker.md`, `epic` label): a short parent that names the review branch, anchors its PR, and becomes each ticket's `Parent`. A genuinely standalone single ticket may omit the parent (the `Parent` template section is optional), but a set of related tickets should share one.
+
+### 2. Gather context
 
 Work from whatever is already in the conversation context. If the user passes a reference (a spec path, an issue number or URL) as an argument, fetch it and read its full body and comments.
 
-### 2. Explore the codebase (optional)
+### 3. Explore the codebase (optional)
 
 If you have not already explored the codebase, do so to understand the current state of the code. Ticket titles and descriptions should use the project's domain glossary vocabulary, and respect ADRs in the area you're touching.
 
 Look for opportunities to prefactor the code to make the implementation easier. "Make the change easy, then make the easy change."
 
-### 3. Draft vertical slices
+### 4. Draft vertical slices
 
 Break the work into **tracer bullet** tickets.
 
@@ -44,7 +48,7 @@ Give each ticket its **blocking edges** — the other tickets that must complete
 
 **Wide refactors are the exception to vertical slicing.** A **wide refactor** is one mechanical change — rename a column, retype a shared symbol — whose **blast radius** fans across the whole codebase, so a single edit breaks thousands of call sites at once and no vertical slice can land green. Don't force it into a tracer bullet; sequence it as **expand–contract**. First expand: add the new form beside the old so nothing breaks. Then migrate the call sites over in batches sized by blast radius (per package, per directory), each batch its own ticket blocked by the expand, keeping CI green batch to batch because the old form still exists. Finally contract: delete the old form once no caller remains, in a ticket blocked by every migrate batch. When even the batches can't stay green alone, keep the sequence but let them share an integration branch that all block a final integrate-and-verify ticket — green is promised only there.
 
-### 4. Quiz the user
+### 5. Quiz the user
 
 Present the proposed breakdown as a numbered list. For each ticket, show:
 
@@ -62,13 +66,13 @@ Ask the user:
 
 Iterate until the user approves the breakdown.
 
-### 5. Stage the tickets for review
+### 6. Stage the tickets for review
 
 Draft the approved tickets as local files under `docs/spec/<name>/` — one kebab-named file per ticket, using the issue-body template below — and open them as a PR against `develop` (draft per the repo convention, marked ready when set). This is the review gate (`docs/agents/spec-review.md`): the slicing is reviewed as a diff before any issue exists.
 
-### 6. Publish once the review PR merges
+### 7. Publish once the review PR merges
 
-After the PR is approved and merged, create the tickets on the issue tracker (GitHub Issues — see `docs/agents/issue-tracker.md`), one issue per ticket in dependency order (blockers first) so each ticket's blocking edges can reference real issue identifiers. Use GitHub's native sub-issue / blocking relationship where it fits; otherwise set each ticket's "Blocked by" to the blocking issues. Set each ticket's `Parent` to the spec issue. Apply the `ready-for-agent` triage label unless instructed otherwise — the tickets are agent-grabbable by construction.
+After the PR is approved and merged, create the tickets on the issue tracker (GitHub Issues — see `docs/agents/issue-tracker.md`), one issue per ticket in dependency order (blockers first) so each ticket's blocking edges can reference real issue identifiers. Use GitHub's native sub-issue / blocking relationship where it fits; otherwise set each ticket's "Blocked by" to the blocking issues. Set each ticket's `Parent` to the parent issue from step 1 — a spec issue, wayfinder map, or the minted epic. Apply the `ready-for-agent` triage label unless instructed otherwise — the tickets are agent-grabbable by construction.
 
 The temporary `docs/spec/<name>/` drafts are now on protected `develop`, so removing them needs its own commit: open a **small follow-up PR against `develop`** that deletes the folder once the tracker issues exist. The tracker issues are the durable home.
 

--- a/docs/agents/spec-review.md
+++ b/docs/agents/spec-review.md
@@ -7,7 +7,7 @@ It is **not** a planning flow and **not** attached to grilling or wayfinder. It 
 ## The requirement
 
 - **A spec** (`/to-spec`) is written to `docs/spec/<name>/spec.md`, opened as a PR against `develop` (draft per the repo PR convention, marked ready when set), reviewed, and merged. Only then is the spec published as its issue. If it came from a wayfinder map, the spec reads the map and links back to it.
-- **A plan** (`/to-tickets`) is drafted as local files under `docs/spec/<name>/` — one kebab-named file per proposed ticket — opened as a PR, reviewed, and merged. Only then are the tickets created on the tracker, each with `Parent` = the spec issue.
+- **A plan** (`/to-tickets`) is drafted as local files under `docs/spec/<name>/` — one kebab-named file per proposed ticket — opened as a PR, reviewed, and merged. Only then are the tickets created on the tracker, each with `Parent` = the parent issue (a spec issue, a wayfinder map, or an epic minted by `/to-tickets` when it is entered directly).
 - The staged files under `docs/spec/<name>/` are **temporary** — they exist for review. Once the issues exist, they are removed in a **small follow-up PR against `develop`** (the drafts merged to protected `develop`, so the deletion needs its own commit). The spec and its tickets are the durable home.
 
 ## What is *not* gated


### PR DESCRIPTION
Closes #699.

## What

Add a step-1 to the to-tickets skill, "Ensure a parent issue exists", mirroring the mint to-spec already has (#696). When to-tickets is reached directly from grilling — a well-understood, multi-ticket feature with no spec prose — it now mints an epic parent that names the review branch, anchors the review PR, and becomes each ticket's Parent. Paths that already carry a parent (to-spec, wayfinder, triage) use it and skip creation. The rest of the process steps are renumbered.

## Why

The spec/plan review gate names each review branch by an issue number and parents tickets to an upstream issue. to-spec got that anchor via #696; to-tickets did not, so a cold grill to-tickets run had no parent and no branch anchor. This closes the asymmetry and blesses grill to-tickets as a first-class path for well-understood, multi-ticket work.

## Also

Generalised the publish step and the spec-review doc from "Parent = the spec issue" to "the parent issue" (a spec issue, wayfinder map, or minted epic), since the parent is no longer always a spec.
