### PR TITLE
Add S Volts cell-voltage heatmap view and rename Voltage to C Volts

### DIFF
--- a/angular-client/src/pages/bms-debug-page/bms-debug-page.component.ts
+++ b/angular-client/src/pages/bms-debug-page/bms-debug-page.component.ts
@@ -45,6 +45,10 @@ export class BmsDebugPageComponent implements OnInit, OnDestroy {
       function: () => this.heatMapService.setAllSegViews(HeatMapView.Voltage)
     },
     {
+      name: formatAllSelectorName(HeatMapView.SVolts.toString()),
+      function: () => this.heatMapService.setAllSegViews(HeatMapView.SVolts)
+    },
+    {
       name: formatAllSelectorName(HeatMapView.Balancing.toString()),
       function: () => this.heatMapService.setAllSegViews(HeatMapView.Balancing)
     },

--- a/angular-client/src/pages/bms-debug-page/bms-segment-view/bms-segment-view.component.ts
+++ b/angular-client/src/pages/bms-debug-page/bms-segment-view/bms-segment-view.component.ts
@@ -63,6 +63,12 @@ export class BmsSegmentViewComponent implements OnInit, OnDestroy {
       }
     },
     {
+      name: HeatMapView.SVolts.toString(),
+      function: () => {
+        this.heatMapService.setCurrentView(this.segmentId, HeatMapView.SVolts);
+      }
+    },
+    {
       name: HeatMapView.Balancing.toString(),
       function: () => {
         this.heatMapService.setCurrentView(this.segmentId, HeatMapView.Balancing);

--- a/angular-client/src/pages/bms-debug-page/components/hex-tile/hex-tile.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/hex-tile/hex-tile.component.ts
@@ -4,6 +4,7 @@ import { HeatMapView } from 'src/services/heat-map.service';
 /** Maps each HeatMapView to its CSS modifier class suffix */
 const VIEW_CLASS_MAP: Record<HeatMapView, string> = {
   [HeatMapView.Voltage]: 'view-voltage',
+  [HeatMapView.SVolts]: 'view-voltage',
   [HeatMapView.Balancing]: 'view-balancing',
   [HeatMapView.Temperature]: 'view-temperature',
   [HeatMapView.CvsFailure]: 'view-cvs-failure'
@@ -12,6 +13,7 @@ const VIEW_CLASS_MAP: Record<HeatMapView, string> = {
 /** Maps each HeatMapView to the unit label shown inside the hex */
 const VIEW_UNIT_MAP: Record<HeatMapView, string> = {
   [HeatMapView.Voltage]: 'V',
+  [HeatMapView.SVolts]: 'V',
   [HeatMapView.Temperature]: '°C',
   [HeatMapView.Balancing]: '',
   [HeatMapView.CvsFailure]: ''

--- a/angular-client/src/pages/bms-debug-page/components/segment-heatmap/segment-heatmap.component.spec.ts
+++ b/angular-client/src/pages/bms-debug-page/components/segment-heatmap/segment-heatmap.component.spec.ts
@@ -1,0 +1,101 @@
+import { provideExperimentalZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DialogService } from 'primeng/dynamicdialog';
+import Storage from 'src/services/storage.service';
+import { CellService } from 'src/services/cell.service';
+import { HeatMapService, HeatMapView } from 'src/services/heat-map.service';
+import { DataValue } from 'src/utils/socket.utils';
+import { topics } from 'src/utils/topic.utils';
+import { SegmentHeatmapComponent } from './segment-heatmap.component';
+
+const SEGMENT = 0;
+const CELL = 0;
+const GREY = 'grey';
+
+const push = (storage: Storage, key: string, value: string): void => {
+  storage.addValue(key, { values: [value], time: '0', unit: '' } as DataValue);
+};
+
+/**
+ * Drives the heatmap through its real storage seam (Storage -> CellService ->
+ * SegmentHeatmapComponent) and asserts the value + color the component binds onto
+ * each hex tile, for the C Volts and S Volts views, plus the no-data grey.
+ *
+ * Assertions read the component's rendered outputs (alphaDisplayCells[].value and
+ * getColor) directly rather than re-running change detection per push: CellService
+ * mutates its readings synchronously on storage.next, and a shared module-level
+ * cell array means a template re-render would raise a spurious NG0100.
+ */
+describe('SegmentHeatmapComponent (storage seam)', () => {
+  let fixture: ComponentFixture<SegmentHeatmapComponent>;
+  let component: SegmentHeatmapComponent;
+  let storage: Storage;
+  let cellService: CellService;
+  let heatMap: HeatMapService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SegmentHeatmapComponent],
+      providers: [
+        provideExperimentalZonelessChangeDetection(),
+        Storage,
+        CellService,
+        HeatMapService,
+        { provide: DialogService, useValue: {} }
+      ]
+    }).compileComponents();
+
+    storage = TestBed.inject(Storage);
+    cellService = TestBed.inject(CellService);
+    heatMap = TestBed.inject(HeatMapService);
+    cellService.updateCellInfo(); // wire the per-cell storage subscriptions
+
+    fixture = TestBed.createComponent(SegmentHeatmapComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('segment', SEGMENT);
+    fixture.detectChanges(); // runs the effect (loads cells) + ngOnInit (view subscription)
+  });
+
+  const alphaCell = (cellNumber: number) => component.alphaDisplayCells.find((c) => c.cellLabel === cellNumber.toString());
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('renders the C Volts value and color from the Volts topic', () => {
+    heatMap.setCurrentView(SEGMENT, HeatMapView.Voltage);
+    push(storage, topics.alphaVolt(SEGMENT, CELL), '3.60');
+
+    expect(alphaCell(CELL)?.value).toBeCloseTo(3.6);
+    expect(component.getColor(alphaCell(CELL)!)).toBe('hsl(120, 100%, 50%)'); // (3.6 - 3.0) * 200 = 120
+  });
+
+  it('renders the S Volts value and color from the S_Volts topic, reusing the C Volts scale', () => {
+    heatMap.setCurrentView(SEGMENT, HeatMapView.SVolts);
+    push(storage, topics.alphaSVolt(SEGMENT, CELL), '3.50');
+
+    expect(alphaCell(CELL)?.value).toBeCloseTo(3.5);
+    expect(component.getColor(alphaCell(CELL)!)).toBe('hsl(100, 100%, 50%)'); // (3.5 - 3.0) * 200 = 100
+  });
+
+  it('shows the no-data grey for an S Volts cell with no value', () => {
+    heatMap.setCurrentView(SEGMENT, HeatMapView.SVolts);
+
+    // The last cell is never published to by any test in this suite.
+    const cells = component.alphaDisplayCells;
+    const untouched = cells[cells.length - 1];
+    expect(untouched.value).toBeUndefined();
+    expect(component.getColor(untouched)).toBe(GREY);
+  });
+
+  it('keeps C Volts and S Volts as independent readings for the same cell', () => {
+    push(storage, topics.alphaVolt(SEGMENT, CELL), '3.10');
+    push(storage, topics.alphaSVolt(SEGMENT, CELL), '3.50');
+
+    heatMap.setCurrentView(SEGMENT, HeatMapView.Voltage);
+    expect(alphaCell(CELL)?.value).toBeCloseTo(3.1);
+
+    heatMap.setCurrentView(SEGMENT, HeatMapView.SVolts);
+    expect(alphaCell(CELL)?.value).toBeCloseTo(3.5);
+  });
+});

--- a/angular-client/src/pages/bms-debug-page/components/segment-heatmap/segment-heatmap.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/segment-heatmap/segment-heatmap.component.ts
@@ -112,6 +112,7 @@ export class SegmentHeatmapComponent implements OnInit, OnDestroy {
   private getCellValue(cell: CellReading): number | undefined {
     if (this.view === HeatMapView.Temperature) return cell.temp;
     if (this.view === HeatMapView.Voltage) return cell.voltage;
+    if (this.view === HeatMapView.SVolts) return cell.svolts;
     return undefined;
   }
 

--- a/angular-client/src/pages/bms-debug-page/components/segment-row/segment-row.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/segment-row/segment-row.component.ts
@@ -32,6 +32,10 @@ export class SegmentRowComponent implements OnInit, OnDestroy {
       function: () => this.heatMapService.setCurrentView(this.segment(), HeatMapView.Voltage)
     },
     {
+      name: HeatMapView.SVolts.toString(),
+      function: () => this.heatMapService.setCurrentView(this.segment(), HeatMapView.SVolts)
+    },
+    {
       name: HeatMapView.Temperature.toString(),
       function: () => this.heatMapService.setCurrentView(this.segment(), HeatMapView.Temperature)
     },
@@ -48,14 +52,14 @@ export class SegmentRowComponent implements OnInit, OnDestroy {
   constructor() {}
 
   ngOnInit(): void {
-    this.viewSelectorConfig = { options: this.viewOptions, placeholder: 'Voltage' };
+    this.viewSelectorConfig = { options: this.viewOptions, placeholder: HeatMapView.Voltage.toString() };
     const viewSub = this.heatMapService.getCurrentView(this.segment());
     if (viewSub) {
       this.subscriptions.push(
         viewSub.subscribe((view) => {
           this.viewSelectorConfig = {
             ...this.viewSelectorConfig,
-            defaultValue: view !== undefined ? view : 'Voltage'
+            defaultValue: view !== undefined ? view : HeatMapView.Voltage.toString()
           };
         })
       );

--- a/angular-client/src/services/cell.service.ts
+++ b/angular-client/src/services/cell.service.ts
@@ -5,10 +5,12 @@ import Storage from './storage.service';
 import {
   allAlphaBurnValues,
   allAlphaCvsValues,
+  allAlphaSVoltValues,
   allAlphaThermValues,
   allAlphaVoltValues,
   allBetaBurnValues,
   allBetaCvsValues,
+  allBetaSVoltValues,
   allBetaThermValues,
   allBetaVoltValues,
   topics
@@ -19,6 +21,7 @@ export type CellReading = {
   segment: Segment;
   temp: number | undefined;
   voltage: number | undefined;
+  svolts: number | undefined;
   balancing: boolean | undefined;
   cvs: boolean | undefined;
   cellNumber: number;
@@ -32,6 +35,7 @@ const createSegmentCells = (segment: number, chip: Chip, count: number): CellRea
       segment,
       temp: undefined,
       voltage: undefined,
+      svolts: undefined,
       balancing: undefined,
       cvs: undefined,
       cellNumber: i
@@ -82,10 +86,17 @@ export class CellService {
         });
       });
 
-      // Volts: one per cell
+      // Volts: one per cell (C-ADC voltage)
       allAlphaVoltValues.forEach((volt, voltIndex) => {
         this.storageService.get(topics.alphaVolt(segmentNumber, volt)).subscribe((data) => {
           segmentAlphaCells[voltIndex].voltage = parseFloat(data.values[0]);
+        });
+      });
+
+      // S Volts: one per cell (S-ADC voltage, mirrors Volts)
+      allAlphaSVoltValues.forEach((sVolt, sVoltIndex) => {
+        this.storageService.get(topics.alphaSVolt(segmentNumber, sVolt)).subscribe((data) => {
+          segmentAlphaCells[sVoltIndex].svolts = parseFloat(data.values[0]);
         });
       });
 
@@ -122,10 +133,17 @@ export class CellService {
         });
       });
 
-      // Volts: one per cell
+      // Volts: one per cell (C-ADC voltage)
       allBetaVoltValues.map((volt, voltIndex) => {
         this.storageService.get(topics.betaVolt(segmentNumber, volt)).subscribe((data) => {
           segmentBetaCells[voltIndex].voltage = parseFloat(data.values[0]);
+        });
+      });
+
+      // S Volts: one per cell (S-ADC voltage, mirrors Volts)
+      allBetaSVoltValues.map((sVolt, sVoltIndex) => {
+        this.storageService.get(topics.betaSVolt(segmentNumber, sVolt)).subscribe((data) => {
+          segmentBetaCells[sVoltIndex].svolts = parseFloat(data.values[0]);
         });
       });
 

--- a/angular-client/src/services/heat-map.service.ts
+++ b/angular-client/src/services/heat-map.service.ts
@@ -6,7 +6,8 @@ import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { CellViewComponent } from 'src/pages/bms-debug-page/components/cell-view/cell-view.component';
 
 export enum HeatMapView {
-  Voltage = 'Voltage',
+  Voltage = 'C Volts',
+  SVolts = 'S Volts',
   Temperature = 'Temperature',
   Balancing = 'Balancing',
   CvsFailure = 'CvS Failure'

--- a/angular-client/src/utils/topic.utils.ts
+++ b/angular-client/src/utils/topic.utils.ts
@@ -22,6 +22,9 @@ export const alphaTemp = (segment: Segment, cell: number) => `BMS/PerCell/Alpha/
 export const betaTemp = (segment: Segment, cell: number) => `BMS/PerCell/Beta/${segment}/Therms/${cell}`;
 export const alphaVolt = (segment: Segment, cell: number) => `BMS/PerCell/Alpha/${segment}/Volts/${cell}`;
 export const betaVolt = (segment: Segment, cell: number) => `BMS/PerCell/Beta/${segment}/Volts/${cell}`;
+// S-ADC per-cell voltage (S Volts) — mirrors the C-ADC Volts topics above.
+export const alphaSVolt = (segment: Segment, cell: number) => `BMS/PerCell/Alpha/${segment}/S_Volts/${cell}`;
+export const betaSVolt = (segment: Segment, cell: number) => `BMS/PerCell/Beta/${segment}/S_Volts/${cell}`;
 export const alphaBurning = (segment: Segment, cell: number) => `BMS/PerCell/Alpha/${segment}/Burning/${cell}`;
 export const betaBurning = (segment: Segment, cell: number) => `BMS/PerCell/Beta/${segment}/Burning/${cell}`;
 export const alphaCvs = (segment: Segment, cell: number) => `BMS/PerCell/Alpha/${segment}/CvS/${cell}`;
@@ -173,6 +176,8 @@ export const topics = {
   betaTemp,
   alphaVolt,
   betaVolt,
+  alphaSVolt,
+  betaSVolt,
   alphaBurning,
   betaBurning,
   alphaCvs,
@@ -270,6 +275,9 @@ export const allAlphaThermValues: number[] = Array.from({ length: BMS_CONFIG.ALP
 export const allBetaThermValues: number[] = Array.from({ length: BMS_CONFIG.BETA_THERM_COUNT }, (_, i) => i * 2);
 export const allAlphaVoltValues: number[] = Array.from({ length: BMS_CONFIG.ALPHA_VOLT_COUNT }, (_, i) => i);
 export const allBetaVoltValues: number[] = Array.from({ length: BMS_CONFIG.BETA_VOLT_COUNT }, (_, i) => i);
+// S Volts cover the same per-cell set as C Volts, so reuse the Volts cell counts.
+export const allAlphaSVoltValues: number[] = Array.from({ length: BMS_CONFIG.ALPHA_VOLT_COUNT }, (_, i) => i);
+export const allBetaSVoltValues: number[] = Array.from({ length: BMS_CONFIG.BETA_VOLT_COUNT }, (_, i) => i);
 export const allAlphaBurnValues: number[] = Array.from({ length: BMS_CONFIG.ALPHA_BURN_COUNT }, (_, i) => i);
 export const allBetaBurnValues: number[] = Array.from({ length: BMS_CONFIG.BETA_BURN_COUNT }, (_, i) => i);
 export const allAlphaCvsValues: number[] = Array.from({ length: BMS_CONFIG.ALPHA_CVS_COUNT }, (_, i) => i);


### PR DESCRIPTION
## Changes

Adds an "S Volts" option to the BMS cell-voltage heatmap that shows each cell's S-ADC voltage exactly as the current view shows the C-ADC voltage, and renames the existing "Voltage" view to "C Volts".

The rename is label and view-model only: the underlying Volts topic, stored data, and color logic are unchanged (the HeatMapView.Voltage member keeps its name; only its display string changes).

S Volts appears in all three view selectors (per-segment, set-all, and the accumulator-overview per-row selector), reuses the C Volts color scale and unit, and shows the standard no-data grey where no S-ADC value has arrived. The per-cell topic is BMS/PerCell/{Alpha|Beta}/{segment}/S_Volts/{cell}.

Frontend-only: telemetry ingest is schemaless (Topic = DataType), so there is no scylla-server, Charybdis, or Siren change.

## Notes

Build-ahead-of-firmware: the S_Volts per-cell topic is not yet in the shipped Odyssey definitions, so tiles render grey against real data until firmware publishes it. Verified by injecting S_Volts through the calypso sim.

Pre-existing and unrelated to this PR: the repo's full ng test suite does not run to green on develop today — the spec tsconfig omits node types, one graph-page spec has a stale type error, and specs need the zoneless change-detection provider after the app moved to zoneless. Worth a separate test-harness-repair ticket.

## Test Cases

- The former "Voltage" view now reads "C Volts" in all three selectors (per-segment, set-all, accumulator per-row).
- S Volts is selectable in all three selectors and renders each cell's S-ADC voltage on the same color scale and unit as C Volts.
- No S-ADC data: S Volts tiles show the standard no-data grey.
- New segment-heatmap storage-seam spec drives Storage through CellService to the SegmentHeatmapComponent and asserts rendered value and color for S Volts and C Volts plus the no-data grey; passes in isolation.
- ng build: green.

## Screenshots

Full Accumulator (BMS) page, normal window.

Renamed view — "C Volts" in the Set-All and per-segment selectors:

<img src="https://github.com/user-attachments/assets/e59e62dc-a454-48e5-9368-e758e617fc6e" width="820" />

New "S Volts" view selected, before any S-ADC data arrives (standard no-data grey):

<img src="https://github.com/user-attachments/assets/6f9ff9af-3244-4c7a-a86c-d7e7d10b1672" width="820" />

"S Volts" with values injected through the calypso sim — same color scale and unit as C Volts:

<img src="https://github.com/user-attachments/assets/2494f7f5-4791-4900-8979-125b7997918b" width="820" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #704.
