### PR TITLE
#711 - Add Open Wire per-cell heatmap view mirroring CvS Failure

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,10 +40,6 @@ _Avoid_: sense voltage.
 Per-cell boolean the BMS raises when a cell's C-ADC and S-ADC readings diverge past threshold. Topic `BMS/PerCell/{Alpha|Beta}/{segment}/CvS/{cell}`; rendered as the **CvS Failure** heatmap view.
 _Avoid_: C-vs-S failure (say "CvS").
 
-**OW** (**Open Wire**):
-Per-cell boolean the BMS raises when it detects an open sense wire on a cell tap. Topic `BMS/PerCell/{Alpha|Beta}/{segment}/OW/{cell}`; rendered as the **Open Wire** heatmap view, styled identically to CvS Failure. Distinct from the pack-level critical fault `BMS/Faults/Critical/Open_Wire`, which is unrelated to the per-cell flags.
-_Avoid_: open wire detect (say "Open Wire" or "OW").
-
 ### Alerting
 
 **Fault**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,12 +33,16 @@ A cell's voltage from the ADBMS chip's primary C-ADC. Published per cell at `BMS
 _Avoid_: "the voltage" — ambiguous now that the S-ADC reading also exists.
 
 **S-ADC voltage** (**S Volts**):
-The same cell measured independently by the ADBMS chip's redundant S-ADC. Expected per-cell topic `BMS/PerCell/{Alpha|Beta}/{segment}/S_Volts/{cell}` in `V`, mirroring the C-ADC's `Volts`; rendered as the **S Volts** BMS-heatmap view.
+The same cell measured independently by the ADBMS chip's redundant S-ADC. Per-cell topic `BMS/PerCell/{Alpha|Beta}/{segment}/S_Volts/{cell}` in `V`, mirroring the C-ADC's `Volts`; rendered as the **S Volts** BMS-heatmap view.
 _Avoid_: sense voltage.
 
 **CvS**:
 Per-cell boolean the BMS raises when a cell's C-ADC and S-ADC readings diverge past threshold. Topic `BMS/PerCell/{Alpha|Beta}/{segment}/CvS/{cell}`; rendered as the **CvS Failure** heatmap view.
 _Avoid_: C-vs-S failure (say "CvS").
+
+**OW** (**Open Wire**):
+Per-cell boolean the BMS raises when it detects an open sense wire on a cell tap. Topic `BMS/PerCell/{Alpha|Beta}/{segment}/OW/{cell}`; rendered as the **Open Wire** heatmap view, styled identically to CvS Failure. Distinct from the pack-level critical fault `BMS/Faults/Critical/Open_Wire`, which is unrelated to the per-cell flags.
+_Avoid_: open wire detect (say "Open Wire" or "OW").
 
 ### Alerting
 

--- a/angular-client/src/pages/bms-debug-page/bms-debug-page.component.ts
+++ b/angular-client/src/pages/bms-debug-page/bms-debug-page.component.ts
@@ -59,6 +59,10 @@ export class BmsDebugPageComponent implements OnInit, OnDestroy {
     {
       name: formatAllSelectorName(HeatMapView.CvsFailure.toString()),
       function: () => this.heatMapService.setAllSegViews(HeatMapView.CvsFailure)
+    },
+    {
+      name: formatAllSelectorName(HeatMapView.OpenWire.toString()),
+      function: () => this.heatMapService.setAllSegViews(HeatMapView.OpenWire)
     }
   ];
   allSegSelectorConfig: SelectorConfig = {

--- a/angular-client/src/pages/bms-debug-page/bms-segment-view/bms-segment-view.component.ts
+++ b/angular-client/src/pages/bms-debug-page/bms-segment-view/bms-segment-view.component.ts
@@ -79,6 +79,12 @@ export class BmsSegmentViewComponent implements OnInit, OnDestroy {
       function: () => {
         this.heatMapService.setCurrentView(this.segmentId, HeatMapView.CvsFailure);
       }
+    },
+    {
+      name: HeatMapView.OpenWire.toString(),
+      function: () => {
+        this.heatMapService.setCurrentView(this.segmentId, HeatMapView.OpenWire);
+      }
     }
   ];
 

--- a/angular-client/src/pages/bms-debug-page/components/hex-tile/hex-tile.component.css
+++ b/angular-client/src/pages/bms-debug-page/components/hex-tile/hex-tile.component.css
@@ -97,9 +97,9 @@
   padding-bottom: 16%;
 }
 
-/* Temperature & CvS Failure: top-left number anchored away from the value */
+/* Temperature & flag views (CvS Failure, Open Wire): top-left number anchored away from the value */
 .hex-tile.view-temperature .cell-number,
-.hex-tile.view-cvs-failure .cell-number {
+.hex-tile.view-flag .cell-number {
   top: 22%;
   left: 20%;
   transform: none;
@@ -113,13 +113,13 @@
   padding-bottom: 16%;
 }
 
-.hex-tile.view-cvs-failure {
+.hex-tile.view-flag {
   justify-content: center;
   align-items: center;
   padding-bottom: 0;
 }
 
-.hex-tile.view-cvs-failure .cell-value {
+.hex-tile.view-flag .cell-value {
   font-size: calc(var(--hex-w, 42px) * 0.19);
 }
 
@@ -161,20 +161,20 @@
   color: #1a1a1a;
 }
 
-/* CvS Failure (heatmap variant): center TRUE/FALSE; keep cell number anchored top-left */
-:host(.heatmap-cell) .hex-tile.view-cvs-failure {
+/* Flag views (heatmap variant): center TRUE/FALSE; keep cell number anchored top-left */
+:host(.heatmap-cell) .hex-tile.view-flag {
   padding-left: 0;
 }
 
-:host(.heatmap-cell) .hex-tile.view-cvs-failure .cell-number {
+:host(.heatmap-cell) .hex-tile.view-flag .cell-number {
   padding-left: 8%;
 }
 
-:host(.heatmap-cell) .hex-tile.view-cvs-failure .cell-value-container {
+:host(.heatmap-cell) .hex-tile.view-flag .cell-value-container {
   align-self: center;
 }
 
-:host(.heatmap-cell) .hex-tile.view-cvs-failure .cell-value {
+:host(.heatmap-cell) .hex-tile.view-flag .cell-value {
   font-size: calc(var(--hex-w, 48px) * 0.24);
 }
 

--- a/angular-client/src/pages/bms-debug-page/components/hex-tile/hex-tile.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/hex-tile/hex-tile.component.ts
@@ -7,7 +7,8 @@ const VIEW_CLASS_MAP: Record<HeatMapView, string> = {
   [HeatMapView.SVolts]: 'view-voltage',
   [HeatMapView.Balancing]: 'view-balancing',
   [HeatMapView.Temperature]: 'view-temperature',
-  [HeatMapView.CvsFailure]: 'view-cvs-failure'
+  [HeatMapView.CvsFailure]: 'view-cvs-failure',
+  [HeatMapView.OpenWire]: 'view-cvs-failure'
 };
 
 /** Maps each HeatMapView to the unit label shown inside the hex */
@@ -16,7 +17,8 @@ const VIEW_UNIT_MAP: Record<HeatMapView, string> = {
   [HeatMapView.SVolts]: 'V',
   [HeatMapView.Temperature]: '°C',
   [HeatMapView.Balancing]: '',
-  [HeatMapView.CvsFailure]: ''
+  [HeatMapView.CvsFailure]: '',
+  [HeatMapView.OpenWire]: ''
 };
 
 @Component({
@@ -47,7 +49,8 @@ export class HexTileComponent {
   displayValue = computed(() => {
     const boolValue = this.booleanValue();
     if (boolValue !== undefined) {
-      if (this.currentView() === HeatMapView.CvsFailure) return boolValue ? 'TRUE' : 'FALSE';
+      const view = this.currentView();
+      if (view === HeatMapView.CvsFailure || view === HeatMapView.OpenWire) return boolValue ? 'TRUE' : 'FALSE';
       return boolValue ? 'YES' : 'NO';
     }
     const value = this.value();

--- a/angular-client/src/pages/bms-debug-page/components/hex-tile/hex-tile.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/hex-tile/hex-tile.component.ts
@@ -7,8 +7,8 @@ const VIEW_CLASS_MAP: Record<HeatMapView, string> = {
   [HeatMapView.SVolts]: 'view-voltage',
   [HeatMapView.Balancing]: 'view-balancing',
   [HeatMapView.Temperature]: 'view-temperature',
-  [HeatMapView.CvsFailure]: 'view-cvs-failure',
-  [HeatMapView.OpenWire]: 'view-cvs-failure'
+  [HeatMapView.CvsFailure]: 'view-flag',
+  [HeatMapView.OpenWire]: 'view-flag'
 };
 
 /** Maps each HeatMapView to the unit label shown inside the hex */

--- a/angular-client/src/pages/bms-debug-page/components/segment-heatmap/segment-heatmap.component.spec.ts
+++ b/angular-client/src/pages/bms-debug-page/components/segment-heatmap/segment-heatmap.component.spec.ts
@@ -19,7 +19,7 @@ const push = (storage: Storage, key: string, value: string): void => {
 /**
  * Drives the heatmap through its real storage seam (Storage -> CellService ->
  * SegmentHeatmapComponent) and asserts the value + color the component binds onto
- * each hex tile, for the C Volts and S Volts views, plus the no-data grey.
+ * each hex tile, for the C Volts, S Volts, and Open Wire views, plus the no-data grey.
  *
  * Assertions read the component's rendered outputs (alphaDisplayCells[].value and
  * getColor) directly rather than re-running change detection per push: CellService
@@ -86,6 +86,42 @@ describe('SegmentHeatmapComponent (storage seam)', () => {
     const untouched = cells[cells.length - 1];
     expect(untouched.value).toBeUndefined();
     expect(component.getColor(untouched)).toBe(GREY);
+  });
+
+  it('renders Open Wire true as red TRUE from the OW topic, mirroring CvS Failure', () => {
+    heatMap.setCurrentView(SEGMENT, HeatMapView.OpenWire);
+    push(storage, topics.alphaOw(SEGMENT, CELL), '1');
+
+    expect(alphaCell(CELL)?.boolValue).toBeTrue();
+    expect(component.getColor(alphaCell(CELL)!)).toBe('#dc2626');
+  });
+
+  it('renders Open Wire false as green FALSE from the OW topic', () => {
+    heatMap.setCurrentView(SEGMENT, HeatMapView.OpenWire);
+    push(storage, topics.alphaOw(SEGMENT, CELL), '0');
+
+    expect(alphaCell(CELL)?.boolValue).toBeFalse();
+    expect(component.getColor(alphaCell(CELL)!)).toBe('#16a34a');
+  });
+
+  it('shows the no-data grey for an Open Wire cell with no value', () => {
+    heatMap.setCurrentView(SEGMENT, HeatMapView.OpenWire);
+
+    const cells = component.alphaDisplayCells;
+    const untouched = cells[cells.length - 1];
+    expect(untouched.boolValue).toBeUndefined();
+    expect(component.getColor(untouched)).toBe(GREY);
+  });
+
+  it('keeps Open Wire and CvS as independent readings for the same cell', () => {
+    push(storage, topics.alphaCvs(SEGMENT, CELL), '0');
+    push(storage, topics.alphaOw(SEGMENT, CELL), '1');
+
+    heatMap.setCurrentView(SEGMENT, HeatMapView.CvsFailure);
+    expect(alphaCell(CELL)?.boolValue).toBeFalse();
+
+    heatMap.setCurrentView(SEGMENT, HeatMapView.OpenWire);
+    expect(alphaCell(CELL)?.boolValue).toBeTrue();
   });
 
   it('keeps C Volts and S Volts as independent readings for the same cell', () => {

--- a/angular-client/src/pages/bms-debug-page/components/segment-heatmap/segment-heatmap.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/segment-heatmap/segment-heatmap.component.ts
@@ -119,11 +119,13 @@ export class SegmentHeatmapComponent implements OnInit, OnDestroy {
   private getCellBoolValue(cell: CellReading): boolean | undefined {
     if (this.view === HeatMapView.Balancing) return cell.balancing;
     if (this.view === HeatMapView.CvsFailure) return cell.cvs;
+    if (this.view === HeatMapView.OpenWire) return cell.ow;
     return undefined;
   }
 
   getColor(cell: DisplayCell): string {
-    if (this.view === HeatMapView.CvsFailure) return this.getCvsFailureColor(cell.boolValue);
+    if (this.view === HeatMapView.CvsFailure || this.view === HeatMapView.OpenWire)
+      return this.getCvsFailureColor(cell.boolValue);
     if (this.view === HeatMapView.Balancing) return this.getBalancingColor(cell.boolValue);
     if (this.view === HeatMapView.Temperature) return this.getTempColor(cell.value);
     return this.getVoltColor(cell.value);

--- a/angular-client/src/pages/bms-debug-page/components/segment-row/segment-row.component.ts
+++ b/angular-client/src/pages/bms-debug-page/components/segment-row/segment-row.component.ts
@@ -46,6 +46,10 @@ export class SegmentRowComponent implements OnInit, OnDestroy {
     {
       name: HeatMapView.CvsFailure.toString(),
       function: () => this.heatMapService.setCurrentView(this.segment(), HeatMapView.CvsFailure)
+    },
+    {
+      name: HeatMapView.OpenWire.toString(),
+      function: () => this.heatMapService.setCurrentView(this.segment(), HeatMapView.OpenWire)
     }
   ];
 

--- a/angular-client/src/services/cell.service.ts
+++ b/angular-client/src/services/cell.service.ts
@@ -5,11 +5,13 @@ import Storage from './storage.service';
 import {
   allAlphaBurnValues,
   allAlphaCvsValues,
+  allAlphaOwValues,
   allAlphaSVoltValues,
   allAlphaThermValues,
   allAlphaVoltValues,
   allBetaBurnValues,
   allBetaCvsValues,
+  allBetaOwValues,
   allBetaSVoltValues,
   allBetaThermValues,
   allBetaVoltValues,
@@ -24,6 +26,7 @@ export type CellReading = {
   svolts: number | undefined;
   balancing: boolean | undefined;
   cvs: boolean | undefined;
+  ow: boolean | undefined;
   cellNumber: number;
 };
 
@@ -38,6 +41,7 @@ const createSegmentCells = (segment: number, chip: Chip, count: number): CellRea
       svolts: undefined,
       balancing: undefined,
       cvs: undefined,
+      ow: undefined,
       cellNumber: i
     })
   );
@@ -113,6 +117,13 @@ export class CellService {
           segmentAlphaCells[cvsIndex].cvs = parseInt(data.values[0]) === 1;
         });
       });
+
+      // Open Wire: one per cell (mirrors CvS)
+      allAlphaOwValues.forEach((ow, owIndex) => {
+        this.storageService.get(topics.alphaOw(segmentNumber, ow)).subscribe((data) => {
+          segmentAlphaCells[owIndex].ow = parseInt(data.values[0]) === 1;
+        });
+      });
     });
   };
 
@@ -158,6 +169,13 @@ export class CellService {
       allBetaCvsValues.forEach((cvs, cvsIndex) => {
         this.storageService.get(topics.betaCvs(segmentNumber, cvs)).subscribe((data) => {
           segmentBetaCells[cvsIndex].cvs = parseInt(data.values[0]) === 1;
+        });
+      });
+
+      // Open Wire: one per cell (mirrors CvS)
+      allBetaOwValues.forEach((ow, owIndex) => {
+        this.storageService.get(topics.betaOw(segmentNumber, ow)).subscribe((data) => {
+          segmentBetaCells[owIndex].ow = parseInt(data.values[0]) === 1;
         });
       });
     });

--- a/angular-client/src/services/heat-map.service.ts
+++ b/angular-client/src/services/heat-map.service.ts
@@ -10,7 +10,8 @@ export enum HeatMapView {
   SVolts = 'S Volts',
   Temperature = 'Temperature',
   Balancing = 'Balancing',
-  CvsFailure = 'CvS Failure'
+  CvsFailure = 'CvS Failure',
+  OpenWire = 'Open Wire'
 }
 
 export interface SelectedCellInfo {

--- a/angular-client/src/utils/topic.utils.ts
+++ b/angular-client/src/utils/topic.utils.ts
@@ -29,6 +29,9 @@ export const alphaBurning = (segment: Segment, cell: number) => `BMS/PerCell/Alp
 export const betaBurning = (segment: Segment, cell: number) => `BMS/PerCell/Beta/${segment}/Burning/${cell}`;
 export const alphaCvs = (segment: Segment, cell: number) => `BMS/PerCell/Alpha/${segment}/CvS/${cell}`;
 export const betaCvs = (segment: Segment, cell: number) => `BMS/PerCell/Beta/${segment}/CvS/${cell}`;
