### PR TITLE
#708 - fix repo-wide broken ng test, gate with CI

### DIFF
--- a/.github/workflows/test-check.yml
+++ b/.github/workflows/test-check.yml
@@ -1,0 +1,31 @@
+name: Frontend Unit Tests
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+      - "feature/**"
+
+jobs:
+  run-frontend-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.17.0
+          cache: "npm"
+          cache-dependency-path: ./angular-client/package-lock.json
+      - name: Install modules
+        working-directory: ./angular-client
+        run: npm ci
+      - name: Run unit tests
+        working-directory: ./angular-client
+        run: npm run test:ci

--- a/angular-client/angular.json
+++ b/angular-client/angular.json
@@ -80,6 +80,7 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
+            "main": "src/test-setup.ts",
             "tsConfig": "tsconfig.spec.json",
             "assets": ["src/favicon.ico", "src/assets"],
             "styles": ["@angular/material/prebuilt-themes/rose-red.css", "src/styles.css"],

--- a/angular-client/package.json
+++ b/angular-client/package.json
@@ -11,7 +11,8 @@
     "start:production": "ng serve --configuration production --host 0.0.0.0",
     "install-dependencies": "npm install",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "test:ci": "ng test --watch=false --browsers=ChromeHeadless"
   },
   "private": true,
   "dependencies": {

--- a/angular-client/src/app/app-nav-bar/app-nav-bar.component.ts
+++ b/angular-client/src/app/app-nav-bar/app-nav-bar.component.ts
@@ -6,7 +6,7 @@ import { interval, map, Observable, startWith, Subscription } from 'rxjs';
 import { startNewRun } from 'src/api/run.api';
 import APIService from 'src/services/api.service';
 import SidebarService from 'src/services/sidebar.service';
-import { appRoutes } from '../app-routing.module';
+import { appRoutes } from '../app-routes';
 import { Sidebar } from 'primeng/sidebar';
 import { CurrentRunDisplayComponent } from '../../pages/landing-page/components/current-run-display/current-run-display.component';
 import { ToastButtonComponent } from '../../components/toast-button/toast-button.component';

--- a/angular-client/src/app/app-routes.ts
+++ b/angular-client/src/app/app-routes.ts
@@ -1,0 +1,37 @@
+import { Segment } from 'src/utils/bms.utils';
+
+// Route-path builders live here, separate from AppRoutingModule, so that components can import
+// `appRoutes` without pulling in the NgModule (which imports every page component). That import
+// direction created component <-> app-routing.module cycles that threw module-load TDZ errors.
+
+const landingRoute = () => `/landing`;
+const graphRoute = () => `/graph`;
+const mapRoute = () => `/map`;
+const chargingRoute = () => `/charging`;
+const bmsRoute = () => `/bms`;
+const bmsSegmentViewRoute = (id: Segment) => `/bms/segment/${id + 1}`;
+const cameraRoute = () => `/camera`;
+const faultsRoute = () => `/faults`;
+const faultsGraphRoute = () => `/faults/fault-graph`;
+const commandsRoute = () => `/commands`;
+const rulesRoute = () => `/rules`;
+const efusesRoute = () => `/efuses`;
+const notificationLogRoute = () => `/notification-log`;
+const lapTimerRoute = () => `/lap-timer`;
+
+export const appRoutes = {
+  landingRoute,
+  graphRoute,
+  mapRoute,
+  chargingRoute,
+  bmsRoute,
+  bmsSegmentViewRoute,
+  cameraRoute,
+  faultsRoute,
+  faultsGraphRoute,
+  commandsRoute,
+  rulesRoute,
+  efusesRoute,
+  notificationLogRoute,
+  lapTimerRoute
+};

--- a/angular-client/src/app/app-routing.module.ts
+++ b/angular-client/src/app/app-routing.module.ts
@@ -13,39 +13,7 @@ import LandingPageComponent from 'src/pages/landing-page/landing-page.component'
 import LapTimerPageComponent from 'src/pages/lap-timer-page/lap-timer-page.component';
 import MapComponent from 'src/pages/map/map.component';
 import NotificationRulesPageComponent from 'src/pages/notification-rules-page/notification-rules-page.component';
-import { Segment } from 'src/utils/bms.utils';
-
-const landingRoute = () => `/landing`;
-const graphRoute = () => `/graph`;
-const mapRoute = () => `/map`;
-const chargingRoute = () => `/charging`;
-const bmsRoute = () => `/bms`;
-const bmsSegmentViewRoute = (id: Segment) => `/bms/segment/${id + 1}`;
-const cameraRoute = () => `/camera`;
-const faultsRoute = () => `/faults`;
-const faultsGraphRoute = () => `/faults/fault-graph`;
-const commandsRoute = () => `/commands`;
-const rulesRoute = () => `/rules`;
-const efusesRoute = () => `/efuses`;
-const notificationLogRoute = () => `/notification-log`;
-const lapTimerRoute = () => `/lap-timer`;
-
-export const appRoutes = {
-  landingRoute,
-  graphRoute,
-  mapRoute,
-  chargingRoute,
-  bmsRoute,
-  bmsSegmentViewRoute,
-  cameraRoute,
-  faultsRoute,
-  faultsGraphRoute,
-  commandsRoute,
-  rulesRoute,
-  efusesRoute,
-  notificationLogRoute,
-  lapTimerRoute
-};
+import { appRoutes } from './app-routes';
 
 // Routes should be defined carefully in accordance with the appRoutes
 const routes: Routes = [

--- a/angular-client/src/components/connection-dot-with-message/connection-dot-with-message.component.spec.ts
+++ b/angular-client/src/components/connection-dot-with-message/connection-dot-with-message.component.spec.ts
@@ -13,6 +13,8 @@ describe('ConnectionDotWithMessageComponent', () => {
 
     fixture = TestBed.createComponent(ConnectionDotWithMessageComponent);
     component = fixture.componentInstance;
+    // getStatusColor is a required input read by the template.
+    fixture.componentRef.setInput('getStatusColor', () => 'green');
     fixture.detectChanges();
   });
 

--- a/angular-client/src/components/form-template/form-template.component.spec.ts
+++ b/angular-client/src/components/form-template/form-template.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
 import { FormTemplateComponent } from './form-template.component';
 
@@ -8,11 +9,17 @@ describe('FormTemplateComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [FormTemplateComponent]
+      imports: [FormTemplateComponent],
+      providers: [
+        { provide: DynamicDialogConfig, useValue: { data: {} } },
+        { provide: DynamicDialogRef, useValue: { close: () => {} } }
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(FormTemplateComponent);
     component = fixture.componentInstance;
+    // fields is a required input consumed by ngOnInit -> buildForm.
+    fixture.componentRef.setInput('fields', []);
     fixture.detectChanges();
   });
 

--- a/angular-client/src/components/nav-options-menu/nav-options-menu.component.spec.ts
+++ b/angular-client/src/components/nav-options-menu/nav-options-menu.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DynamicDialogConfig } from 'primeng/dynamicdialog';
 
 import { NavOptionsMenuComponent } from './nav-options-menu.component';
 
@@ -8,7 +9,8 @@ describe('NavOptionsMenuComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NavOptionsMenuComponent]
+      imports: [NavOptionsMenuComponent],
+      providers: [{ provide: DynamicDialogConfig, useValue: { data: { items: [] } } }]
     }).compileComponents();
 
     fixture = TestBed.createComponent(NavOptionsMenuComponent);

