### PR TITLE
Scope spec-review gate to specs only; create tickets directly

### DIFF
--- a/.claude/skills/to-spec/SKILL.md
+++ b/.claude/skills/to-spec/SKILL.md
@@ -24,7 +24,7 @@ Check with the user that these seams match their expectations.
 
 4. Write the spec using the template below to `docs/spec/<name>/spec.md`, and open it as a PR for review (`docs/agents/spec-review.md`). Once the PR is approved and merged, publish the spec to the tracking issue from step 1 (creating one only if none exists yet) and apply the `ready-for-agent` triage label - no need for additional triage. `to-tickets` then breaks it into implementation tickets parented to this spec.
 
-   The staged `docs/spec/<name>/spec.md` is temporary. If `to-tickets` will run next, it drafts into the same folder and removes it (via its follow-up PR) after publishing; if this is a spec-only effort with no ticket breakout, remove `spec.md` in a small follow-up PR against `develop` once the spec issue exists.
+   The staged `docs/spec/<name>/spec.md` is temporary — it exists only for review. Once the spec issue exists, remove `spec.md` in a small follow-up PR against `develop`. (`to-tickets` creates its tickets directly on the tracker and no longer stages files, so it won't clean this up.)
 
 <spec-template>
 

--- a/.claude/skills/to-tickets/SKILL.md
+++ b/.claude/skills/to-tickets/SKILL.md
@@ -74,7 +74,7 @@ Do NOT close or modify any parent issue.
 
 ## Parent
 
-A reference to the parent issue on the issue tracker (if the source was an existing issue, otherwise omit this section).
+A reference to the originating spec issue or wayfinder map, if one exists — otherwise omit this section.
 
 ## What to build
 

--- a/.claude/skills/to-tickets/SKILL.md
+++ b/.claude/skills/to-tickets/SKILL.md
@@ -10,25 +10,21 @@ Break a plan, spec, or conversation into a set of **tickets** — tracer-bullet 
 
 Issue tracker conventions live in `docs/agents/issue-tracker.md`; the triage label vocabulary lives in `docs/agents/triage-labels.md`.
 
-A ticket set is a **review artifact** — it is drafted as files and reviewed as a PR before the tickets publish. This is the gate that keeps unreviewed tickets off the tracker. See `docs/agents/spec-review.md`.
+Tickets are **created directly on the tracker** after the quiz below — not staged as files or gated behind a PR. Their slicing is reviewed interactively here and then on the tracker, the same way `wayfinder` investigation tickets are; only a **spec** passes through the file-review gate (see `docs/agents/spec-review.md`).
 
 ## Process
 
-### 1. Ensure a parent issue exists
-
-The tickets are parented to an issue, and the review branch is named for it (`{issue-number}-{slug}`). Most paths here already have one — `to-spec` published a spec issue, `wayfinder` has its map, `triage` has the incoming issue — so use it and skip creation. Reaching `to-tickets` directly from `grill-with-docs` — a well-understood feature that needs several tickets but no spec prose — does not, so mint an **epic** issue now (`docs/agents/issue-tracker.md`, `epic` label): a short parent that names the review branch, anchors its PR, and becomes each ticket's `Parent`. A genuinely standalone single ticket may omit the parent (the `Parent` template section is optional), but a set of related tickets should share one.
-
-### 2. Gather context
+### 1. Gather context
 
 Work from whatever is already in the conversation context. If the user passes a reference (a spec path, an issue number or URL) as an argument, fetch it and read its full body and comments.
 
-### 3. Explore the codebase (optional)
+### 2. Explore the codebase (optional)
 
 If you have not already explored the codebase, do so to understand the current state of the code. Ticket titles and descriptions should use the project's domain glossary vocabulary, and respect ADRs in the area you're touching.
 
 Look for opportunities to prefactor the code to make the implementation easier. "Make the change easy, then make the easy change."
 
-### 4. Draft vertical slices
+### 3. Draft vertical slices
 
 Break the work into **tracer bullet** tickets.
 
@@ -48,7 +44,7 @@ Give each ticket its **blocking edges** — the other tickets that must complete
 
 **Wide refactors are the exception to vertical slicing.** A **wide refactor** is one mechanical change — rename a column, retype a shared symbol — whose **blast radius** fans across the whole codebase, so a single edit breaks thousands of call sites at once and no vertical slice can land green. Don't force it into a tracer bullet; sequence it as **expand–contract**. First expand: add the new form beside the old so nothing breaks. Then migrate the call sites over in batches sized by blast radius (per package, per directory), each batch its own ticket blocked by the expand, keeping CI green batch to batch because the old form still exists. Finally contract: delete the old form once no caller remains, in a ticket blocked by every migrate batch. When even the batches can't stay green alone, keep the sequence but let them share an integration branch that all block a final integrate-and-verify ticket — green is promised only there.
 
-### 5. Quiz the user
+### 4. Quiz the user
 
 Present the proposed breakdown as a numbered list. For each ticket, show:
 
@@ -66,15 +62,11 @@ Ask the user:
 
 Iterate until the user approves the breakdown.
 
-### 6. Stage the tickets for review
+### 5. Create the tickets on the tracker
 
-Draft the approved tickets as local files under `docs/spec/<name>/` — one kebab-named file per ticket, using the issue-body template below — and open them as a PR against `develop` (draft per the repo convention, marked ready when set). This is the review gate (`docs/agents/spec-review.md`): the slicing is reviewed as a diff before any issue exists.
+Once the user approves the breakdown, create the tickets directly on the issue tracker (GitHub Issues — see `docs/agents/issue-tracker.md`), one issue per ticket in dependency order (blockers first) so each ticket's blocking edges can reference real issue identifiers, using the issue-body template below. There is no file-staging step and no review PR — the slicing was reviewed in the quiz and stays reviewable on the tracker.
 
-### 7. Publish once the review PR merges
-
-After the PR is approved and merged, create the tickets on the issue tracker (GitHub Issues — see `docs/agents/issue-tracker.md`), one issue per ticket in dependency order (blockers first) so each ticket's blocking edges can reference real issue identifiers. Use GitHub's native sub-issue / blocking relationship where it fits; otherwise set each ticket's "Blocked by" to the blocking issues. Set each ticket's `Parent` to the parent issue from step 1 — a spec issue, wayfinder map, or the minted epic. Apply the `ready-for-agent` triage label unless instructed otherwise — the tickets are agent-grabbable by construction.
-
-The temporary `docs/spec/<name>/` drafts are now on protected `develop`, so removing them needs its own commit: open a **small follow-up PR against `develop`** that deletes the folder once the tracker issues exist. The tracker issues are the durable home.
+Use GitHub's native sub-issue / blocking relationship where it fits; otherwise set each ticket's "Blocked by" to the blocking issues. Set each ticket's `Parent` to the originating spec issue (or wayfinder map) **if one exists** — otherwise omit it; do not invent a parent. Apply the `ready-for-agent` triage label unless instructed otherwise — the tickets are agent-grabbable by construction.
 
 Do NOT close or modify any parent issue.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,9 +56,9 @@ The **main flow** (idea → ship): `grill-with-docs` sharpen the idea → `to-sp
 
 **On-ramps** merge onto that flow: a huge, foggy effort too big for one session → `wayfinder`, which charts a map of investigation tickets on the tracker, then merges at `to-spec` (one map can feed several specs); raw incoming issues → `triage`.
 
-**Spec/plan review:** a spec (`to-spec`) or ticket set (`to-tickets`) is staged as a file and reviewed as a PR before it publishes to the tracker — see `docs/agents/spec-review.md`. Wayfinder investigation tickets are reviewed on the tracker instead and don't pass through this gate.
+**Spec review:** a spec (`to-spec`) is staged as a file and reviewed as a PR before it publishes to the tracker — see `docs/agents/spec-review.md`. Implementation tickets (`to-tickets`) and wayfinder investigation tickets are created directly on the tracker and reviewed there instead — they don't pass through this gate.
 
-See `docs/adr/0002-misc-adopt-matt-pocock-skills.md`, `docs/adr/0003-misc-rename-to-spec-to-tickets.md`, `docs/adr/0004-misc-split-grill-with-docs.md`, and `docs/adr/0005-misc-wayfinder-and-spec-review.md`. The `caveman` terse mode is on by default in this repo as a pilot — see the Communication section above.
+See `docs/adr/0002-misc-adopt-matt-pocock-skills.md`, `docs/adr/0003-misc-rename-to-spec-to-tickets.md`, `docs/adr/0004-misc-split-grill-with-docs.md`, `docs/adr/0005-misc-wayfinder-and-spec-review.md`, and `docs/adr/0006-misc-spec-review-gate-specs-only.md`. The `caveman` terse mode is on by default in this repo as a pilot — see the Communication section above.
 
 ### Issue tracker
 

--- a/docs/adr/0005-misc-wayfinder-and-spec-review.md
+++ b/docs/adr/0005-misc-wayfinder-and-spec-review.md
@@ -1,5 +1,7 @@
 # Adopt wayfinder + implement, and reshape the planning pipeline into a spec/plan review requirement
 
+> **Amended by [ADR-0006](0006-misc-spec-review-gate-specs-only.md).** The review gate described here as covering *two* artifact types — a spec and a plan/ticket set — was later narrowed to **specs only**. Implementation tickets (`to-tickets`) are now created directly on the tracker and reviewed there, like wayfinder investigation tickets. Read the plan/ticket-set gating below as superseded; the spec gating and everything else in this ADR stand.
+
 Argos completes the Matt Pocock engineering-flow adoption. It takes his main flow as the spine — `grill-with-docs → to-spec → to-tickets → implement` — adds `wayfinder` as the exploration on-ramp and `research` as a delegated-reading skill, and reshapes the branch-based planning pipeline (proposed in #669) from a default multi-phase flow into a narrow **spec/plan review requirement**. This supersedes the planning-pipeline design; #669 is closed in its favour.
 
 ## Considered Options

--- a/docs/adr/0006-misc-spec-review-gate-specs-only.md
+++ b/docs/adr/0006-misc-spec-review-gate-specs-only.md
@@ -1,0 +1,25 @@
+# Scope the spec/plan review gate to specs only; create implementation tickets directly
+
+Argos narrows the spec/plan review gate introduced in [ADR-0005](0005-misc-wayfinder-and-spec-review.md) so it covers **specs only**. Implementation tickets from `to-tickets` are no longer staged as files and reviewed via a PR before publishing; they are created directly on the issue tracker after the skill's interactive quiz, then reviewed and refined as issues — the same treatment wayfinder investigation tickets already get. This also drops the epic-parent minting `to-tickets` had briefly gained (#700): a ticket links to its spec via `Parent` only when a spec exists, otherwise it stands alone, wired to its blockers by `Blocked by`.
+
+## Considered Options
+
+- Keep the gate over both specs and ticket sets (the ADR-0005 shape). Rejected — staging every tracer-bullet slice as a file, opening a review PR, merging, then a follow-up PR to delete the drafts is heavy ceremony for lightweight issues that are already editable on the tracker, and it diverges from Matt Pocock's adopted flow.
+- Drop the gate entirely. Rejected — a spec is where a feature's direction is decided and is worth reviewing as a diff before the team commits to it.
+- Gate specs only; create tickets directly (chosen).
+
+## Why this shape
+
+- **Only the spec is a decision artifact worth a diff review.** Ticket slicing is downstream and comparatively mechanical; it is already reviewed interactively in the `to-tickets` quiz and stays reviewable on the tracker.
+- **It matches the adopted source flow.** Matt Pocock's `to-issues` / `to-tickets` files tickets directly with `gh issue create`; the file-staging gate was an Argos addition. His core ticket shape is `What to build` / `Acceptance criteria` / `Blocked by` — a flat dependency graph, not an epic hierarchy.
+- **No invented parents.** A `Parent` link means "the spec that motivated these tickets." With no spec there is no parent to link, so tickets stand alone; minting a hollow epic just to have a parent (as #700 did) contradicts the flat `Blocked by` model.
+- **Precedent already existed.** ADR-0005 already exempted wayfinder investigation tickets from the gate, reviewing them on the tracker. This extends that treatment to implementation tickets.
+
+## Consequences
+
+- `docs/agents/spec-review.md` is rewritten to a spec-only gate and retitled "Spec review"; `docs/spec/<name>/` now stages only `spec.md`. `to-spec` owns removing `spec.md` in its follow-up PR once the spec issue exists.
+- `to-tickets` loses its file-staging step, its review-PR step, its follow-up-delete step, and the #700 epic-mint step; it creates tickets directly on the tracker in dependency order, setting `Parent` only when a spec exists.
+- `CLAUDE.md` and `docs/agents/glossary.md` rename "Spec/plan review" to "Spec review" and note that tickets are created directly.
+- ADR-0005 is amended with a pointer here; its spec gating and everything else stand.
+
+See `docs/adr/0005-misc-wayfinder-and-spec-review.md`, `docs/agents/spec-review.md`, and `docs/agents/issue-tracker.md`.

--- a/docs/agents/glossary.md
+++ b/docs/agents/glossary.md
@@ -14,7 +14,7 @@ Plain-language definitions of the workflow and agent-tooling terms used across t
 
 **Spec (PRD).** A feature spec — you may also know this document as a PRD (Product Requirements Document). The `to-spec` skill writes one; `to-tickets` then breaks it into tracer-bullet tickets.
 
-**Spec/plan review.** The *process* the two artifacts above pass through, not an artifact itself: a spec (`to-spec`) or a ticket set (`to-tickets`) is staged as a file and reviewed as a PR before it publishes, so unreviewed tickets never reach the tracker. Not a planning flow, and not attached to grilling or wayfinder. See spec-review.md.
+**Spec review.** The *process* a spec passes through, not an artifact itself: a spec (`to-spec`) is staged as a file and reviewed as a PR before it publishes as an issue. Implementation tickets (`to-tickets`) are created directly on the tracker after the skill's quiz — not gated as files — so only a spec passes through this gate. Not a planning flow, and not attached to grilling or wayfinder. See spec-review.md.
 
 **Idea.** A raw, un-fleshed feature or bug scrap filed as a single needs-triage ticket before anyone has classified it — the lightweight counterpart to a spec. Filed by the `log-future-addition` skill for `/triage` to classify like any other intake. Deliberately thin; anything already thought through belongs in `to-spec` or `grill-with-docs`.
 

--- a/docs/agents/spec-review.md
+++ b/docs/agents/spec-review.md
@@ -1,22 +1,22 @@
-# Spec/plan review
+# Spec review
 
-Specs and plans are **review artifacts**. Before either publishes to the tracker as issues, it is staged as a file and reviewed as a git pull request. This is the one gate that keeps unreviewed tickets off the tracker.
+A **spec** is a review artifact. Before it publishes to the tracker as an issue, it is staged as a file and reviewed as a git pull request. This is the one gate that keeps an unreviewed feature direction off the tracker.
 
-It is **not** a planning flow and **not** attached to grilling or wayfinder. It attaches to two artifact types only — a **spec** (from `/to-spec`) and a **plan** / ticket set (from `/to-tickets`) — however they were produced.
+It is **not** a planning flow and **not** attached to grilling or wayfinder. It attaches to one artifact type — a **spec** (from `/to-spec`) — however it was produced.
 
 ## The requirement
 
 - **A spec** (`/to-spec`) is written to `docs/spec/<name>/spec.md`, opened as a PR against `develop` (draft per the repo PR convention, marked ready when set), reviewed, and merged. Only then is the spec published as its issue. If it came from a wayfinder map, the spec reads the map and links back to it.
-- **A plan** (`/to-tickets`) is drafted as local files under `docs/spec/<name>/` — one kebab-named file per proposed ticket — opened as a PR, reviewed, and merged. Only then are the tickets created on the tracker, each with `Parent` = the parent issue (a spec issue, a wayfinder map, or an epic minted by `/to-tickets` when it is entered directly).
-- The staged files under `docs/spec/<name>/` are **temporary** — they exist for review. Once the issues exist, they are removed in a **small follow-up PR against `develop`** (the drafts merged to protected `develop`, so the deletion needs its own commit). The spec and its tickets are the durable home.
+- The staged `docs/spec/<name>/spec.md` is **temporary** — it exists for review. Once the spec issue exists, it is removed in a **small follow-up PR against `develop`** (the draft merged to protected `develop`, so the deletion needs its own commit). The spec issue is the durable home.
 
 ## What is *not* gated
 
-- **Wayfinder investigation tickets** — reviewed continuously on the tracker as each resolves; they don't pass through this gate.
-- **A trivial one-liner** with no spec and no ticket set — nothing to review; `/implement` in place at the author's discretion.
+- **Implementation tickets** (`/to-tickets`) — created directly on the tracker after the skill's interactive quiz, then reviewed and refined as issues. Their slicing is reviewed live, not as a file diff, so they don't pass through this gate. Each links to its spec via `Parent` when one exists, and to its blockers via `Blocked by`.
+- **Wayfinder investigation tickets** — reviewed continuously on the tracker as each resolves; they don't pass through this gate either.
+- **A trivial one-liner** with no spec — nothing to review; `/implement` in place at the author's discretion.
 
 ## Why
 
-Two reasons, both about handoff. First, a plan people can see and comment on as a diff before it fans out into issues. Second — and this is the load-bearing one — **no unreviewed tickets spam the tracker**: an implementation ticket only exists once its slicing was approved.
+A spec is where a feature's direction is decided, so it is the thing worth reviewing as a diff before the team commits to it and before it fans out into implementation tickets. Ticket slicing is still reviewed — interactively in the `to-tickets` quiz and then on the tracker — just not as a staged file, matching how wayfinder tickets are handled.
 
 Issues carry the `ai-workflow` label when the subject is the AI dev workflow itself. See `issue-tracker.md` for the label palette and `glossary.md` for the terms.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,10 +1,9 @@
 # docs/spec/
 
-Staging area for the **spec/plan review** gate (`docs/agents/spec-review.md`).
+Staging area for the **spec review** gate (`docs/agents/spec-review.md`).
 
-Each in-review effort gets a folder `docs/spec/<name>/` holding:
+Each in-review spec gets a folder `docs/spec/<name>/` holding:
 
 - `spec.md` — the spec drafted by `/to-spec`, reviewed as a PR before it publishes as an issue.
-- one kebab-named file per proposed ticket — drafted by `/to-tickets`, reviewed as a PR before the tickets publish.
 
-These files are **temporary**: they exist for review and are deleted once the corresponding issues exist on the tracker. The tracker issues are the durable home. Persistent docs (ADRs, `CONTEXT.md`) do not live here.
+This file is **temporary**: it exists for review and is deleted once the spec issue exists on the tracker. The spec issue is the durable home. Implementation tickets (`/to-tickets`) are created directly on the tracker, not staged here. Persistent docs (ADRs, `CONTEXT.md`) do not live here either.


### PR DESCRIPTION
Closes #702.

Scopes the spec/plan review gate (ADR 0005) to specs only. Implementation tickets from to-tickets are now created directly on the tracker after the interactive quiz — no file-staging, no review PR, no follow-up delete — and reviewed there, like wayfinder tickets. Also removes the epic-mint added in #700: a ticket links to a spec via Parent only when one exists, else stands alone via Blocked by.

Touches: spec-review.md (rewritten spec-only, retitled), to-tickets (drops staging / publish-on-merge / epic-mint, creates direct), to-spec (owns spec.md cleanup), docs/spec/README.md, CLAUDE.md, glossary.md, and a new ADR 0006 (ADR 0005 amended with a pointer).

Rationale: aligns with Matt Pocock's direct-filing flow — his ticket shape is What / Acceptance / Blocked-by, a flat dependency graph, filed directly; the file gate was an Argos add-on.
