### PR TITLE
#719 - restore accumulator to 5 segments

### DIFF
--- a/angular-client/src/utils/bms.config.ts
+++ b/angular-client/src/utils/bms.config.ts
@@ -6,7 +6,7 @@
  * between bms.utils.ts and topic.utils.ts.
  */
 export const BMS_CONFIG = {
-  NUM_SEGMENTS: 4,
+  NUM_SEGMENTS: 5,
   ALPHA_VOLT_COUNT: 13,
   BETA_VOLT_COUNT: 13,
   ALPHA_THERM_COUNT: 7,


### PR DESCRIPTION
## Changes

Restores NUM_SEGMENTS to 5 in bms.config.ts, reverting the 4-segment value set in commit 2fdd188. Every segment array and MQTT topic subscription derives from this single constant, so the BMS debug page again renders 5 accumulator segments across the selector, overview, heatmap, at-a-glance, and cell views, with segment index 4 subscribing to its temp, voltage, and per-chip die-temp topics. Per-chip counts (volt, therm, burn, cvs) are unchanged and apply identically to all 5 segments.

## Notes

The car is wired and publishing 5 segments; this brings the frontend back in line.

## Test Cases

- BMS debug page suite passes with the restored segment count
- Full frontend unit suite passes (no hardcoded 4-segment assumptions in components or specs)
- Prettier and lint clean

## Screenshots

_screenshot pending_

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #719

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrSmSGVCZvSm4n7vpidUuN)_