--- a/angular-client/src/components/notification-list/notification-list.component.ts
+++ b/angular-client/src/components/notification-list/notification-list.component.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router';
 import { DatePipe } from '@angular/common';
 import { Button } from 'primeng/button';
 import { NotificationLogService } from 'src/services/notification-log.service';
-import { appRoutes } from 'src/app/app-routing.module';
+import { appRoutes } from 'src/app/app-routes';
 
 export type NotificationListVariant = 'popover' | 'stream';
 

--- a/angular-client/src/components/run-form/run-form.component.spec.ts
+++ b/angular-client/src/components/run-form/run-form.component.spec.ts
@@ -1,4 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MessageService } from 'primeng/api';
+import { DynamicDialogRef } from 'primeng/dynamicdialog';
+import { Subject } from 'rxjs';
 
 import { RunFormComponent } from './run-form.component';
 
@@ -8,7 +11,8 @@ describe('RunFormComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RunFormComponent]
+      imports: [RunFormComponent],
+      providers: [MessageService, { provide: DynamicDialogRef, useValue: { close: () => {}, onClose: new Subject() } }]
     }).compileComponents();
 
     fixture = TestBed.createComponent(RunFormComponent);

--- a/angular-client/src/pages/bms-debug-page/bms-segment-view/bms-segment-view.component.spec.ts
+++ b/angular-client/src/pages/bms-debug-page/bms-segment-view/bms-segment-view.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { of } from 'rxjs';
 
 import { BmsSegmentViewComponent } from './bms-segment-view.component';
 