+// Open-wire detect flag — mirrors the CvS topics above with OW in place of CvS.
+export const alphaOw = (segment: Segment, cell: number) => `BMS/PerCell/Alpha/${segment}/OW/${cell}`;
+export const betaOw = (segment: Segment, cell: number) => `BMS/PerCell/Beta/${segment}/OW/${cell}`;
 export const segmentTemp = (segment: Segment) => `BMS/Segment_Temp/${segment}`;
 export const segmentVoltage = (segment: Segment) => `BMS/Segment_Volt/${segment}`;
 export const segmentTotalVoltage = (segment: Segment) => `BMS/Segment_Total_Volt/${segment}`;
@@ -182,6 +185,8 @@ export const topics = {
   betaBurning,
   alphaCvs,
   betaCvs,
+  alphaOw,
+  betaOw,
   segmentTemp,
   segmentVoltage,
   segmentTotalVoltage,
@@ -282,6 +287,9 @@ export const allAlphaBurnValues: number[] = Array.from({ length: BMS_CONFIG.ALPH
 export const allBetaBurnValues: number[] = Array.from({ length: BMS_CONFIG.BETA_BURN_COUNT }, (_, i) => i);
 export const allAlphaCvsValues: number[] = Array.from({ length: BMS_CONFIG.ALPHA_CVS_COUNT }, (_, i) => i);
 export const allBetaCvsValues: number[] = Array.from({ length: BMS_CONFIG.BETA_CVS_COUNT }, (_, i) => i);
+// Open Wire covers the same per-cell set as CvS, so reuse the CvS cell counts.
+export const allAlphaOwValues: number[] = Array.from({ length: BMS_CONFIG.ALPHA_CVS_COUNT }, (_, i) => i);
+export const allBetaOwValues: number[] = Array.from({ length: BMS_CONFIG.BETA_CVS_COUNT }, (_, i) => i);
 
 export enum ChipFault {
   VA_OV = 'VA_OV',


### PR DESCRIPTION
## Changes

Adds an "Open Wire" view to the BMS debug-page cell heatmap, mirroring the CvS Failure view exactly: per-cell 0/1 flag from topic BMS/PerCell/{Alpha|Beta}/{segment}/OW/{cell}, red TRUE when an open wire is detected, green FALSE when clear, standard no-data grey otherwise. Selectable in all three view selectors (per-segment, Set ALL Maps, segment-detail page). Payload and topic confirmed by Jack Rubacha (2026-07-15): same topic shape as CvS with OW in place of CvS, boolean per cell.

Frontend-only — telemetry ingest is schemaless, so no scylla-server/Charybdis/Siren change. The pack-level Critical Open_Wire fault is untouched and unrelated.

## Notes

- Reuses the CvS Failure colors, hex-tile CSS class, TRUE/FALSE display, and the CvS per-cell counts (13 per chip), so the two views stay visually identical by construction.
- Full suite 96/96 SUCCESS including the 4 new Open Wire specs; CI run-frontend-tests green.
- Smallest-window shot omitted deliberately: the BMS page has pre-existing narrow-width defects unrelated to this change — blank page below 768px and At A Glance stat overlap below ~1200px — filed separately as bug tickets rather than showcased here.

## Test Cases

- Open Wire true renders red TRUE; false renders green FALSE (storage-seam spec, both asserted against the live CvS colors)
- Cell with no OW value renders no-data grey
- OW and CvS stay independent readings for the same cell
- Visual: injected OW flags via calypso-sim `--stream` against the live stack — all four segments rendered exactly the published Alpha/Beta patterns on the accumulator page and the segment-detail page; CvS Failure view unchanged

## Screenshots

Full BMS page at 1920x1080, Open Wire on all segments (simulated flags on every segment):

<img width="1920" alt="bms-open-wire-wide" src="https://github.com/user-attachments/assets/bb0d1639-c6c4-4831-b9c1-cff26ad81311" />

Segment-detail page at 1920x1080, Open Wire view:

<img width="1920" alt="segment-detail-open-wire-wide" src="https://github.com/user-attachments/assets/0ab54d31-9db3-4749-bbc7-7bf674f138cc" />

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #711