@@ -7,8 +9,15 @@ describe('BmsSegmentViewComponent', () => {
   let fixture: ComponentFixture<BmsSegmentViewComponent>;
 
   beforeEach(async () => {
+    const routeMock = { url: of([]), paramMap: of(convertToParamMap({ id: '1' })) };
+    const routerMock = { navigate: () => Promise.resolve(true), url: '/bms/segment/1' };
+
     await TestBed.configureTestingModule({
-      imports: [BmsSegmentViewComponent]
+      imports: [BmsSegmentViewComponent],
+      providers: [
+        { provide: ActivatedRoute, useValue: routeMock },
+        { provide: Router, useValue: routerMock }
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(BmsSegmentViewComponent);

--- a/angular-client/src/pages/bms-debug-page/components/bms-at-a-glance/bms-at-a-glance.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/bms-at-a-glance/bms-at-a-glance.component.ts
@@ -7,7 +7,7 @@ import {
   getCellChipLabel,
   getChipFromTopicValue,
   getConnectionDotStatusColor,
-  segmentInfoMap
+  segmentInfo
 } from 'src/utils/bms.utils';
 import { topics } from 'src/utils/topic.utils';
 import { BatteryLevelIndicatorComponent } from '../../../../components/battery-level-indicator/battery-level-indicator.component';
@@ -33,7 +33,7 @@ export class BmsAtAGlanceComponent {
   private storage = inject(Storage);
 
   protected packVoltage = toSignal(
-    combineLatest(allSegments.map((seg) => this.storage.get(segmentInfoMap[seg].totalVoltageKey))).pipe(
+    combineLatest(allSegments.map((seg) => this.storage.get(segmentInfo(seg).totalVoltageKey))).pipe(
       map((segments) => segments.reduce((sum, v) => sum + parseFloat(v.values[0]), 0))
     )
   );

--- a/angular-client/src/pages/bms-debug-page/components/bms-header/bms-header.component.spec.ts
+++ b/angular-client/src/pages/bms-debug-page/components/bms-header/bms-header.component.spec.ts
@@ -13,6 +13,7 @@ describe('BmsHeaderComponent', () => {
 
     fixture = TestBed.createComponent(BmsHeaderComponent);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput('pageTitle', 'Test');
     fixture.detectChanges();
   });
 

--- a/angular-client/src/pages/bms-debug-page/components/cell-view/cell-view.component.spec.ts
+++ b/angular-client/src/pages/bms-debug-page/components/cell-view/cell-view.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DynamicDialogConfig } from 'primeng/dynamicdialog';
 
 import { CellViewComponent } from './cell-view.component';
 
@@ -8,7 +9,8 @@ describe('CellViewComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [CellViewComponent]
+      imports: [CellViewComponent],
+      providers: [{ provide: DynamicDialogConfig, useValue: { data: { cells: new Map() } } }]
     }).compileComponents();
 
     fixture = TestBed.createComponent(CellViewComponent);

--- a/angular-client/src/pages/bms-debug-page/components/chip-diagnostics/chip-diagnostics.component.spec.ts
+++ b/angular-client/src/pages/bms-debug-page/components/chip-diagnostics/chip-diagnostics.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Chip } from 'src/utils/bms.utils';
 
 import { ChipDiagnosticsComponent } from './chip-diagnostics.component';
 
@@ -13,6 +14,8 @@ describe('ChipDiagnosticsComponent', () => {
 
     fixture = TestBed.createComponent(ChipDiagnosticsComponent);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput('chip', Chip.Alpha);
+    fixture.componentRef.setInput('segment', 0);
     fixture.detectChanges();
   });
 

--- a/angular-client/src/pages/bms-debug-page/components/chip-faults/chip-faults.component.spec.ts
+++ b/angular-client/src/pages/bms-debug-page/components/chip-faults/chip-faults.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Chip } from 'src/utils/bms.utils';
 
 import { ChipFaultsComponent } from './chip-faults.component';
 
@@ -13,6 +14,8 @@ describe('ChipFaultsComponent', () => {
 
     fixture = TestBed.createComponent(ChipFaultsComponent);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput('chip', Chip.Alpha);
+    fixture.componentRef.setInput('segment', 0);
     fixture.detectChanges();
   });
 

--- a/angular-client/src/pages/bms-debug-page/components/chip-faults/chip-faults.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/chip-faults/chip-faults.component.ts
@@ -1,7 +1,7 @@
 import { Component, effect, inject, input, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';
-import { appRoutes } from 'src/app/app-routing.module';
+import { appRoutes } from 'src/app/app-routes';
 import { FaultService } from 'src/services/fault.service';
 import Storage from 'src/services/storage.service';
 import { Chip, chipToString } from 'src/utils/bms.utils';

--- a/angular-client/src/pages/bms-debug-page/components/segment-at-a-glance/segment-at-a-glance.component.spec.ts
+++ b/angular-client/src/pages/bms-debug-page/components/segment-at-a-glance/segment-at-a-glance.component.spec.ts
@@ -13,6 +13,7 @@ describe('SegmentAtAGlanceComponent', () => {
 
     fixture = TestBed.createComponent(SegmentAtAGlanceComponent);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput('segmentNumber', 0);
     fixture.detectChanges();
   });
 

--- a/angular-client/src/pages/bms-debug-page/components/segment-overview/segment-overview.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/segment-overview/segment-overview.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, input, OnDestroy, OnInit, signal } from '@angular/core';
 import { Subscription } from 'rxjs';
 import Storage from 'src/services/storage.service';
-import { Segment, segmentInfoMap, SegmentInfo } from 'src/utils/bms.utils';
+import { Segment, segmentInfo, SegmentInfo } from 'src/utils/bms.utils';
 import { StatConfig, StatSummaryComponent } from 'src/components/stat-summary/stat-summary.component';
 
 const DEFAULT_SEGMENT_STATS: StatConfig[] = [
@@ -28,7 +28,7 @@ export class SegmentOverviewComponent implements OnInit, OnDestroy {
   statConfigs = signal<StatConfig[]>(DEFAULT_SEGMENT_STATS);
 
   ngOnInit(): void {
-    const info = segmentInfoMap[this.segment()];
+    const info = segmentInfo(this.segment());
     const configs = [...DEFAULT_SEGMENT_STATS];
 
     SEGMENT_TOPIC_KEYS.forEach((key, i) => {

--- a/angular-client/src/pages/bms-debug-page/components/segment-row/segment-row.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/segment-row/segment-row.component.ts
@@ -8,7 +8,7 @@ import {
   SelectorConfig,
   SelectDropdownComponent
 } from 'src/components/select-dropdown/select-dropdown.component';
-import { appRoutes } from 'src/app/app-routing.module';
+import { appRoutes } from 'src/app/app-routes';
 import { SegmentHeatmapComponent } from '../segment-heatmap/segment-heatmap.component';
 import { SegmentOverviewComponent } from '../segment-overview/segment-overview.component';
 

--- a/angular-client/src/pages/bms-debug-page/components/segment-selector/segment-selector.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/segment-selector/segment-selector.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { appRoutes } from 'src/app/app-routing.module';
+import { appRoutes } from 'src/app/app-routes';
 import { DropdownOption } from 'src/components/select-dropdown/select-dropdown.component';
 import { allSegments } from 'src/utils/bms.utils';
 import { InfoBackgroundComponent } from '../../../../components/info-background/info-background.component';

--- a/angular-client/src/pages/bms-debug-page/components/segment-summary/segment-summary.component.spec.ts
+++ b/angular-client/src/pages/bms-debug-page/components/segment-summary/segment-summary.component.spec.ts
@@ -13,6 +13,7 @@ describe('SegmentSummaryComponent', () => {
 
     fixture = TestBed.createComponent(SegmentSummaryComponent);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput('segmentNumber', 0);
     fixture.detectChanges();
   });
 

--- a/angular-client/src/pages/bms-debug-page/components/segment-summary/segment-summary.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/segment-summary/segment-summary.component.ts
@@ -1,9 +1,9 @@
 import { Component, inject, input, OnDestroy, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { Router } from '@angular/router';
-import { appRoutes } from 'src/app/app-routing.module';
+import { appRoutes } from 'src/app/app-routes';
 import Storage from 'src/services/storage.service';
-import { SegmentInfo, Segment, segmentInfoMap } from 'src/utils/bms.utils';
+import { SegmentInfo, Segment, segmentInfo } from 'src/utils/bms.utils';
 import { InfoBackgroundComponent } from '../../../../components/info-background/info-background.component';
 
 import { InfoValueDisplayComponent } from '../../../../components/info-value-dispaly/info-value-display.component';
@@ -59,7 +59,7 @@ export class SegmentSummaryComponent implements OnInit, OnDestroy {
   };
 
   getRelevantKeys = (): SegmentInfo => {
-    return segmentInfoMap[this.segmentNumber()];
+    return segmentInfo(this.segmentNumber());
   };
 
   ngOnDestroy(): void {

--- a/angular-client/src/pages/fault-page/fault-page.component.ts
+++ b/angular-client/src/pages/fault-page/fault-page.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { appRoutes } from 'src/app/app-routing.module';
+import { appRoutes } from 'src/app/app-routes';
 import { FaultService } from 'src/services/fault.service';
 import { FaultData, FaultNode } from 'src/utils/types.utils';
 

--- a/angular-client/src/pages/graph-page/graph-page.component.spec.ts
+++ b/angular-client/src/pages/graph-page/graph-page.component.spec.ts
@@ -32,7 +32,7 @@ describe('GraphPageComponent — URL/topic-selection sync', () => {
     const apiServiceMock: Pick<APIService, 'query'> = {
       query: <T>() => {
         queryCalls += 1;
-        const response: QueryResponse<unknown> =
+        const response =
           queryCalls === 1
             ? {
                 isLoading: new BehaviorSubject<boolean>(true),
@@ -46,7 +46,7 @@ describe('GraphPageComponent — URL/topic-selection sync', () => {
                 isError: new BehaviorSubject<boolean>(false),
                 error: new BehaviorSubject<Error | null>(null)
               };
-        return response as QueryResponse<T>;
+        return response as unknown as QueryResponse<T>;
       }
     };
 

--- a/angular-client/src/pages/graph-page/graph-page.component.ts
+++ b/angular-client/src/pages/graph-page/graph-page.component.ts
@@ -5,7 +5,7 @@ import { BehaviorSubject, Subscription } from 'rxjs';
 import { getDataByDatatTypeNameAndTiming, getDataByDataTypeNameAndRunId } from 'src/api/data.api';
 import { getAllDatatypes } from 'src/api/datatype.api';
 import { getAllRuns } from 'src/api/run.api';
-import { appRoutes } from 'src/app/app-routing.module';
+import { appRoutes } from 'src/app/app-routes';
 import APIService from 'src/services/api.service';
 import { FaultService } from 'src/services/fault.service';
 import Storage from 'src/services/storage.service';

--- a/angular-client/src/pages/notification-rules-page/notification-rules-page.component.spec.ts
+++ b/angular-client/src/pages/notification-rules-page/notification-rules-page.component.spec.ts
@@ -9,6 +9,9 @@ describe('NotificationRulesPageComponent', () => {
   let messageService: MessageService;
 
   beforeEach(async () => {
+    // The real app eagerly creates the client ID in AppContextComponent; the page only reads it.
+    localStorage.setItem('notification_rules_client_id', 'test-client-id');
+
     await TestBed.configureTestingModule({
       imports: [NotificationRulesPageComponent],
       providers: [MessageService, DialogService]
@@ -39,7 +42,7 @@ describe('NotificationRulesPageComponent', () => {
   });
 
   describe('CSV parsing', () => {
-    it('should reject files without .csv extension', () => {
+    it('should reject files without .csv extension', async () => {
       const addSpy = spyOn(messageService, 'add');
       const event = {
         target: {
@@ -48,7 +51,7 @@ describe('NotificationRulesPageComponent', () => {
         }
       } as unknown as Event;
 
-      component.onFileSelected(event);
+      await component.onFileSelected(event);
       expect(addSpy).toHaveBeenCalledWith(jasmine.objectContaining({ severity: 'error', summary: 'Invalid File' }));
     });
   });

--- a/angular-client/src/pages/notification-rules-page/notification-rules-page.component.ts
+++ b/angular-client/src/pages/notification-rules-page/notification-rules-page.component.ts
@@ -4,7 +4,7 @@ import { MessageService } from 'primeng/api';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { InputText } from 'primeng/inputtext';
 import { take } from 'rxjs';
-import { appRoutes } from 'src/app/app-routing.module';
+import { appRoutes } from 'src/app/app-routes';
 import TypographyComponent from 'src/components/typography/typography.component';
 import { ButtonComponent } from 'src/components/argos-button/argos-button.component';
 import {

--- a/angular-client/src/services/graph-preset.service.spec.ts
+++ b/angular-client/src/services/graph-preset.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { MessageService } from 'primeng/api';
 import { GraphPresetService, PRESET_SEEDS, Preset } from './graph-preset.service';
 
 const STORAGE_KEY = 'argos.graphPresets';
@@ -19,7 +20,7 @@ describe('GraphPresetService', () => {
   });
 
   function build(): GraphPresetService {
-    TestBed.configureTestingModule({ providers: [GraphPresetService] });
+    TestBed.configureTestingModule({ providers: [GraphPresetService, MessageService] });
     return TestBed.inject(GraphPresetService);
   }
 

--- a/angular-client/src/test-setup.ts
+++ b/angular-client/src/test-setup.ts
@@ -1,0 +1,23 @@
+import { provideExperimentalZonelessChangeDetection } from '@angular/core';
+import { getTestBed, TestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+import { MessageService } from 'primeng/api';
+import { DialogService } from 'primeng/dynamicdialog';
+import { ChipFaultPipe } from 'src/utils/pipes/chip-fault.pipe';
+
+// Supplying `main` in angular.json replaces the builder's auto-generated test entry, so we must
+// initialise the test environment ourselves (the auto entry used to do this).
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+
+// Register globally the app-root providers that every component implicitly relies on, so specs
+// mirror the real bootstrap in main.ts and need no per-spec wiring:
+//   - provideExperimentalZonelessChangeDetection: the app is zoneless; without it component
+//     TestBeds throw NG0908 ("Angular requires Zone.js").
+//   - MessageService / DialogService / ChipFaultPipe: provided at root in main.ts.
+// This root-level beforeEach runs before each spec's own beforeEach, and configureTestingModule
+// accumulates providers, so per-spec configuration still applies on top.
+beforeEach(() => {
+  TestBed.configureTestingModule({
+    providers: [provideExperimentalZonelessChangeDetection(), MessageService, DialogService, ChipFaultPipe]
+  });
+});

--- a/angular-client/src/utils/bms.utils.ts
+++ b/angular-client/src/utils/bms.utils.ts
@@ -37,19 +37,30 @@ export type SegmentInfo = {
   totalVoltageKey: string;
 };
 
-/** Dynamically generated map of segment index → SegmentInfo topic keys. */
-export const segmentInfoMap: Record<Segment, SegmentInfo> = Object.fromEntries(
-  allSegments.map((seg) => [
-    seg,
-    {
+const segmentInfoCache = new Map<Segment, SegmentInfo>();
+
+/**
+ * SegmentInfo topic keys for a segment, computed lazily and memoised.
+ *
+ * Computed on first access rather than at module load so that bms.utils does not read `topics`
+ * from topic.utils while its module body evaluates. That eager access created a bms.utils <->
+ * topic.utils import cycle that threw a TDZ error ("Cannot access 'topics' before
+ * initialization") when the two modules loaded in the wrong order.
+ */
+export const segmentInfo = (seg: Segment): SegmentInfo => {
+  let info = segmentInfoCache.get(seg);
+  if (!info) {
+    info = {
       segmentTempKey: topics.segmentTemp(seg),
       alphaChipTempKey: topics.dieTemp(seg, Chip.Alpha),
       betaChipTempKey: topics.dieTemp(seg, Chip.Beta),
       voltageKey: topics.segmentVoltage(seg),
       totalVoltageKey: topics.segmentTotalVoltage(seg)
-    }
-  ])
-);
+    };
+    segmentInfoCache.set(seg, info);
+  }
+  return info;
+};
 
 export const getConnectionDotStatusColor = (voltage: number): string => {
   if (voltage <= 375) {

--- a/angular-client/src/utils/tree.utils.spec.ts
+++ b/angular-client/src/utils/tree.utils.spec.ts
@@ -99,7 +99,7 @@ describe('flattenTreeNodes', () => {
     ];
     const flat = flattenTreeNodes(tree);
     const labels = flat.map((n) => n.label);
-    expect(labels).toEqual(['Aux/Sensor/Zeta', 'BMS/Pack/SOC', 'BMS/Pack/Voltage', 'MPU/State/Speed']);
+    expect(labels).toEqual(['Aux/Sensor/Zeta', 'BMS/Pack/SoC', 'BMS/Pack/Voltage', 'MPU/State/Speed']);
   });
 
   it('returns an empty list when the tree has no leaves', () => {

--- a/angular-client/src/utils/tree.utils.ts
+++ b/angular-client/src/utils/tree.utils.ts
@@ -76,7 +76,7 @@ export function flattenTreeNodes(treeNodes: TreeNode<TreeNodeData>[], maxLabelLe
     for (const node of nodes) {
       if (node.children?.length) {
         collect(node.children as TreeNode<TreeNodeData>[]);
-      } else if (node.data?.dataType) {
+      } else if (node.selectable && node.data?.dataType) {
         leaves.push({
           ...node,
           label: compactTopicLabel(node.data.dataType.name, maxLabelLength),

--- a/angular-client/tsconfig.spec.json
+++ b/angular-client/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
-    "types": ["jasmine"]
+    "types": ["jasmine", "node"]
   },
-  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
+  "include": ["src/test-setup.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
## Changes

Frontend unit tests went from not compiling at all (zero specs ran on a fresh checkout) to a fully green suite of 87, now gated by a new Frontend Unit Tests CI job.

Three bundle-abort causes fixed: node types added to the spec tsconfig (TS2503 on NodeJS.Timeout), the stale graph-page QueryResponse mock cast (TS2322), and zoneless change detection — the app is zoneless but specs didn't provide it (NG0908). Zoneless plus the app-root PrimeNG services (MessageService, DialogService, ChipFaultPipe) are now registered once in a new global test entry (src/test-setup.ts, wired as the karma `main`), mirroring main.ts so new specs need no per-spec wiring.

Turning tests back on exposed a wave of never-run breakage, all fixed here:

- ~15 specs repaired — missing providers, unset required inputs, a stale SoC/SOC fixture, an un-awaited async CSV assertion, a seeded client id.
- Latent circular imports broken: appRoutes extracted into a dependency-free app-routes.ts (removes the component ↔ routing-module cycles), bms.utils segmentInfoMap replaced by a lazily-memoised segmentInfo(seg) so it no longer touches topic.utils at module load, and flattenTreeNodes now keys leaf detection off the selectable flag. All three are behavior-preserving for real data.

## Notes

The CI job launches plain ChromeHeadless (no custom karma config). A karma.conf.js launcher with --no-sandbox was tried but it broke the CLI's test adapter, so the simpler form was kept — worth a glance on the first Actions run since headless Chrome on runners is a common flake point.

The repeated per-spec provider/input boilerplate could later be pulled into a shared test-utils factory; left as-is to keep this change focused.

## Test Cases

- Full suite runs headless and passes (87 specs, exit 0).
- Production build, lint, and prettier all clean — the circular-import and util refactors don't change runtime behavior.
- Spec-level coverage that was previously dead now executes: graph-page URL/topic sync, GraphPresetService seeding, tree flattening, BMS debug components, notification-rules CSV rejection and client-id.

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #708
